### PR TITLE
Resolve patch-specific test references and validate PDB integration

### DIFF
--- a/src/Balu.Tests/Balu.Tests.csproj
+++ b/src/Balu.Tests/Balu.Tests.csproj
@@ -26,4 +26,17 @@
 		<ProjectReference Include="..\Balu\Balu.csproj" />
 	</ItemGroup>
 
+	<Target Name="CopyReferenceAssembliesForEmitterTests" AfterTargets="CopyFilesToOutputDirectory">
+		<ItemGroup>
+			<_EmitterTestReference Include="@(ReferencePath)" Condition="
+				'%(Filename)' == 'System.Runtime' OR
+				'%(Filename)' == 'System.Runtime.Extensions' OR
+				'%(Filename)' == 'System.Console'" />
+		</ItemGroup>
+		<MakeDir Directories="$(TargetDir)reference-assemblies" />
+		<Copy SourceFiles="@(_EmitterTestReference)" DestinationFolder="$(TargetDir)reference-assemblies" SkipUnchangedFiles="true">
+			<Output TaskParameter="CopiedFiles" ItemName="FileWrites" />
+		</Copy>
+	</Target>
+
 </Project>

--- a/src/Balu.Tests/EmitterTests/DebugSymbolTests.cs
+++ b/src/Balu.Tests/EmitterTests/DebugSymbolTests.cs
@@ -1,0 +1,55 @@
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using Balu.Diagnostics;
+using Balu.Syntax;
+using Balu.Tests.TestHelper;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Xunit;
+
+namespace Balu.Tests.EmitterTests;
+
+public partial class EmitterTests
+{
+    [Fact]
+    public void Emitter_DebugSymbols_AreDiscoverableAndDescribeSourceFile()
+    {
+        var directory = Directory.CreateTempSubdirectory("Balu-Ren\u00E9-");
+        try
+        {
+            var sourcePath = Path.Combine(directory.FullName, "source.b");
+            var outputPath = Path.Combine(directory.FullName, "program.dll");
+            var symbolPath = Path.ChangeExtension(outputPath, ".pdb");
+            const string source = "println(\"Ren\u00E9\")";
+            var encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+            File.WriteAllBytes(sourcePath, encoding.GetPreamble().Concat(encoding.GetBytes(source)).ToArray());
+
+            var compilation = Compilation.Create(SyntaxTree.Load(sourcePath));
+            var diagnostics = compilation.Emit("DebugSymbols", ReferenceProvider.References, outputPath, symbolPath);
+
+            Assert.Empty(diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
+            Assert.True(File.Exists(outputPath));
+            Assert.True(File.Exists(symbolPath));
+
+            using var assembly = AssemblyDefinition.ReadAssembly(outputPath, new ReaderParameters { ReadSymbols = true });
+            Assert.True(assembly.MainModule.HasSymbols);
+            var sequencePoints = assembly.MainModule.Types
+                                         .SelectMany(type => type.Methods)
+                                         .SelectMany(method => method.DebugInformation.SequencePoints)
+                                         .ToArray();
+            Assert.NotEmpty(sequencePoints);
+            Assert.All(sequencePoints, sequencePoint => Assert.Equal(sourcePath, sequencePoint.Document.Url));
+
+            var document = sequencePoints[0].Document;
+            Assert.Equal(DocumentHashAlgorithm.SHA256, document.HashAlgorithm);
+            using var algorithm = SHA256.Create();
+            Assert.Equal(algorithm.ComputeHash(File.ReadAllBytes(sourcePath)), document.Hash);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+}

--- a/src/Balu.Tests/TestHelper/ReferenceProvider.cs
+++ b/src/Balu.Tests/TestHelper/ReferenceProvider.cs
@@ -1,12 +1,16 @@
-﻿namespace Balu.Tests.TestHelper;
+﻿using System;
+using System.IO;
+
+namespace Balu.Tests.TestHelper;
 
 static class ReferenceProvider
 {
-    // HACK: find a way to get this for tests
+    static readonly string referenceDirectory = Path.Combine(AppContext.BaseDirectory, "reference-assemblies");
+
     public static string[] References { get; } =
     [
-        @"C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\9.0.4\ref\net9.0\System.Runtime.dll",
-        @"C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\9.0.4\ref\net9.0\System.Runtime.Extensions.dll",
-        @"C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\9.0.4\ref\net9.0\System.Console.dll"
+        Path.Combine(referenceDirectory, "System.Runtime.dll"),
+        Path.Combine(referenceDirectory, "System.Runtime.Extensions.dll"),
+        Path.Combine(referenceDirectory, "System.Console.dll")
     ];
 }

--- a/src/Balu/Emit/Emitter.cs
+++ b/src/Balu/Emit/Emitter.cs
@@ -629,8 +629,11 @@ sealed class Emitter : IDisposable
     {
         if (!documents.TryGetValue(location.Text, out var document))
         {
-            var uriString = Uri.TryCreate(location.FileName, UriKind.RelativeOrAbsolute, out var uri) ? uri.ToString() : string.Empty;
-            document = new(uriString);
+            document = new(location.FileName)
+            {
+                HashAlgorithm = DocumentHashAlgorithm.SHA256,
+                Hash = location.Text.Checksum.ToArray()
+            };
             documents[location.Text] = document;
         }
 

--- a/src/Balu/Syntax/SyntaxTree.cs
+++ b/src/Balu/Syntax/SyntaxTree.cs
@@ -3,7 +3,6 @@ using Balu.Text;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.IO;
 using System.Linq;
 using System.Threading;
 
@@ -55,12 +54,7 @@ public sealed class SyntaxTree
         }
     }
 
-    public static SyntaxTree Load(string fileName)
-    {
-        var text = File.ReadAllText(fileName);
-        var sourceText = SourceText.From(text, fileName);
-        return Parse(sourceText);
-    }
+    public static SyntaxTree Load(string fileName) => Parse(SourceText.Load(fileName));
 
     public static SyntaxTree Parse(string input) => Parse(SourceText.From(input));
     public static SyntaxTree Parse(SourceText text) => new(text, Parse);

--- a/src/Balu/Text/SourceText.cs
+++ b/src/Balu/Text/SourceText.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace Balu.Text;
 
@@ -10,13 +13,15 @@ public sealed class SourceText
 
     public string FileName { get; }
     public ImmutableArray<TextLine> Lines { get; }
+    internal ImmutableArray<byte> Checksum { get; }
     public char this[int index] => text[index];
     public int Length => text.Length;
 
-    SourceText(string text, string fileName)
+    SourceText(string text, string fileName, ImmutableArray<byte> checksum)
     {
         this.text = text;
         FileName = fileName;
+        Checksum = checksum;
         Lines = ParseLines(this, text);
     }
 
@@ -65,6 +70,29 @@ public sealed class SourceText
         return builder.ToImmutable();
     }
 
-    public static SourceText From(string text, string fileName = "") => new(text ?? throw new ArgumentNullException(nameof(text)),
-                                                                            fileName ?? throw new ArgumentNullException(nameof(fileName)));
+    internal static SourceText Load(string fileName)
+    {
+        using var stream = File.OpenRead(fileName ?? throw new ArgumentNullException(nameof(fileName)));
+        var checksum = ComputeChecksum(stream);
+        stream.Position = 0;
+        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+        return new(reader.ReadToEnd(), fileName, checksum);
+    }
+    public static SourceText From(string text, string fileName = "")
+    {
+        _ = text ?? throw new ArgumentNullException(nameof(text));
+        _ = fileName ?? throw new ArgumentNullException(nameof(fileName));
+        return new(text, fileName, ComputeChecksum(Encoding.UTF8.GetBytes(text)));
+    }
+
+    static ImmutableArray<byte> ComputeChecksum(Stream stream)
+    {
+        using var algorithm = SHA256.Create();
+        return ImmutableArray.CreateRange(algorithm.ComputeHash(stream));
+    }
+    static ImmutableArray<byte> ComputeChecksum(byte[] bytes)
+    {
+        using var algorithm = SHA256.Create();
+        return ImmutableArray.CreateRange(algorithm.ComputeHash(bytes));
+    }
 }


### PR DESCRIPTION
## Summary
- resolve emitter test references through MSBuild instead of a fixed .NET patch path
- preserve source document paths and add SHA-256 checksums based on the exact compiled bytes
- add an on-disk Portable PDB integration test covering Unicode paths, discovery, PE/PDB association, and checksums

## Testing
- `dotnet test src/Balu.Tests/Balu.Tests.csproj --no-restore` (21,594 passed)
- `dotnet build src/Balu.sln` (fails in the existing `Balu.VSIX` project because `Microsoft.VisualStudio` SDK types are unavailable; all other projects build)

Closes #94

Partially addresses #82 and #85.