### PR TITLE
Validate in-memory PDB document identities

### DIFF
--- a/src/Balu.Tests/EmitterTests/DebugSymbolTests.cs
+++ b/src/Balu.Tests/EmitterTests/DebugSymbolTests.cs
@@ -5,6 +5,7 @@ using System.Text;
 using Balu.Diagnostics;
 using Balu.Syntax;
 using Balu.Tests.TestHelper;
+using Balu.Text;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Xunit;
@@ -13,6 +14,84 @@ namespace Balu.Tests.EmitterTests;
 
 public partial class EmitterTests
 {
+    [Fact]
+    public void Emitter_DebugSymbols_RequireDocumentName()
+    {
+        var compilation = Compilation.Create(SyntaxTree.Parse("function main() {}"));
+        using var outputStream = new MemoryStream();
+        using var symbolStream = new MemoryStream();
+
+        var diagnostics = compilation.Emit("DebugSymbols", ReferenceProvider.References, outputStream, symbolStream);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal(DiagnosticId.SourceDocumentNameMissing, diagnostic.Id);
+        Assert.Equal("Cannot emit debug symbols for a source document without a name.", diagnostic.Message);
+        Assert.Equal(0, outputStream.Length);
+        Assert.Equal(0, symbolStream.Length);
+    }
+
+    [Fact]
+    public void Emitter_DebugSymbols_RejectDocumentNameCollision()
+    {
+        var helper = SyntaxTree.Parse(SourceText.From("function helper() {}", "shared.b"));
+        var main = SyntaxTree.Parse(SourceText.From("function main() { helper() }", "shared.b"));
+        var compilation = Compilation.Create(helper, main);
+        using var outputStream = new MemoryStream();
+        using var symbolStream = new MemoryStream();
+
+        var diagnostics = compilation.Emit("DebugSymbols", ReferenceProvider.References, outputStream, symbolStream);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal(DiagnosticId.SourceDocumentNameCollision, diagnostic.Id);
+        Assert.Equal("Cannot emit debug symbols because document name 'shared.b' identifies different source texts.", diagnostic.Message);
+        Assert.Equal(0, outputStream.Length);
+        Assert.Equal(0, symbolStream.Length);
+    }
+
+    [Fact]
+    public void Emitter_DebugSymbols_DescribeMultipleInMemoryDocuments()
+    {
+        const string helpersSource = "function first() {} function second() {}";
+        const string mainSource = "function main() { first() second() }";
+        var helpers = SyntaxTree.Parse(SourceText.From(helpersSource, "helpers.b"));
+        var main = SyntaxTree.Parse(SourceText.From(mainSource, "main.b"));
+        var compilation = Compilation.Create(helpers, main);
+        using var outputStream = new MemoryStream();
+        using var symbolStream = new MemoryStream();
+
+        var diagnostics = compilation.Emit("DebugSymbols", ReferenceProvider.References, outputStream, symbolStream);
+
+        Assert.Empty(diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
+        outputStream.Position = 0;
+        symbolStream.Position = 0;
+        using var assembly = AssemblyDefinition.ReadAssembly(
+            outputStream,
+            new ReaderParameters { ReadSymbols = true, SymbolReaderProvider = new PortablePdbReaderProvider(), SymbolStream = symbolStream });
+        var documents = assembly.MainModule.Types
+                                .SelectMany(type => type.Methods)
+                                .SelectMany(method => method.DebugInformation.SequencePoints)
+                                .Select(sequencePoint => sequencePoint.Document)
+                                .Distinct()
+                                .OrderBy(document => document.Url)
+                                .ToArray();
+        Assert.Equal(new[] { "helpers.b", "main.b" }, documents.Select(document => document.Url));
+        using var algorithm = SHA256.Create();
+        Assert.Equal(algorithm.ComputeHash(Encoding.UTF8.GetBytes(helpersSource)), documents[0].Hash);
+        Assert.Equal(algorithm.ComputeHash(Encoding.UTF8.GetBytes(mainSource)), documents[1].Hash);
+    }
+
+    [Fact]
+    public void Emitter_WithoutDebugSymbols_AllowsMissingDocumentName()
+    {
+        var compilation = Compilation.Create(SyntaxTree.Parse("function main() {}"));
+        using var outputStream = new MemoryStream();
+
+        var diagnostics = compilation.Emit("NoDebugSymbols", ReferenceProvider.References, outputStream, null);
+
+        Assert.Empty(diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
+        Assert.True(outputStream.Length > 0);
+    }
+
     [Fact]
     public void Emitter_DebugSymbols_AreDiscoverableAndDescribeSourceFile()
     {

--- a/src/Balu/Diagnostics/DiagnosticBag.cs
+++ b/src/Balu/Diagnostics/DiagnosticBag.cs
@@ -116,4 +116,8 @@ sealed class DiagnosticBag : List<Diagnostic>
         Add(new(DiagnosticId.RequiredTypeAmbiguous, default, $"The required type '{name}' is ambiguous among these referenced assemblies: {string.Join(", ", typeDefinitions.Select(t => t.Module.Assembly.Name.Name).OrderBy(n => n))}."));
     public void ReportRequiredMethodNotFound(string type, string name, string[] parameterTypeNames) =>
         Add(new(DiagnosticId.RequiredMethodNotFound, default, $"The required method'{type}.{name}({string.Join(", ", parameterTypeNames)})' could not be found in the referenced assemblies."));
+    public void ReportSourceDocumentNameMissing(TextLocation location) =>
+        Add(new(DiagnosticId.SourceDocumentNameMissing, location, "Cannot emit debug symbols for a source document without a name."));
+    public void ReportSourceDocumentNameCollision(TextLocation location, string documentName) =>
+        Add(new(DiagnosticId.SourceDocumentNameCollision, location, $"Cannot emit debug symbols because document name '{documentName}' identifies different source texts."));
 }

--- a/src/Balu/Diagnostics/DiagnosticId.cs
+++ b/src/Balu/Diagnostics/DiagnosticId.cs
@@ -45,5 +45,7 @@ public enum DiagnosticId
     InvalidAssemblyReference,
     RequiredTypeNotFound,
     RequiredTypeAmbiguous,
-    RequiredMethodNotFound
+    RequiredMethodNotFound,
+    SourceDocumentNameMissing,
+    SourceDocumentNameCollision
 }

--- a/src/Balu/Emit/Emitter.cs
+++ b/src/Balu/Emit/Emitter.cs
@@ -27,6 +27,7 @@ sealed class Emitter : IDisposable
     readonly Dictionary<BoundLabel, int> labels = [];
     readonly List<(int instrcutionIndex, BoundLabel label)> gotosToFix = [];
     readonly Dictionary<SourceText, Document> documents = [];
+    readonly Dictionary<string, (ImmutableArray<byte> checksum, Document document)> documentsByName = new(StringComparer.Ordinal);
     readonly Dictionary<Symbol, string> globalSymbolNames = [];
     readonly BoundLabel exitLabel = new("<exit>");
 
@@ -627,14 +628,27 @@ sealed class Emitter : IDisposable
     }
     void AddSequencePoint(ILProcessor processor, Instruction instruction, TextLocation location)
     {
-        if (!documents.TryGetValue(location.Text, out var document))
+        var sourceText = location.Text!;
+        if (!documents.TryGetValue(sourceText, out var document))
         {
-            document = new(location.FileName)
+            var documentName = sourceText.FileName;
+            if (string.IsNullOrWhiteSpace(documentName))
             {
-                HashAlgorithm = DocumentHashAlgorithm.SHA256,
-                Hash = location.Text.Checksum.ToArray()
-            };
-            documents[location.Text] = document;
+                diagnostics.ReportSourceDocumentNameMissing(location);
+                document = CreateDocument(documentName, sourceText);
+            }
+            else if (documentsByName.TryGetValue(documentName, out var existing))
+            {
+                document = existing.document;
+                if (!sourceText.Checksum.SequenceEqual(existing.checksum))
+                    diagnostics.ReportSourceDocumentNameCollision(location, documentName);
+            }
+            else
+            {
+                document = CreateDocument(documentName, sourceText);
+                documentsByName.Add(documentName, (sourceText.Checksum, document));
+            }
+            documents[sourceText] = document;
         }
 
         var sequencePoint = new SequencePoint(instruction, document)
@@ -646,6 +660,11 @@ sealed class Emitter : IDisposable
         };
         processor.Body.Method.DebugInformation.SequencePoints.Add(sequencePoint);
 
+        static Document CreateDocument(string documentName, SourceText sourceText) => new(documentName)
+        {
+            HashAlgorithm = DocumentHashAlgorithm.SHA256,
+            Hash = sourceText.Checksum.ToArray()
+        };
     }
 
     void EmitFields(ImmutableDictionary<GlobalVariableSymbol, object> initializedGlobalVariables)
@@ -734,6 +753,8 @@ sealed class Emitter : IDisposable
         EmitMethod(methods[program.EntryPoint], program.EntryPoint);
         foreach (var x in methods.Where(x => x.Key != program.EntryPoint))
             EmitMethod(x.Value, x.Key);
+
+        if (diagnostics.HasErrors()) return;
 
         referencedMembers.Assembly.EntryPoint = methods[program.EntryPoint];
 


### PR DESCRIPTION
## Summary
- reject unnamed PDB documents and document names that identify different source checksums
- reuse one Portable PDB document for equal name/checksum identities and stop before writing invalid symbol output
- keep anonymous sources valid when no symbol stream is requested
- cover multiple in-memory documents, collisions, missing names, deduplication, and exact checksums

## Interpreter scope
The interpreter-specific submission lifecycle was split into #97 so it can be retained or retired independently.

## Testing
- `dotnet test src/Balu.Tests/Balu.Tests.csproj --no-restore` (21,598 passed)
- `dotnet build src/Balu/Balu.csproj --no-restore` (passed with no warnings)
- `dotnet build src/Balu.sln --no-restore` (fails in the existing `Balu.VSIX` project because `Microsoft.VisualStudio` SDK types are unavailable; all other projects build)

Closes #85