### PR TITLE
Meta commands to emit IL of the current submission

### DIFF
--- a/src/Balu.Tests/TestHelper/CompilationAsserter.cs
+++ b/src/Balu.Tests/TestHelper/CompilationAsserter.cs
@@ -8,10 +8,17 @@ namespace Balu.Tests.TestHelper;
 
 static class CompilationAsserter
 {
+    // HACK: find a way to get this for tests
+    static readonly string[] referencedAssemblies = 
+    {
+        @"C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.13\ref\net6.0\System.Runtime.dll",
+        @"C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.13\ref\net6.0\System.Runtime.Extensions.dll",
+        @"C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.13\ref\net6.0\System.Console.dll"
+    };
     internal static void AssertEvaluation(this string code, string? diagnostics = null, object? value = null)
     {
         var annotatedText = AnnotatedText.Parse(code);
-        var result = Compilation.CreateScript(null, SyntaxTree.Parse(annotatedText.Text)).Evaluate(ImmutableDictionary<GlobalVariableSymbol, object>.Empty);
+        var result = Compilation.CreateScript(null, SyntaxTree.Parse(annotatedText.Text)).Evaluate(referencedAssemblies, ImmutableDictionary<GlobalVariableSymbol, object>.Empty);
 
         var expectedDiagnostics = AnnotatedText.UnindentLines(diagnostics);
         if (expectedDiagnostics.Length != annotatedText.Spans.Length)

--- a/src/Balu/Compilation.cs
+++ b/src/Balu/Compilation.cs
@@ -60,10 +60,10 @@ public sealed class Compilation
         IsScript = isScript;
     }
 
-    public EvaluationResult Evaluate(ImmutableDictionary<GlobalVariableSymbol, object> initializedGlobalVariables)
+    public EvaluationResult Evaluate(string[] referencedAssemblies, ImmutableDictionary<GlobalVariableSymbol, object> initializedGlobalVariables)
     {
         using var memoryStream = new MemoryStream();
-        var emitterResult = Emitter.Emit(Program, "BaluInterpreter", ReferencedAssembliesFinder.GetReferences(), memoryStream, null, initializedGlobalVariables);
+        var emitterResult = Emitter.Emit(Program, "BaluInterpreter", referencedAssemblies, memoryStream, null, initializedGlobalVariables);
         if (emitterResult.Diagnostics.Any())
             return new(emitterResult.Diagnostics, null, initializedGlobalVariables);
 

--- a/src/bi/ReferencedAssembliesFinder.cs
+++ b/src/bi/ReferencedAssembliesFinder.cs
@@ -7,7 +7,7 @@ using System.Threading;
 
 #pragma warning disable CA1031
 
-namespace Balu;
+namespace Balu.Interactive;
 
 internal static class ReferencedAssembliesFinder
 {


### PR DESCRIPTION
Added commands #emit and #emitd that emit the current submission to an assembly on disk at the specified path. (#emitd emits a pdb file at the same place with *.pdb extension).
The determination of the referenced assemblies was moved out of Balu (where it does not belong) into the interpreter (bi). But that measn that the Balu.Tests have to find the references themselves, too... what would be a good way, here? referencing bi does not seem correct.

fixes #43