### PR TITLE
Refactored Scopes, removed chain of previous scopes

### DIFF
--- a/src/Balu/Binding/BoundGlobalScope.cs
+++ b/src/Balu/Binding/BoundGlobalScope.cs
@@ -5,15 +5,13 @@ using Balu.Symbols;
 namespace Balu.Binding;
 sealed class BoundGlobalScope
 {
-    public BoundGlobalScope? Previous { get; }
     public FunctionSymbol EntryPoint { get; }
     public BoundBlockStatement Statement { get; }
     public ImmutableArray<Symbol> Symbols { get; }
     public ImmutableArray<Diagnostic> Diagnostics { get; }
 
-    public BoundGlobalScope(BoundGlobalScope? previous, FunctionSymbol entryPoint, BoundBlockStatement statement, IEnumerable<Symbol> symbols, IEnumerable<Diagnostic> diagnostics)
+    public BoundGlobalScope(FunctionSymbol entryPoint, BoundBlockStatement statement, IEnumerable<Symbol> symbols, IEnumerable<Diagnostic> diagnostics)
     {
-        Previous = previous;
         EntryPoint = entryPoint;
         Statement = statement;
         Symbols = symbols.ToImmutableArray();

--- a/src/Balu/Binding/BoundProgram.cs
+++ b/src/Balu/Binding/BoundProgram.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
+﻿using System.Collections.Immutable;
 using Balu.Symbols;
 
 namespace Balu.Binding;
@@ -10,26 +8,13 @@ sealed class BoundProgram
     public FunctionSymbol EntryPoint { get; }
     public ImmutableArray<Symbol> Symbols { get; }
     public ImmutableDictionary<FunctionSymbol, BoundBlockStatement> Functions { get; }
-    public ImmutableDictionary<FunctionSymbol, BoundBlockStatement> AllVisibleFunctions { get; }
     public ImmutableArray<Diagnostic> Diagnostics { get; }
 
-    public BoundProgram(BoundProgram?  previous, FunctionSymbol entryPoint, ImmutableArray<Symbol> symbols, ImmutableDictionary<FunctionSymbol, BoundBlockStatement> functions, ImmutableArray<Diagnostic> diagnostics)
+    public BoundProgram(FunctionSymbol entryPoint, ImmutableArray<Symbol> symbols, ImmutableDictionary<FunctionSymbol, BoundBlockStatement> functions, ImmutableArray<Diagnostic> diagnostics)
     {
         EntryPoint = entryPoint;
         Symbols = symbols;
         Functions = functions;
         Diagnostics = diagnostics;
-
-        if (previous is null)
-            AllVisibleFunctions = Functions;
-        else
-        {
-            var builder = Functions.ToBuilder();
-            var functionNames = Functions.Select(x => x.Key.Name).ToHashSet();
-            foreach (var (symbol, body) in previous.AllVisibleFunctions)
-                if (functionNames.Add(symbol.Name))
-                    builder.TryAdd(symbol, body);
-            AllVisibleFunctions = builder.ToImmutable();
-        }
     }
 }

--- a/src/Balu/Emit/Emitter.cs
+++ b/src/Balu/Emit/Emitter.cs
@@ -59,7 +59,7 @@ sealed class Emitter : IDisposable
         gotosToFix.Clear();
         labels.Clear();
 
-        var body = program.AllVisibleFunctions[function];
+        var body = program.Functions[function];
         foreach (var statement in body.Statements)
             EmitStatement(processor, statement);
 
@@ -565,7 +565,7 @@ sealed class Emitter : IDisposable
 
         EmitFields(initializedFields);
 
-        foreach (var function in program.AllVisibleFunctions.Keys)
+        foreach (var function in program.Functions.Keys)
             methods.Add(function, CreateMethod(function));
 
         // emit entry point first, in scripts this declares global variables as fields

--- a/src/HelloWorld/hello.b
+++ b/src/HelloWorld/hello.b
@@ -1,11 +1,13 @@
 ﻿function showRandom(i:int)
 {
-   print(string(i) + ". Zahl: ")
+   print(string(i) + " (" + string(a) + "). Zahl: ")
    println(random(10))
 }
-function main()
-{
+var a = 12
+
 	for i=1 to 10
+	{
+		a = 2*i
 		showRandom(i)
+	}
 	println("Done.")
-}

--- a/src/bi/BaluRepl.cs
+++ b/src/bi/BaluRepl.cs
@@ -193,7 +193,7 @@ sealed class BaluRepl : Repl
     void ListSymbols()
     {
         var compilation = previous ?? Compilation.CreateScript(null);
-        foreach (var symbol in compilation.AllVisibleSymbols.OrderBy(symbol => symbol.Name))
+        foreach (var symbol in compilation.Symbols.OrderBy(symbol => symbol.Name))
         {
             symbol.WriteTo(Console.Out);
             Console.Out.WriteLine();
@@ -203,7 +203,7 @@ sealed class BaluRepl : Repl
     void Dump(string functionName)
     {
         var compilation = previous ?? Compilation.CreateScript(null);
-        var function = compilation.AllVisibleSymbols.OfType<FunctionSymbol>().SingleOrDefault(function => function.Name == functionName);
+        var function = compilation.Symbols.OfType<FunctionSymbol>().SingleOrDefault(function => function.Name == functionName);
         if (function is null)
         {
             Console.Error.WriteColoredText($"Error: Function '{functionName}' does not exist.{Environment.NewLine}", ConsoleColor.Red);
@@ -217,7 +217,7 @@ sealed class BaluRepl : Repl
     void Graph(string functionName, string path)
     {
         var compilation = previous ?? Compilation.CreateScript(null);
-        var function = compilation.AllVisibleSymbols.OfType<FunctionSymbol>().SingleOrDefault(function => function.Name == functionName);
+        var function = compilation.Symbols.OfType<FunctionSymbol>().SingleOrDefault(function => function.Name == functionName);
         if (function is null)
         {
             Console.Error.WriteColoredText($"Error: Function '{functionName}' does not exist.{Environment.NewLine}", ConsoleColor.Red);


### PR DESCRIPTION
When creating a `BoundProgram` or `BoundGlobalScope` we know only store the available symbols in a flat list.
This remove the noise that was created by chaining previous scopes.
This also amends #19 