### PR TITLE
Bugs/#46

### DIFF
--- a/src/Balu.Tests/CompilationTests/ExecutionTests/MiscellaneousTests.cs
+++ b/src/Balu.Tests/CompilationTests/ExecutionTests/MiscellaneousTests.cs
@@ -91,7 +91,8 @@ public partial class ExecutionTests
 
     [Theory]
     [InlineData("{ [print] = 12 }", "Unexpected symbol kind 'Function', expected 'print' to be a variable or argument.")]
-    [InlineData("{ var a = 7 [a](12) }", "Unexpected symbol kind 'GlobalVariable', expected 'a' to be a function.")]
+    [InlineData("{ var a = 7 [a](12) }", "Unexpected symbol kind 'LocalVariable', expected 'a' to be a function.")]
+    [InlineData(" var a = 7 [a](12) ", "Unexpected symbol kind 'GlobalVariable', expected 'a' to be a function.")]
     public void Script_Reports_SymbolTypeMisatch(string text, string diagnostics) => text.AssertScriptEvaluation(diagnostics);
 
     [Fact]

--- a/src/Balu.Tests/CompilationTests/ExecutionTests/RedeclaringSymbolsTests.cs
+++ b/src/Balu.Tests/CompilationTests/ExecutionTests/RedeclaringSymbolsTests.cs
@@ -8,10 +8,9 @@ public partial class ExecutionTests
     [Fact]
     public void Script_RedeclaringSymbolsUsedInFunctions_FunctionsKeepWorkingOnOldSymbol()
     {
-        var compilation = "function a():int { return 42 }".AssertScriptEvaluation();
-        compilation = "function b() : int { return a() } b()".AssertScriptEvaluation(value: 42, previous: compilation);
-        compilation = "var a = 23".AssertScriptEvaluation(previous: compilation);
-        "b()".AssertScriptEvaluation(value: 42, previous: compilation);
-        Assert.Fail("This does not work in REPL!");
+        var (compilation, globals) = "function a():int { return 42 }".AssertScriptEvaluation();
+        (compilation, globals) = "function b() : int { return a() } b()".AssertScriptEvaluation(value: 42, previous: compilation, initializedGlobalVariables: globals);
+        (compilation, globals) = "var a = 23".AssertScriptEvaluation(previous: compilation, initializedGlobalVariables: globals);
+        "b()".AssertScriptEvaluation(value: 42, previous: compilation, initializedGlobalVariables: globals);
     }
 }

--- a/src/Balu/Binding/BoundGlobalScope.cs
+++ b/src/Balu/Binding/BoundGlobalScope.cs
@@ -7,14 +7,18 @@ sealed class BoundGlobalScope
 {
     public FunctionSymbol EntryPoint { get; }
     public BoundBlockStatement Statement { get; }
-    public ImmutableArray<Symbol> Symbols { get; }
+    public ImmutableArray<Symbol> ShadowedSymbols { get; }
+    public ImmutableArray<Symbol> VisibleSymbols { get; }
+    public ImmutableArray<Symbol> AllSymbols { get; }
     public ImmutableArray<Diagnostic> Diagnostics { get; }
 
-    public BoundGlobalScope(FunctionSymbol entryPoint, BoundBlockStatement statement, IEnumerable<Symbol> symbols, IEnumerable<Diagnostic> diagnostics)
+    public BoundGlobalScope(FunctionSymbol entryPoint, BoundBlockStatement statement, ImmutableArray<Symbol> shadowedSymbols, ImmutableArray<Symbol> visibleSymbols, IEnumerable<Diagnostic> diagnostics)
     {
         EntryPoint = entryPoint;
         Statement = statement;
-        Symbols = symbols.ToImmutableArray();
+        ShadowedSymbols = shadowedSymbols;
+        VisibleSymbols = visibleSymbols;
+        AllSymbols = shadowedSymbols.AddRange(visibleSymbols);
         Diagnostics = diagnostics.ToImmutableArray();
     }
 

--- a/src/Balu/Binding/BoundProgram.cs
+++ b/src/Balu/Binding/BoundProgram.cs
@@ -7,13 +7,15 @@ sealed class BoundProgram
 {
     public FunctionSymbol EntryPoint { get; }
     public ImmutableArray<Symbol> Symbols { get; }
+    public ImmutableArray<Symbol> VisibleSymbols { get; }
     public ImmutableDictionary<FunctionSymbol, BoundBlockStatement> Functions { get; }
     public ImmutableArray<Diagnostic> Diagnostics { get; }
 
-    public BoundProgram(FunctionSymbol entryPoint, ImmutableArray<Symbol> symbols, ImmutableDictionary<FunctionSymbol, BoundBlockStatement> functions, ImmutableArray<Diagnostic> diagnostics)
+    public BoundProgram(FunctionSymbol entryPoint, ImmutableArray<Symbol> symbols, ImmutableArray<Symbol> visibleSymbols, ImmutableDictionary<FunctionSymbol, BoundBlockStatement> functions, ImmutableArray<Diagnostic> diagnostics)
     {
         EntryPoint = entryPoint;
         Symbols = symbols;
+        VisibleSymbols = visibleSymbols;
         Functions = functions;
         Diagnostics = diagnostics;
     }

--- a/src/Balu/Emit/EmitterResult.cs
+++ b/src/Balu/Emit/EmitterResult.cs
@@ -6,10 +6,10 @@ namespace Balu.Emit;
 sealed class EmitterResult
 {
     public ImmutableArray<Diagnostic> Diagnostics { get; }
-    public ImmutableDictionary<GlobalVariableSymbol, string> GlobalFieldNames { get; }
-    public EmitterResult(ImmutableArray<Diagnostic> diagnostics, ImmutableDictionary<GlobalVariableSymbol, string> globalFieldNames)
+    public ImmutableDictionary<Symbol, string> GlobalSymbolNames { get; }
+    public EmitterResult(ImmutableArray<Diagnostic> diagnostics, ImmutableDictionary<Symbol, string> globalSymbolNames)
     {
         Diagnostics = diagnostics;
-        GlobalFieldNames = globalFieldNames;
+        GlobalSymbolNames = globalSymbolNames;
     }
 }

--- a/src/Balu/EvaluationResult.cs
+++ b/src/Balu/EvaluationResult.cs
@@ -7,12 +7,12 @@ public sealed class EvaluationResult
 {
     public ImmutableArray<Diagnostic> Diagnostics { get; }
     public object? Value { get; }
-    public ImmutableDictionary<GlobalVariableSymbol, object> GlobalVariables { get; }
+    public ImmutableDictionary<Symbol, object> GlobalSymbols{ get; }
 
-    internal EvaluationResult(ImmutableArray<Diagnostic> diagnostics, object? value, ImmutableDictionary<GlobalVariableSymbol, object> globalVariables)
+    internal EvaluationResult(ImmutableArray<Diagnostic> diagnostics, object? value, ImmutableDictionary<Symbol, object> globalSymbols)
     {
         Diagnostics = diagnostics;
         Value = value;
-        GlobalVariables = globalVariables;
+        GlobalSymbols = globalSymbols;
     }
 }

--- a/src/HelloWorld/hello.b
+++ b/src/HelloWorld/hello.b
@@ -1,1 +1,1 @@
-﻿printGreeting()
+﻿printGreeting(10)

--- a/src/HelloWorld/world.b
+++ b/src/HelloWorld/world.b
@@ -1,4 +1,5 @@
-﻿function printGreeting()
+﻿function printGreeting(i:int)
 {
 	println("Hello world!")
+	println(string(random(i)))
 }


### PR DESCRIPTION
fixes #46 

So I thought I was clever when I refactored the `BoundGlobalScope`, but it was all wrong. And then there is the emitter that needs to handle shadowed symbols like functions used by other functions etc...
This seems now reasonably fixed, the scope knows all symbols and distinguished between those that will be declared by the current code and those that already existed. The emitter returns a map from symbols to actual names in code.