### PR TITLE
Give interpreter submissions unique PDB identities

### DIFF
--- a/src/Balu.Interpretation/Interpreter.cs
+++ b/src/Balu.Interpretation/Interpreter.cs
@@ -11,6 +11,8 @@ namespace Balu.Interpretation;
 
 public sealed class Interpreter
 {
+    int submissionCount;
+
     public Compilation Compilation { get; private set; } = Compilation.CreateScript(null, SyntaxTree.Parse(string.Empty));
     public object? Result { get; private set; }
     public ImmutableArray<Symbol> VisibleSymbols => Compilation.VisibleSymbols;
@@ -26,11 +28,14 @@ public sealed class Interpreter
         "BaluInterpreter", ReferencedAssembliesFinder.GetReferences(), path ?? throw new ArgumentNullException(nameof(path)), symbolPath, GlobalVariables);
     public void Reset()
     {
+        submissionCount = 0;
         Compilation = Compilation.CreateScript(null, SyntaxTree.Parse(string.Empty));
     }
     public ImmutableArray<Diagnostic> Execute(string code, bool ignoreWarnings = true)
     {
-        var compilation = Compilation.CreateScript(Compilation, SyntaxTree.Parse(SourceText.From(code, "BaluInterpreter.b")));
+        var submissionNumber = submissionCount + 1;
+        var documentName = $"BaluInterpreter/submission-{submissionNumber:0000}.b";
+        var compilation = Compilation.CreateScript(Compilation, SyntaxTree.Parse(SourceText.From(code, documentName)));
         var referencedAssemblies = ReferencedAssembliesFinder.GetReferences();
 
         if (Out is not null)
@@ -57,6 +62,7 @@ public sealed class Interpreter
         if (emitterResult.Diagnostics.HasErrors() || !ignoreWarnings && emitterResult.Diagnostics.Any())
             return emitterResult.Diagnostics;
 
+        submissionCount = submissionNumber;
         Compilation = compilation;
 
         memoryStream.Seek(0, SeekOrigin.Begin);

--- a/src/Balu.Tests/InterpreterTests/InterpreterTests.cs
+++ b/src/Balu.Tests/InterpreterTests/InterpreterTests.cs
@@ -1,10 +1,96 @@
-﻿using Balu.Tests.TestHelper;
+﻿using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using Balu.Diagnostics;
+using Balu.Interpretation;
+using Balu.Tests.TestHelper;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
 using Xunit;
 
 namespace Balu.Tests.InterpreterTests;
 
 public sealed class InterpreterTests
 {
+    [Fact]
+    public void Interpreter_SubmissionNames_AdvanceOnlyForAcceptedCompilationsAndReset()
+    {
+        var interpreter = new Interpreter();
+
+        var invalidDiagnostics = interpreter.Execute("function invalid() { missing() }");
+        var validDiagnostics = interpreter.Execute("function valid() {}");
+
+        Assert.True(invalidDiagnostics.HasErrors());
+        Assert.False(validDiagnostics.HasErrors());
+        Assert.Equal("BaluInterpreter/submission-0001.b", Assert.Single(interpreter.Compilation.SyntaxTrees).Text.FileName);
+
+        interpreter.Reset();
+        var resetDiagnostics = interpreter.Execute("function afterReset() {}");
+
+        Assert.False(resetDiagnostics.HasErrors());
+        Assert.Equal("BaluInterpreter/submission-0001.b", Assert.Single(interpreter.Compilation.SyntaxTrees).Text.FileName);
+        var directory = Directory.CreateTempSubdirectory("BaluInterpreterReset-");
+        try
+        {
+            var outputPath = Path.Combine(directory.FullName, "program.dll");
+            var emitDiagnostics = interpreter.Emit(outputPath, Path.ChangeExtension(outputPath, ".pdb"));
+
+            Assert.False(emitDiagnostics.HasErrors());
+            using var assembly = AssemblyDefinition.ReadAssembly(outputPath, new ReaderParameters { ReadSymbols = true });
+            var documentNames = assembly.MainModule.Types
+                                        .SelectMany(type => type.Methods)
+                                        .SelectMany(method => method.DebugInformation.SequencePoints)
+                                        .Select(sequencePoint => sequencePoint.Document.Url)
+                                        .Distinct()
+                                        .ToArray();
+            Assert.Equal(new[] { "BaluInterpreter/submission-0001.b" }, documentNames);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Interpreter_EmitDebug_DescribesAllSubmissions()
+    {
+        const string firstSource = "function first() { println(\"first\") }";
+        const string secondSource = "function second() { first() }";
+        var interpreter = new Interpreter();
+        Assert.False(interpreter.Execute(firstSource).HasErrors());
+        Assert.False(interpreter.Execute(secondSource).HasErrors());
+        var directory = Directory.CreateTempSubdirectory("BaluInterpreter-");
+        try
+        {
+            var outputPath = Path.Combine(directory.FullName, "program.dll");
+            var symbolPath = Path.ChangeExtension(outputPath, ".pdb");
+
+            var diagnostics = interpreter.Emit(outputPath, symbolPath);
+
+            Assert.Empty(diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
+            using var assembly = AssemblyDefinition.ReadAssembly(outputPath, new ReaderParameters { ReadSymbols = true });
+            var documents = assembly.MainModule.Types
+                                    .SelectMany(type => type.Methods)
+                                    .SelectMany(method => method.DebugInformation.SequencePoints)
+                                    .Select(sequencePoint => sequencePoint.Document)
+                                    .Distinct()
+                                    .OrderBy(document => document.Url)
+                                    .ToArray();
+            Assert.Equal(
+                new[] { "BaluInterpreter/submission-0001.b", "BaluInterpreter/submission-0002.b" },
+                documents.Select(document => document.Url));
+            Assert.All(documents, document => Assert.Equal(DocumentHashAlgorithm.SHA256, document.HashAlgorithm));
+            using var algorithm = SHA256.Create();
+            Assert.Equal(algorithm.ComputeHash(Encoding.UTF8.GetBytes(firstSource)), documents[0].Hash);
+            Assert.Equal(algorithm.ComputeHash(Encoding.UTF8.GetBytes(secondSource)), documents[1].Hash);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
     [Fact]
     public void Interpreter_UsesOnlyErrorFreeCompilations()
     {


### PR DESCRIPTION
## Summary
- assign accepted interpreter submissions stable names such as `BaluInterpreter/submission-0001.b`
- leave the sequence unchanged for rejected compilations and restart it when `Reset` starts a new compilation chain
- verify that debug emission after multiple submissions produces discoverable, distinct PDB documents with exact SHA-256 checksums
- verify that reset removes previous submission documents from subsequent PDB output

## Scope
Normal `Execute` calls still emit no PDB. The names are retained only so the existing `#emitd`/`Interpreter.Emit(path, symbolPath)` path can create valid symbols later.

## Testing
- `dotnet test src/Balu.Tests/Balu.Tests.csproj --no-restore` (21,600 passed)
- `dotnet build src/Balu.Interpretation/Balu.Interpretation.csproj --no-restore` (passed with no warnings)
- `dotnet build src/Balu.sln --no-restore` (fails in the existing `Balu.VSIX` project; additionally, a running `bi` process locks its output assemblies)

Closes #97