### PR TITLE
Cache and dispose emitter references

### DIFF
--- a/src/Balu.Interpretation/Interpreter.cs
+++ b/src/Balu.Interpretation/Interpreter.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using System.Runtime.Loader;
 using Balu.Diagnostics;
+using Balu.Emit;
 using Balu.Symbols;
 using Balu.Syntax;
 using Balu.Text;
@@ -9,15 +10,15 @@ using Balu.Visualization;
 
 namespace Balu.Interpretation;
 
-public sealed class Interpreter
+public sealed class Interpreter : IDisposable
 {
     int submissionCount;
-    readonly string[] referencedAssemblies;
+    readonly EmitReferenceSet references;
 
     public Interpreter(string[] referencedAssemblies)
     {
         ArgumentNullException.ThrowIfNull(referencedAssemblies);
-        this.referencedAssemblies = [.. referencedAssemblies];
+        references = new(referencedAssemblies);
     }
 
     public Compilation Compilation { get; private set; } = Compilation.CreateScript(null, SyntaxTree.Parse(string.Empty));
@@ -31,8 +32,9 @@ public sealed class Interpreter
     public bool WriteSyntax { get; set; }
     public bool WriteProgram { get; set; }
 
-    public ImmutableArray<Diagnostic> Emit(string path, string? symbolPath = null) => Compilation.Emit(
-        "BaluInterpreter", referencedAssemblies, path ?? throw new ArgumentNullException(nameof(path)), symbolPath, GlobalVariables);
+    public ImmutableArray<Diagnostic> Emit(string path, string? symbolPath = null) => Compilation.EmitWithReferenceSet(
+        "BaluInterpreter", references, path ?? throw new ArgumentNullException(nameof(path)), symbolPath, GlobalVariables);
+    public void Dispose() => references.Dispose();
     public void Reset()
     {
         submissionCount = 0;
@@ -62,7 +64,7 @@ public sealed class Interpreter
         }
 
         using var memoryStream = new MemoryStream();
-        var emitterResult = compilation.Emit("BaluInterpreter", referencedAssemblies, memoryStream, null, GlobalVariables);
+        var emitterResult = compilation.EmitWithReferenceSet("BaluInterpreter", references, memoryStream, null, GlobalVariables);
         Error?.WriteDiagnostics(emitterResult.Diagnostics);
 
         if (emitterResult.Diagnostics.HasErrors() || !ignoreWarnings && emitterResult.Diagnostics.Any())

--- a/src/Balu.Tests/EmitterTests/ReferenceLifetimeTests.cs
+++ b/src/Balu.Tests/EmitterTests/ReferenceLifetimeTests.cs
@@ -1,0 +1,107 @@
+using System;
+using System.IO;
+using System.Linq;
+using Balu.Diagnostics;
+using Balu.Emit;
+using Balu.Syntax;
+using Balu.Tests.TestHelper;
+using Xunit;
+
+namespace Balu.Tests.EmitterTests;
+
+public partial class EmitterTests
+{
+    [Fact]
+    public void Emitter_ReleasesReferencesAfterSuccessfulEmit()
+    {
+        var directory = Directory.CreateTempSubdirectory("BaluEmitterReferences-");
+        try
+        {
+            var references = CopyReferences(directory);
+            var compilation = Compilation.Create(SyntaxTree.Parse("function main() {}"));
+            using var output = new MemoryStream();
+
+            var diagnostics = compilation.Emit("ReferenceLifetime", references, output, null);
+
+            Assert.False(diagnostics.HasErrors());
+            AssertCanOpenExclusively(references);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Emitter_ReleasesReferencesAfterPartialLoadFailure()
+    {
+        var directory = Directory.CreateTempSubdirectory("BaluEmitterReferences-");
+        try
+        {
+            var validReference = Path.Combine(directory.FullName, Path.GetFileName(ReferenceProvider.References[0]));
+            File.Copy(ReferenceProvider.References[0], validReference);
+            var invalidReference = Path.Combine(directory.FullName, "invalid.dll");
+            File.WriteAllText(invalidReference, "not an assembly");
+            var references = new[] { validReference, invalidReference };
+            var compilation = Compilation.Create(SyntaxTree.Parse("function main() {}"));
+            using var output = new MemoryStream();
+
+            var diagnostics = compilation.Emit("ReferenceLifetime", references, output, null);
+
+            Assert.Contains(diagnostics, diagnostic => diagnostic.Id == DiagnosticId.InvalidAssemblyReference);
+            AssertCanOpenExclusively(references);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Emitter_ReleasesReferencesAfterValidationFailure()
+    {
+        var directory = Directory.CreateTempSubdirectory("BaluEmitterReferences-");
+        try
+        {
+            var reference = Path.Combine(directory.FullName, Path.GetFileName(ReferenceProvider.References[0]));
+            File.Copy(ReferenceProvider.References[0], reference);
+            var compilation = Compilation.Create(SyntaxTree.Parse("function main() {}"));
+            using var output = new MemoryStream();
+
+            var diagnostics = compilation.Emit("ReferenceLifetime", new[] { reference }, output, null);
+
+            Assert.Contains(diagnostics, diagnostic => diagnostic.Id == DiagnosticId.RequiredTypeNotFound);
+            AssertCanOpenExclusively(new[] { reference });
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void EmitReferenceSet_DisposeIsIdempotentAndRejectsFurtherUse()
+    {
+        var references = new EmitReferenceSet(ReferenceProvider.References);
+        references.Dispose();
+        var compilation = Compilation.Create(SyntaxTree.Parse("function main() {}"));
+        using var output = new MemoryStream();
+
+        references.Dispose();
+        Assert.Throws<ObjectDisposedException>(() => compilation.EmitWithReferenceSet("DisposedReferences", references, output, null));
+    }
+
+    static string[] CopyReferences(DirectoryInfo directory) =>
+        ReferenceProvider.References.Select(reference =>
+        {
+            var copy = Path.Combine(directory.FullName, Path.GetFileName(reference));
+            File.Copy(reference, copy);
+            return copy;
+        }).ToArray();
+
+    static void AssertCanOpenExclusively(string[] references)
+    {
+        foreach (var reference in references)
+            using (File.Open(reference, FileMode.Open, FileAccess.ReadWrite, FileShare.None)) { }
+    }
+}

--- a/src/Balu.Tests/ExecutionTests/RedeclaringSymbolsTests.cs
+++ b/src/Balu.Tests/ExecutionTests/RedeclaringSymbolsTests.cs
@@ -8,7 +8,7 @@ public partial class ExecutionTests
     [Fact]
     public void Script_RedeclaringSymbolsUsedInFunctions_FunctionsKeepWorkingOnOldSymbol()
     {
-        var asserter = new CompilationAsserter();
+        using var asserter = new CompilationAsserter();
         asserter.AssertScriptEvaluation("function a():int { return 42 }");
         asserter.AssertScriptEvaluation("function b() : int { return a() } b()", value: 42);
         asserter.AssertScriptEvaluation("var a = 23");

--- a/src/Balu.Tests/InterpreterTests/InterpreterTests.cs
+++ b/src/Balu.Tests/InterpreterTests/InterpreterTests.cs
@@ -17,7 +17,7 @@ public sealed class InterpreterTests
     public void Interpreter_CopiesReferences()
     {
         var references = ReferenceProvider.References.ToArray();
-        var interpreter = new Interpreter(references);
+        using var interpreter = new Interpreter(references);
         references[0] = null!;
 
         var diagnostics = interpreter.Execute("1");
@@ -28,7 +28,7 @@ public sealed class InterpreterTests
     [Fact]
     public void Interpreter_SubmissionNames_AdvanceOnlyForAcceptedCompilationsAndReset()
     {
-        var interpreter = new Interpreter(ReferenceProvider.References);
+        using var interpreter = new Interpreter(ReferenceProvider.References);
 
         var invalidDiagnostics = interpreter.Execute("function invalid() { missing() }");
         var validDiagnostics = interpreter.Execute("function valid() {}");
@@ -69,7 +69,7 @@ public sealed class InterpreterTests
     {
         const string firstSource = "function first() { println(\"first\") }";
         const string secondSource = "function second() { first() }";
-        var interpreter = new Interpreter(ReferenceProvider.References);
+        using var interpreter = new Interpreter(ReferenceProvider.References);
         Assert.False(interpreter.Execute(firstSource).HasErrors());
         Assert.False(interpreter.Execute(secondSource).HasErrors());
         var directory = Directory.CreateTempSubdirectory("BaluInterpreter-");
@@ -106,10 +106,36 @@ public sealed class InterpreterTests
     [Fact]
     public void Interpreter_UsesOnlyErrorFreeCompilations()
     {
-        var asserter = new CompilationAsserter();
+        using var asserter = new CompilationAsserter();
         asserter.AssertScriptEvaluation("function a() { var x = [y] }", expectedDiagnostics: "Undefined name 'y'.");
         asserter.AssertScriptEvaluation("function c() : int { return 42 }");
         asserter.AssertScriptEvaluation("c()", value: 42);
+    }
+
+    [Fact]
+    public void Interpreter_ReusesReferenceSnapshot()
+    {
+        var directory = Directory.CreateTempSubdirectory("BaluInterpreterReferences-");
+        try
+        {
+            var references = ReferenceProvider.References.Select(reference =>
+            {
+                var copy = Path.Combine(directory.FullName, Path.GetFileName(reference));
+                File.Copy(reference, copy);
+                return copy;
+            }).ToArray();
+            using var interpreter = new Interpreter(references);
+
+            Assert.False(interpreter.Execute("1").HasErrors());
+            foreach (var reference in references)
+                File.Delete(reference);
+
+            Assert.False(interpreter.Execute("2").HasErrors());
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
     }
 
 }

--- a/src/Balu.Tests/TestHelper/CompilationAsserter.cs
+++ b/src/Balu.Tests/TestHelper/CompilationAsserter.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Balu.Diagnostics;
 using Balu.Interpretation;
@@ -6,9 +7,11 @@ using Balu.Symbols;
 using Xunit;
 namespace Balu.Tests.TestHelper;
 
-class CompilationAsserter
+class CompilationAsserter : IDisposable
 {
     public Interpreter Interpreter { get; } = new(ReferenceProvider.References);
+
+    public void Dispose() => Interpreter.Dispose();
 
     internal void AssertScriptEvaluation(string code, string? expectedDiagnostics = null,
                                          IDictionary<GlobalVariableSymbol, object>? expectedGlobalVariables = null, object? value = null,

--- a/src/Balu.Tests/TestHelper/StaticCompilationAsserter.cs
+++ b/src/Balu.Tests/TestHelper/StaticCompilationAsserter.cs
@@ -13,7 +13,7 @@ static class StaticCompilationAsserter{
     internal static void AssertScriptEvaluation(this string code, string? expectedDiagnostics = null, object? value = null, bool ignoreWarnings = true)
     {
         var annotatedText = AnnotatedText.Parse(code);
-        var interpreter = new Interpreter(ReferenceProvider.References);
+        using var interpreter = new Interpreter(ReferenceProvider.References);
         var actualDiagnostics = interpreter.Execute(annotatedText.Text, ignoreWarnings);
 
         DiagnosticAsserter.AssertDiagnostics(annotatedText, actualDiagnostics, expectedDiagnostics, ignoreWarnings);

--- a/src/Balu/Compilation.cs
+++ b/src/Balu/Compilation.cs
@@ -84,6 +84,25 @@ public sealed class Compilation
             symbolStream?.Dispose();
         }
     }
+    public ImmutableArray<Diagnostic> EmitWithReferenceSet(string moduleName, EmitReferenceSet references, string outputPath, string? symbolPath) =>
+        EmitWithReferenceSet(moduleName, references, outputPath, symbolPath, ImmutableDictionary<GlobalVariableSymbol, object>.Empty);
+    public ImmutableArray<Diagnostic> EmitWithReferenceSet(string moduleName, EmitReferenceSet references, string outputPath, string? symbolPath, ImmutableDictionary<GlobalVariableSymbol, object> initializedGlobalVariables)
+    {
+        _ = moduleName ?? throw new ArgumentNullException(nameof(moduleName));
+        _ = references ?? throw new ArgumentNullException(nameof(references));
+        _ = outputPath ?? throw new ArgumentNullException(nameof(outputPath));
+
+        Stream? symbolStream = string.IsNullOrWhiteSpace(symbolPath) ? null : File.Create(symbolPath);
+        try
+        {
+            using var outputStream = File.Create(outputPath);
+            return EmitWithReferenceSet(moduleName, references, outputStream, symbolStream, initializedGlobalVariables).Diagnostics;
+        }
+        finally
+        {
+            symbolStream?.Dispose();
+        }
+    }
     public ImmutableArray<Diagnostic> Emit(string moduleName, string[] references, Stream outputStream, Stream? symbolStream)
     {
         _ = moduleName ?? throw new ArgumentNullException(nameof(moduleName));
@@ -92,6 +111,20 @@ public sealed class Compilation
         return Emitter.Emit(Program, moduleName, references, outputStream, symbolStream, ImmutableDictionary<GlobalVariableSymbol, object>.Empty).Diagnostics;
     }
     public EmitterResult Emit(string moduleName, string[] references, Stream outputStream, Stream? symbolStream, ImmutableDictionary<GlobalVariableSymbol, object> initializedGlobalVariables)
+    {
+        _ = moduleName ?? throw new ArgumentNullException(nameof(moduleName));
+        _ = references ?? throw new ArgumentNullException(nameof(references));
+        _ = outputStream ?? throw new ArgumentNullException(nameof(outputStream));
+        return Emitter.Emit(Program, moduleName, references, outputStream, symbolStream, initializedGlobalVariables);
+    }
+    public ImmutableArray<Diagnostic> EmitWithReferenceSet(string moduleName, EmitReferenceSet references, Stream outputStream, Stream? symbolStream)
+    {
+        _ = moduleName ?? throw new ArgumentNullException(nameof(moduleName));
+        _ = references ?? throw new ArgumentNullException(nameof(references));
+        _ = outputStream ?? throw new ArgumentNullException(nameof(outputStream));
+        return Emitter.Emit(Program, moduleName, references, outputStream, symbolStream, ImmutableDictionary<GlobalVariableSymbol, object>.Empty).Diagnostics;
+    }
+    public EmitterResult EmitWithReferenceSet(string moduleName, EmitReferenceSet references, Stream outputStream, Stream? symbolStream, ImmutableDictionary<GlobalVariableSymbol, object> initializedGlobalVariables)
     {
         _ = moduleName ?? throw new ArgumentNullException(nameof(moduleName));
         _ = references ?? throw new ArgumentNullException(nameof(references));

--- a/src/Balu/Emit/EmitReferenceSet.cs
+++ b/src/Balu/Emit/EmitReferenceSet.cs
@@ -1,0 +1,247 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Balu.Diagnostics;
+using Mono.Cecil;
+
+namespace Balu.Emit;
+
+public sealed class EmitReferenceSet : IDisposable
+{
+    static class RequiredMethodParameters
+    {
+        static readonly string[] SingleObject = ["System.Object"];
+        static readonly string[] Empty = [];
+
+        public static readonly string[] ConsoleWrite = SingleObject;
+        public static readonly string[] ConsoleWriteLine = SingleObject;
+        public static readonly string[] ConsoleReadLine = Empty;
+        public static readonly string[] StringConcat2 = ["System.String", "System.String"];
+        public static readonly string[] StringConcat3 = ["System.String", "System.String", "System.String"];
+        public static readonly string[] StringConcat4 = ["System.String", "System.String", "System.String", "System.String"];
+        public static readonly string[] StringConcatArray = ["System.String[]"];
+        public static readonly string[] ConvertToBool = SingleObject;
+        public static readonly string[] ConvertToInt = SingleObject;
+        public static readonly string[] ConvertToString = SingleObject;
+        public static readonly string[] ObjectEquals = ["System.Object", "System.Object"];
+        public static readonly string[] RandomCtor = Empty;
+        public static readonly string[] RandomNext = ["System.Int32"];
+        public static readonly string[] DebuggableCtor = ["System.Boolean", "System.Boolean"];
+    }
+
+    static readonly string[] requiredTypeNames =
+    [
+        "System.Object",
+        "System.Console",
+        "System.String",
+        "System.Convert",
+        "System.Int32",
+        "System.Boolean",
+        "System.Void",
+        "System.Random",
+        "System.Diagnostics.DebuggableAttribute"
+    ];
+
+    readonly object gate = new();
+    readonly List<AssemblyDefinition> assemblies = [];
+    readonly ImmutableArray<Diagnostic> diagnostics;
+    ResolvedReferences? resolvedReferences;
+    bool isDisposed;
+
+    public EmitReferenceSet(string[] references)
+    {
+        _ = references ?? throw new ArgumentNullException(nameof(references));
+        var referencePaths = references.ToArray();
+        var diagnosticBag = new DiagnosticBag();
+        try
+        {
+            LoadReferences(referencePaths, diagnosticBag);
+            if (!diagnosticBag.HasErrors())
+                resolvedReferences = ResolveReferences(diagnosticBag);
+
+            diagnostics = diagnosticBag.ToImmutableArray();
+            if (diagnostics.HasErrors()) DisposeAssemblies();
+        }
+        catch
+        {
+            DisposeAssemblies();
+            throw;
+        }
+    }
+
+    internal ReferencedMembers CreateReferencedMembers(string moduleName)
+    {
+        lock (gate)
+        {
+            if (isDisposed) throw new ObjectDisposedException(nameof(EmitReferenceSet));
+            if (diagnostics.HasErrors()) throw new MissingReferencesException(diagnostics);
+            return new(moduleName, resolvedReferences!);
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (gate)
+        {
+            if (isDisposed) return;
+            DisposeAssemblies();
+            resolvedReferences = null;
+            isDisposed = true;
+        }
+    }
+
+    void LoadReferences(string[] references, DiagnosticBag diagnosticBag)
+    {
+        foreach (var reference in references)
+        {
+            try
+            {
+                assemblies.Add(AssemblyDefinition.ReadAssembly(reference, new ReaderParameters { InMemory = true }));
+            }
+            catch (BadImageFormatException exception)
+            {
+                diagnosticBag.ReportInvalidAssemblyReference(reference, exception.Message);
+            }
+            catch (IOException exception)
+            {
+                diagnosticBag.ReportInvalidAssemblyReference(reference, exception.Message);
+            }
+        }
+    }
+
+    ResolvedReferences? ResolveReferences(DiagnosticBag diagnosticBag)
+    {
+        var candidates = requiredTypeNames.ToDictionary(name => name, _ => new List<TypeDefinition>(), StringComparer.Ordinal);
+        foreach (var type in assemblies.SelectMany(assembly => assembly.Modules).SelectMany(module => module.Types))
+            if (candidates.TryGetValue(type.FullName, out var definitions))
+                definitions.Add(type);
+
+        var types = new Dictionary<string, TypeDefinition?>(StringComparer.Ordinal);
+        foreach (var name in requiredTypeNames)
+        {
+            var definitions = candidates[name];
+            if (definitions.Count == 1)
+                types.Add(name, definitions[0]);
+            else
+            {
+                types.Add(name, null);
+                if (definitions.Count == 0)
+                    diagnosticBag.ReportRequiredTypeNotFound(name);
+                else
+                    diagnosticBag.ReportRequiredTypeAmbiguous(name, [.. definitions]);
+            }
+        }
+
+        if (diagnosticBag.HasErrors()) return null;
+
+        var objectType = types["System.Object"]!;
+        var consoleType = types["System.Console"]!;
+        var stringType = types["System.String"]!;
+        var convertType = types["System.Convert"]!;
+        var intType = types["System.Int32"]!;
+        var boolType = types["System.Boolean"]!;
+        var voidType = types["System.Void"]!;
+        var randomType = types["System.Random"]!;
+        var debuggableAttributeType = types["System.Diagnostics.DebuggableAttribute"]!;
+
+        var consoleWrite = ResolveMethod(consoleType, "Write", RequiredMethodParameters.ConsoleWrite, diagnosticBag);
+        var consoleWriteLine = ResolveMethod(consoleType, "WriteLine", RequiredMethodParameters.ConsoleWriteLine, diagnosticBag);
+        var consoleReadLine = ResolveMethod(consoleType, "ReadLine", RequiredMethodParameters.ConsoleReadLine, diagnosticBag);
+        var stringConcat2 = ResolveMethod(stringType, "Concat", RequiredMethodParameters.StringConcat2, diagnosticBag);
+        var stringConcat3 = ResolveMethod(stringType, "Concat", RequiredMethodParameters.StringConcat3, diagnosticBag);
+        var stringConcat4 = ResolveMethod(stringType, "Concat", RequiredMethodParameters.StringConcat4, diagnosticBag);
+        var stringConcatArray = ResolveMethod(stringType, "Concat", RequiredMethodParameters.StringConcatArray, diagnosticBag);
+        var convertToBool = ResolveMethod(convertType, "ToBoolean", RequiredMethodParameters.ConvertToBool, diagnosticBag);
+        var convertToInt = ResolveMethod(convertType, "ToInt32", RequiredMethodParameters.ConvertToInt, diagnosticBag);
+        var convertToString = ResolveMethod(convertType, "ToString", RequiredMethodParameters.ConvertToString, diagnosticBag);
+        var objectEquals = ResolveMethod(objectType, "Equals", RequiredMethodParameters.ObjectEquals, diagnosticBag);
+        var randomCtor = ResolveMethod(randomType, ".ctor", RequiredMethodParameters.RandomCtor, diagnosticBag);
+        var randomNext = ResolveMethod(randomType, "Next", RequiredMethodParameters.RandomNext, diagnosticBag);
+        var debuggableCtor = ResolveMethod(debuggableAttributeType, ".ctor", RequiredMethodParameters.DebuggableCtor, diagnosticBag);
+        if (diagnosticBag.HasErrors()) return null;
+
+        return new(
+            objectType,
+            stringType,
+            intType,
+            boolType,
+            voidType,
+            randomType,
+            consoleWrite!,
+            consoleWriteLine!,
+            consoleReadLine!,
+            stringConcat2!,
+            stringConcat3!,
+            stringConcat4!,
+            stringConcatArray!,
+            convertToBool!,
+            convertToInt!,
+            convertToString!,
+            objectEquals!,
+            randomCtor!,
+            randomNext!,
+            debuggableCtor!);
+    }
+
+    static MethodDefinition? ResolveMethod(TypeDefinition type, string name, string[] parameterTypeNames, DiagnosticBag diagnosticBag)
+    {
+        var method = type.Methods.FirstOrDefault(candidate =>
+            candidate.Name == name && candidate.Parameters.Select(parameter => parameter.ParameterType.FullName).SequenceEqual(parameterTypeNames));
+        if (method is null)
+            diagnosticBag.ReportRequiredMethodNotFound(type.FullName, name, parameterTypeNames);
+        return method;
+    }
+
+    void DisposeAssemblies()
+    {
+        foreach (var assembly in assemblies)
+            assembly.Dispose();
+        assemblies.Clear();
+    }
+
+    internal sealed class ResolvedReferences(
+        TypeDefinition objectType,
+        TypeDefinition stringType,
+        TypeDefinition intType,
+        TypeDefinition boolType,
+        TypeDefinition voidType,
+        TypeDefinition randomType,
+        MethodDefinition consoleWrite,
+        MethodDefinition consoleWriteLine,
+        MethodDefinition consoleReadLine,
+        MethodDefinition stringConcat2,
+        MethodDefinition stringConcat3,
+        MethodDefinition stringConcat4,
+        MethodDefinition stringConcatArray,
+        MethodDefinition convertToBool,
+        MethodDefinition convertToInt,
+        MethodDefinition convertToString,
+        MethodDefinition objectEquals,
+        MethodDefinition randomCtor,
+        MethodDefinition randomNext,
+        MethodDefinition debuggableCtor)
+    {
+        public TypeDefinition ObjectType { get; } = objectType;
+        public TypeDefinition StringType { get; } = stringType;
+        public TypeDefinition IntType { get; } = intType;
+        public TypeDefinition BoolType { get; } = boolType;
+        public TypeDefinition VoidType { get; } = voidType;
+        public TypeDefinition RandomType { get; } = randomType;
+        public MethodDefinition ConsoleWrite { get; } = consoleWrite;
+        public MethodDefinition ConsoleWriteLine { get; } = consoleWriteLine;
+        public MethodDefinition ConsoleReadLine { get; } = consoleReadLine;
+        public MethodDefinition StringConcat2 { get; } = stringConcat2;
+        public MethodDefinition StringConcat3 { get; } = stringConcat3;
+        public MethodDefinition StringConcat4 { get; } = stringConcat4;
+        public MethodDefinition StringConcatArray { get; } = stringConcatArray;
+        public MethodDefinition ConvertToBool { get; } = convertToBool;
+        public MethodDefinition ConvertToInt { get; } = convertToInt;
+        public MethodDefinition ConvertToString { get; } = convertToString;
+        public MethodDefinition ObjectEquals { get; } = objectEquals;
+        public MethodDefinition RandomCtor { get; } = randomCtor;
+        public MethodDefinition RandomNext { get; } = randomNext;
+        public MethodDefinition DebuggableCtor { get; } = debuggableCtor;
+    }
+}

--- a/src/Balu/Emit/Emitter.cs
+++ b/src/Balu/Emit/Emitter.cs
@@ -35,12 +35,12 @@ sealed class Emitter : IDisposable
     LocalVariableScope? locals;
     bool debug;
 
-    Emitter(BoundProgram program, string moduleName, string[] references)
+    Emitter(BoundProgram program, string moduleName, EmitReferenceSet references)
     {
         this.program = program;
 
         diagnostics.AddRange(program.Diagnostics);
-        referencedMembers = new(moduleName, references);
+        referencedMembers = references.CreateReferencedMembers(moduleName);
     }
     public void Dispose() => referencedMembers.Dispose();
 
@@ -773,6 +773,13 @@ sealed class Emitter : IDisposable
     }
 
     public static EmitterResult Emit(BoundProgram program, string moduleName, string[] references, Stream outputStream, Stream? symbolStream, ImmutableDictionary<GlobalVariableSymbol, object> initializedGlobalVariables)
+    {
+        if (program.Diagnostics.HasErrors()) return new(program.Diagnostics, ImmutableDictionary<Symbol, string>.Empty);
+        using var referenceSet = new EmitReferenceSet(references);
+        return Emit(program, moduleName, referenceSet, outputStream, symbolStream, initializedGlobalVariables);
+    }
+
+    public static EmitterResult Emit(BoundProgram program, string moduleName, EmitReferenceSet references, Stream outputStream, Stream? symbolStream, ImmutableDictionary<GlobalVariableSymbol, object> initializedGlobalVariables)
     {
         try
         {

--- a/src/Balu/Emit/ReferencedMembers.cs
+++ b/src/Balu/Emit/ReferencedMembers.cs
@@ -1,10 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using Balu.Diagnostics;
 using Balu.Symbols;
 using Mono.Cecil;
 
@@ -12,29 +7,6 @@ namespace Balu.Emit;
 
 sealed class ReferencedMembers : IDisposable
 {
-    static class ReferencedMethodParameters
-    {
-        static readonly string[] SingleObject = ["System.Object"];
-        static readonly string[] Empty = [];
-
-        public static readonly string[] ConsoleWrite = SingleObject ;
-        public static readonly string[] ConsoleWriteLine = SingleObject;
-        public static readonly string[] ConsoleReadLine = Empty;
-        public static readonly string[] StringConcat2 = ["System.String", "System.String"];
-        public static readonly string[] StringConcat3 = ["System.String", "System.String", "System.String"];
-        public static readonly string[] StringConcat4 = ["System.String", "System.String", "System.String", "System.String"];
-        public static readonly string[] StringConcatArray = ["System.String[]"];
-        public static readonly string[] ConvertToBool = SingleObject;
-        public static readonly string[] ConvertToInt = SingleObject;
-        public static readonly string[] ConvertToString = SingleObject;
-        public static readonly string[] ObjectEquals = ["System.Object", "System.Object"];
-        public static readonly string[] RandomCtor = Empty;
-        public static readonly string[] RandomNext = ["System.Int32"];
-        public static readonly string[] DebuggableCtor = ["System.Boolean", "System.Boolean"];
-    }
-    readonly DiagnosticBag diagnostics = [];
-    readonly List<AssemblyDefinition> referencedAssemblies = [];
-
     public  MethodReference DebuggableAttributeCtor { get; }
 
     public AssemblyDefinition Assembly { get; }
@@ -59,141 +31,47 @@ sealed class ReferencedMembers : IDisposable
 
     public ImmutableDictionary<TypeSymbol, TypeReference> TypeMap { get; }
 
-    public ReferencedMembers(string moduleName, string[] referencedAssemblies)
+    public ReferencedMembers(string moduleName, EmitReferenceSet.ResolvedReferences references)
     {
-        LoadReferences(referencedAssemblies);
-        if (diagnostics.HasErrors()) throw new MissingReferencesException(diagnostics.ToImmutableArray());
-
-        var objectTypeDefinition = ResolveTypeDefinition("System.Object");
-        var consoleTypeDefinition = ResolveTypeDefinition("System.Console");
-        var stringTypeDefinition = ResolveTypeDefinition("System.String");
-        var convertTypeDefinition = ResolveTypeDefinition("System.Convert");
-        var intTypeDefinition = ResolveTypeDefinition("System.Int32");
-        var boolTypeDefinition = ResolveTypeDefinition("System.Boolean");
-        var voidTypeDefinition = ResolveTypeDefinition("System.Void");
-        var randomTypeDefinition = ResolveTypeDefinition("System.Random");
-        var debuggableAttributeTypeDefinition = ResolveTypeDefinition("System.Diagnostics.DebuggableAttribute");
-        if (diagnostics.HasErrors() ||
-            objectTypeDefinition is null ||
-            consoleTypeDefinition is null ||
-            stringTypeDefinition is null ||
-            convertTypeDefinition is null ||
-            intTypeDefinition is null ||
-            boolTypeDefinition is null ||
-            voidTypeDefinition is null ||
-            randomTypeDefinition is null ||
-            debuggableAttributeTypeDefinition is null) throw new MissingReferencesException(diagnostics.ToImmutableArray());
-
-        var consoleWrite = ResolveMethodDefinition(consoleTypeDefinition, "Write", ReferencedMethodParameters.ConsoleWrite);
-        var consoleWriteLine = ResolveMethodDefinition(consoleTypeDefinition, "WriteLine", ReferencedMethodParameters.ConsoleWriteLine);
-        var consoleReadLine = ResolveMethodDefinition(consoleTypeDefinition, "ReadLine", ReferencedMethodParameters.ConsoleReadLine);
-        var stringConcat2 = ResolveMethodDefinition(stringTypeDefinition, "Concat", ReferencedMethodParameters.StringConcat2);
-        var stringConcat3 = ResolveMethodDefinition(stringTypeDefinition, "Concat", ReferencedMethodParameters.StringConcat3);
-        var stringConcat4 = ResolveMethodDefinition(stringTypeDefinition, "Concat", ReferencedMethodParameters.StringConcat4);
-        var stringConcatArray = ResolveMethodDefinition(stringTypeDefinition, "Concat", ReferencedMethodParameters.StringConcatArray);
-        var convertToBool = ResolveMethodDefinition(convertTypeDefinition, "ToBoolean", ReferencedMethodParameters.ConvertToBool);
-        var convertToInt = ResolveMethodDefinition(convertTypeDefinition, "ToInt32", ReferencedMethodParameters.ConvertToInt);
-        var convertToString = ResolveMethodDefinition(convertTypeDefinition, "ToString", ReferencedMethodParameters.ConvertToString);
-        var objectEquals = ResolveMethodDefinition(objectTypeDefinition, "Equals", ReferencedMethodParameters.ObjectEquals);
-        var randomCtor = ResolveMethodDefinition(randomTypeDefinition, ".ctor", ReferencedMethodParameters.RandomCtor);
-        var randomNext = ResolveMethodDefinition(randomTypeDefinition, "Next", ReferencedMethodParameters.RandomNext);
-        var debuggableCtor = ResolveMethodDefinition(debuggableAttributeTypeDefinition, ".ctor", ReferencedMethodParameters.DebuggableCtor);
-        if (diagnostics.HasErrors()) throw new MissingReferencesException(diagnostics.ToImmutableArray());
-        Debug.Assert(
-            consoleWrite is not null &&
-            consoleWriteLine is not null &&
-            consoleReadLine is not null &&
-            stringConcat2 is not null &&
-            stringConcat3 is not null &&
-            stringConcat4 is not null &&
-            stringConcatArray is not null &&
-            convertToBool is not null &&
-            convertToInt is not null &&
-            convertToString is not null &&
-            objectEquals is not null &&
-            randomCtor is not null &&
-            randomNext is not null && 
-            debuggableCtor is not null);
-
         var assemblyName = new AssemblyNameDefinition(moduleName, new(1, 0));
         Assembly = AssemblyDefinition.CreateAssembly(assemblyName, moduleName, ModuleKind.Dll);
-
-        ConsoleWrite = Assembly.MainModule.ImportReference(consoleWrite);
-        ConsoleWriteLine = Assembly.MainModule.ImportReference(consoleWriteLine);
-        ConsoleReadLine = Assembly.MainModule.ImportReference(consoleReadLine);
-        StringConcat2 = Assembly.MainModule.ImportReference(stringConcat2);
-        StringConcat3 = Assembly.MainModule.ImportReference(stringConcat3);
-        StringConcat4 = Assembly.MainModule.ImportReference(stringConcat4);
-        StringConcatArray = Assembly.MainModule.ImportReference(stringConcatArray);
-        ConvertToBool = Assembly.MainModule.ImportReference(convertToBool);
-        ConvertToInt = Assembly.MainModule.ImportReference(convertToInt);
-        ConvertToString = Assembly.MainModule.ImportReference(convertToString);
-        ObjectEquals = Assembly.MainModule.ImportReference(objectEquals);
-        var randomReference = Assembly.MainModule.ImportReference(randomTypeDefinition);
-        RandomCtor = Assembly.MainModule.ImportReference(randomCtor);
-        RandomNext = Assembly.MainModule.ImportReference(randomNext);
-        DebuggableAttributeCtor = Assembly.MainModule.ImportReference(debuggableCtor);
-
-        var typeMapBuilder = ImmutableDictionary.CreateBuilder<TypeSymbol, TypeReference>();
-        typeMapBuilder.Add(TypeSymbol.Void, Assembly.MainModule.ImportReference(voidTypeDefinition));
-        typeMapBuilder.Add(TypeSymbol.Any, Assembly.MainModule.ImportReference(objectTypeDefinition));
-        typeMapBuilder.Add(TypeSymbol.Boolean, Assembly.MainModule.ImportReference(boolTypeDefinition));
-        typeMapBuilder.Add(TypeSymbol.Integer, Assembly.MainModule.ImportReference(intTypeDefinition));
-        typeMapBuilder.Add(TypeSymbol.String, Assembly.MainModule.ImportReference(stringTypeDefinition));
-        TypeMap = typeMapBuilder.ToImmutable();
-
-        ProgramType = new(string.Empty, "Program", TypeAttributes.Abstract | TypeAttributes.Sealed, TypeMap[TypeSymbol.Any]);
-        RandomField = new (GlobalSymbolNames.Random, FieldAttributes.Static | FieldAttributes.SpecialName, randomReference);
-        ProgramType.Fields.Add(RandomField);
-        Assembly.MainModule.Types.Add(ProgramType);
-    }
-    public void Dispose() => Assembly.Dispose();
-
-    void LoadReferences(string[] references)
-    {
-        foreach (var reference in references)
+        try
         {
-            try
-            {
-                referencedAssemblies.Add(AssemblyDefinition.ReadAssembly(reference));
-            }
-            catch (BadImageFormatException exception)
-            {
-                diagnostics.ReportInvalidAssemblyReference(reference, exception.Message);
-            }
-            catch (IOException exception)
-            {
-                diagnostics.ReportInvalidAssemblyReference(reference, exception.Message);
-            }
+            ConsoleWrite = Assembly.MainModule.ImportReference(references.ConsoleWrite);
+            ConsoleWriteLine = Assembly.MainModule.ImportReference(references.ConsoleWriteLine);
+            ConsoleReadLine = Assembly.MainModule.ImportReference(references.ConsoleReadLine);
+            StringConcat2 = Assembly.MainModule.ImportReference(references.StringConcat2);
+            StringConcat3 = Assembly.MainModule.ImportReference(references.StringConcat3);
+            StringConcat4 = Assembly.MainModule.ImportReference(references.StringConcat4);
+            StringConcatArray = Assembly.MainModule.ImportReference(references.StringConcatArray);
+            ConvertToBool = Assembly.MainModule.ImportReference(references.ConvertToBool);
+            ConvertToInt = Assembly.MainModule.ImportReference(references.ConvertToInt);
+            ConvertToString = Assembly.MainModule.ImportReference(references.ConvertToString);
+            ObjectEquals = Assembly.MainModule.ImportReference(references.ObjectEquals);
+            var randomReference = Assembly.MainModule.ImportReference(references.RandomType);
+            RandomCtor = Assembly.MainModule.ImportReference(references.RandomCtor);
+            RandomNext = Assembly.MainModule.ImportReference(references.RandomNext);
+            DebuggableAttributeCtor = Assembly.MainModule.ImportReference(references.DebuggableCtor);
+
+            var typeMapBuilder = ImmutableDictionary.CreateBuilder<TypeSymbol, TypeReference>();
+            typeMapBuilder.Add(TypeSymbol.Void, Assembly.MainModule.ImportReference(references.VoidType));
+            typeMapBuilder.Add(TypeSymbol.Any, Assembly.MainModule.ImportReference(references.ObjectType));
+            typeMapBuilder.Add(TypeSymbol.Boolean, Assembly.MainModule.ImportReference(references.BoolType));
+            typeMapBuilder.Add(TypeSymbol.Integer, Assembly.MainModule.ImportReference(references.IntType));
+            typeMapBuilder.Add(TypeSymbol.String, Assembly.MainModule.ImportReference(references.StringType));
+            TypeMap = typeMapBuilder.ToImmutable();
+
+            ProgramType = new(string.Empty, "Program", TypeAttributes.Abstract | TypeAttributes.Sealed, TypeMap[TypeSymbol.Any]);
+            RandomField = new(GlobalSymbolNames.Random, FieldAttributes.Static | FieldAttributes.SpecialName, randomReference);
+            ProgramType.Fields.Add(RandomField);
+            Assembly.MainModule.Types.Add(ProgramType);
+        }
+        catch
+        {
+            Assembly.Dispose();
+            throw;
         }
     }
-    TypeDefinition? ResolveTypeDefinition(string fullName, TypeSymbol? typeSybmol = null)
-    {
-        var typeDefinitions = referencedAssemblies.SelectMany(referencedAssembly => referencedAssembly.Modules)
-                                                  .SelectMany(module => module.Types)
-                                                  .Where(t => t.FullName == fullName)
-                                                  .ToArray();
-
-        if (typeDefinitions.Length == 1)
-            return typeDefinitions[0];
-
-        if (typeDefinitions.Length == 0)
-            diagnostics.ReportRequiredTypeNotFound(fullName, typeSybmol);
-        else
-            diagnostics.ReportRequiredTypeAmbiguous(fullName, typeDefinitions);
-
-        return null;
-    }
-    MethodDefinition? ResolveMethodDefinition(TypeDefinition typeDefinition, string name, string[] parameterTypeNames)
-    {
-        var candidates = from method in typeDefinition.Methods
-                         where method.Name == name &&
-                               method.Parameters.Select(p => p.ParameterType.FullName).SequenceEqual(parameterTypeNames)
-                         select method;
-        var winner = candidates.FirstOrDefault();
-        if (winner is not null) return winner;
-        diagnostics.ReportRequiredMethodNotFound(typeDefinition.FullName, name, parameterTypeNames);
-        return null;
-    }
+    public void Dispose() => Assembly.Dispose();
 
 }

--- a/src/bi/BaluRepl.cs
+++ b/src/bi/BaluRepl.cs
@@ -14,7 +14,7 @@ using Balu.Visualization;
 
 namespace Balu.Interactive;
 
-sealed class BaluRepl : Repl
+sealed class BaluRepl : Repl, IDisposable
 {
     bool showVars;
     readonly Interpreter interpreter = new(
@@ -27,8 +27,17 @@ sealed class BaluRepl : Repl
 
     public BaluRepl()
     {
-        LoadSubmissions();
+        try
+        {
+            LoadSubmissions();
+        }
+        catch
+        {
+            interpreter.Dispose();
+            throw;
+        }
     }
+    public void Dispose() => interpreter.Dispose();
 
     protected override bool IsCompleteSubmission(string text) => string.IsNullOrWhiteSpace(text) || text.EndsWith(Environment.NewLine+Environment.NewLine, StringComparison.InvariantCultureIgnoreCase) || !SyntaxTree.Parse(text).IsLastTokenMissing;
 

--- a/src/bi/Program.cs
+++ b/src/bi/Program.cs
@@ -1,3 +1,4 @@
 ﻿using Balu.Interactive;
 
-new BaluRepl().Run();
+using var repl = new BaluRepl();
+repl.Run();


### PR DESCRIPTION
## Summary
- add an explicit reusable `EmitReferenceSet` that loads reference assemblies in memory and validates required metadata once
- keep existing path-based emit APIs compatible while adding `EmitWithReferenceSet` for long-lived hosts
- make the interpreter reuse and dispose one reference snapshot across submissions
- dispose partial reference loads and generated assemblies on failure paths
- add lifetime, validation failure, disposal, and interpreter snapshot tests

## Verification
- `dotnet build src/bi/bi.csproj --configuration Release --no-restore`
- `dotnet test src/Balu.Tests/Balu.Tests.csproj --configuration Release --no-restore` (21,606 passed)
- `git diff --check`

Closes #90