### PR TITLE
short-circuiting logical binary expressions in emitter

### DIFF
--- a/src/Balu.Tests/EmitterTests/ShortCircuitedLogicalBinaryExpressions.cs
+++ b/src/Balu.Tests/EmitterTests/ShortCircuitedLogicalBinaryExpressions.cs
@@ -1,0 +1,52 @@
+﻿using Balu.Tests.TestHelper;
+using Xunit;
+
+namespace Balu.Tests.EmitterTests;
+
+public partial class EmitterTests
+{
+    [Theory]
+    [InlineData("var called = false function test() : bool { called = true return true} var x = true && test() called", true)]
+    [InlineData("var called = false function test() : bool { called = true return true} var x = false && test() called", false)]
+    [InlineData("var called = false function test() : bool { called = true return true} var x = false || test() called", true)]
+    [InlineData("var called = false function test() : bool { called = true return true} var x = true || test() called", false)]
+    public void Emitter_LogicalBinaryExpression_ShortCircuited(string code, object? result) => code.AssertScriptEvaluation(value: result);
+    [Fact]
+    public void Emitter_LogicalAnd_ShortCircuited()
+    {
+        const string code = @"
+            function test(a:bool, b:bool) : bool { return a && b }
+            return
+";
+        const string IL = @"
+            IL0000: ldarg.0
+            IL0001: dup
+            IL0002: brfalse.s IL_0006: ret
+            IL0004: pop
+            IL0005: ldarg.1
+            IL0006: ret
+";
+
+        code.AssertIl("test", IL);
+
+    }
+    [Fact]
+    public void Emitter_LogicalOr_ShortCircuited()
+    {
+        const string code = @"
+            function test(a:bool, b:bool) : bool { return a || b } 
+            return
+";
+        const string IL = @"
+            IL0000: ldarg.0
+            IL0001: dup
+            IL0002: brtrue.s IL_0006: ret
+            IL0004: pop
+            IL0005: ldarg.1
+            IL0006: ret
+";
+
+        code.AssertIl("test", IL);
+
+    }
+}

--- a/src/Balu.Tests/EmitterTests/StringConcatTests.cs
+++ b/src/Balu.Tests/EmitterTests/StringConcatTests.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace Balu.Tests.EmitterTests;
 
-public class EmitterTests
+public partial class EmitterTests
 {
     [Fact]
     public void Emitter_StringConcat_UsesCorrectOverload()
@@ -18,46 +18,46 @@ public class EmitterTests
             return
 ";
         const string IL = @"
-            ldarg.0
-            ldarg.1
-            call System.String System.String::Concat(System.String,System.String)
-            stloc.0
-            ldarg.0
-            ldarg.1
-            ldarg.2
-            call System.String System.String::Concat(System.String,System.String,System.String)
-            stloc.1
-            ldarg.0
-            ldarg.1
-            ldarg.2
-            ldarg.3
-            call System.String System.String::Concat(System.String,System.String,System.String,System.String)
-            stloc.2
-            ldc.i4.5
-            newarr System.String
-            dup
-            ldc.i4.0
-            ldarg.0
-            stelem.ref
-            dup
-            ldc.i4.1
-            ldarg.1
-            stelem.ref
-            dup
-            ldc.i4.2
-            ldarg.2
-            stelem.ref
-            dup
-            ldc.i4.3
-            ldarg.3
-            stelem.ref
-            dup
-            ldc.i4.4
-            ldarg.s e
-            stelem.ref
-            call System.String System.String::Concat(System.String[])
-            stloc.3
-            ret
+            IL0000: ldarg.0
+            IL0001: ldarg.1
+            IL0002: call System.String System.String::Concat(System.String,System.String)
+            IL0007: stloc.0
+            IL0008: ldarg.0
+            IL0009: ldarg.1
+            IL0010: ldarg.2
+            IL0011: call System.String System.String::Concat(System.String,System.String,System.String)
+            IL0016: stloc.1
+            IL0017: ldarg.0
+            IL0018: ldarg.1
+            IL0019: ldarg.2
+            IL0020: ldarg.3
+            IL0021: call System.String System.String::Concat(System.String,System.String,System.String,System.String)
+            IL0026: stloc.2
+            IL0027: ldc.i4.5
+            IL0028: newarr System.String
+            IL0033: dup
+            IL0034: ldc.i4.0
+            IL0035: ldarg.0
+            IL0036: stelem.ref
+            IL0037: dup
+            IL0038: ldc.i4.1
+            IL0039: ldarg.1
+            IL0040: stelem.ref
+            IL0041: dup
+            IL0042: ldc.i4.2
+            IL0043: ldarg.2
+            IL0044: stelem.ref
+            IL0045: dup
+            IL0046: ldc.i4.3
+            IL0047: ldarg.3
+            IL0048: stelem.ref
+            IL0049: dup
+            IL0050: ldc.i4.4
+            IL0051: ldarg.s e
+            IL0053: stelem.ref
+            IL0054: call System.String System.String::Concat(System.String[])
+            IL0059: stloc.3
+            IL0060: ret
 ";
 
         code.AssertIl("test", IL);
@@ -74,17 +74,17 @@ public class EmitterTests
             return
 ";
         const string IL = @"
-            ldstr hello
-            stloc.0
-            ldstr world
-            stloc.1
-            ldarg.0
-            ldstr hello
-            ldarg.1
-            ldstr worldhello
-            call System.String System.String::Concat(System.String,System.String,System.String,System.String)
-            stloc.2
-            ret
+            IL0000: ldstr hello
+            IL0005: stloc.0
+            IL0006: ldstr world
+            IL0011: stloc.1
+            IL0012: ldarg.0
+            IL0013: ldstr hello
+            IL0018: ldarg.1
+            IL0019: ldstr worldhello
+            IL0024: call System.String System.String::Concat(System.String,System.String,System.String,System.String)
+            IL0029: stloc.2
+            IL0030: ret
 ";
 
         code.AssertIl("test", IL);

--- a/src/Balu.Tests/TestHelper/IlAsserter.cs
+++ b/src/Balu.Tests/TestHelper/IlAsserter.cs
@@ -28,7 +28,7 @@ static class IlAsserter
         var method = programType.Methods.Single(method => method.Name == methodToAssert);
         var il = string.Join(Environment.NewLine,
                              method.Body.Instructions.Select(
-                                 instruction => $"{instruction.OpCode}{(instruction.Operand is null ? "" : $" {instruction.Operand}")}"));
+                                 instruction => $"IL{instruction.Offset:0000}: {instruction.OpCode}{(instruction.Operand is null ? "" : $" {instruction.Operand}")}"));
         var expected = string.Join(Environment.NewLine, expectedIL.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Select(line => line.Trim()));
         Assert.Equal(expected, il);
     }


### PR DESCRIPTION
The emitter know emits IL that does no longer evaluates the right side of an logical binary expression if the left side determines the outcome. So `false && call()` and `true || call()` don't call `call`.
We don't rewrite our bound tree for that but emit IL that jumps over the right expression if the left is sufficient.