### PR TITLE
added warnings for hidden symbols #71

### DIFF
--- a/src/Balu.Tests/BinderTests/ShadowedSymbolDiagnosticTests.cs
+++ b/src/Balu.Tests/BinderTests/ShadowedSymbolDiagnosticTests.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using Balu.Tests.TestHelper;
+using Xunit;
+
+namespace Balu.Tests.BinderTests;
+
+public sealed partial class BinderTests
+{
+    [Theory]
+    [MemberData(nameof(ProvideShadowingSymbolsTests))]
+    public void Binder_ReportsShadowingSymbols(string code, string diagnostics)
+    {
+        code.AssertScriptEvaluation(expectedDiagnostics: diagnostics, ignoreWarnings: false);
+    }
+
+    public static IEnumerable<object[]> ProvideShadowingSymbolsTests()
+    {
+        yield return new object[]
+        {
+            @"function test([a]:int){} var a = 0",
+            "Parameter 'a' hides global variable 'a'."
+        };
+        yield return new object[]
+        {
+            @"var a = 0 { var [a] = 1} ",
+            "Local variable 'a' hides global variable 'a'."
+        };
+        yield return new object[]
+        {
+            @"function test(){ var [a] = 12 } var a = 0",
+            "Local variable 'a' hides global variable 'a'."
+        };
+        yield return new object[]
+        {
+            @"function test(a:int){var [a] = 0} ",
+            "Local variable 'a' hides parameter 'a'."
+        };
+        yield return new object[]
+        {
+            @"function [println](a:int){}",
+            "Function 'println' hides existing function 'println'."
+        };
+        yield return new object[]
+        {
+            @"function test(a:int){ var [println] = 12}",
+            "Local variable 'println' hides existing function 'println'."
+        };
+        yield return new object[]
+        {
+            @"function test([println]:int){ }",
+            "Parameter 'println' hides existing function 'println'."
+        };
+    }
+}

--- a/src/Balu.Tests/BinderTests/UnreachableCodeTests.cs
+++ b/src/Balu.Tests/BinderTests/UnreachableCodeTests.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace Balu.Tests.BinderTests;
 
-public class BinderTests
+public sealed partial class BinderTests
 {
     [Theory]
     [InlineData("while true print(string(1)) [print(string(2))]")]

--- a/src/Balu/Diagnostics/DiagnosticBag.cs
+++ b/src/Balu/Diagnostics/DiagnosticBag.cs
@@ -38,6 +38,26 @@ sealed class DiagnosticBag : List<Diagnostic>
     public void ReportCannotConvert(TextLocation location, TypeSymbol sourceType, TypeSymbol targetType) => Add(new(DiagnosticId.CannotConvert, location, $"Cannot convert '{sourceType.Name}' to '{targetType.Name}'."));
     public void ReportCannotConvertImplicit(TextLocation location, TypeSymbol sourceType, TypeSymbol targetType) => Add(new(DiagnosticId.CannotConvertImplicit, location, $"Cannot convert '{sourceType.Name}' to '{targetType.Name}'. An explicit conversion exists, are you missing a cast?"));
     public void ReportSymbolAlreadyDeclared(SyntaxToken identifierToken) => Add(new(DiagnosticId.SymbolAlreadyDeclared, identifierToken.Location, $"Symbol '{identifierToken.Text}' is already declared."));
+    public void ReportSymbolHidesSymbol(Symbol hiding, Symbol hidden, TextLocation location)
+    {
+        var hidingKind = hiding.Kind switch
+        {
+            SymbolKind.LocalVariable => "Local variable ",
+            SymbolKind.Parameter => "Parameter ",
+            SymbolKind.Function => "Function ",
+            SymbolKind.GlobalVariable => "Global variable ",
+            _ => string.Empty
+        };
+        var hiddenKind = hidden.Kind switch
+        {
+            SymbolKind.LocalVariable => "outer scope variable ",
+            SymbolKind.Parameter => "parameter ",
+            SymbolKind.Function => "existing function ",
+            SymbolKind.GlobalVariable => "global variable ",
+            _ => string.Empty
+        };
+        Add(new(DiagnosticId.SymbolHidesSymbol, location, $"{hidingKind}'{hiding.Name}' hides {hiddenKind}'{hidden.Name}'.", severity: DiagnosticSeverity.Warning));
+    }
     public void ReportVariableIsReadOnly(SyntaxToken identifierToken) => Add(new(DiagnosticId.VariableIsReadOnly, identifierToken.Location, $"Variable '{identifierToken.Text}' is readonly and cannot be assigned to."));
     public void ReportWrongNumberOfArguments(CallExpressionSyntax syntax, FunctionSymbol function)
     {

--- a/src/Balu/Diagnostics/DiagnosticId.cs
+++ b/src/Balu/Diagnostics/DiagnosticId.cs
@@ -18,6 +18,7 @@ public enum DiagnosticId
     CannotConvert,
     CannotConvertImplicit,
     SymbolAlreadyDeclared,
+    SymbolHidesSymbol,
     VariableIsReadOnly,
     WrongNumberOfArguments,
     ExpressionMustHaveValue,

--- a/src/HelloWorld/hello.b
+++ b/src/HelloWorld/hello.b
@@ -1,2 +1,9 @@
 test(4)
-
+var a = 12
+function random(i:int, a:int){
+  println(a)
+  var i = 0
+}
+{
+ var a = ""
+ }


### PR DESCRIPTION
fixes #71 
warnings are reported when
- a local or global variable or a parameter is declared that hides a function or a global variable or
- a local variable is declared that hides a parameter

The location of the diagnostic is the location of the identifier of the hiding symbol declaration.