### PR TITLE
Protect existing files from failed emits

### DIFF
--- a/src/Balu.Tests/EmitterTests/FileEmissionTests.cs
+++ b/src/Balu.Tests/EmitterTests/FileEmissionTests.cs
@@ -1,0 +1,222 @@
+using System.IO;
+using System.Linq;
+using Balu.Diagnostics;
+using Balu.Emit;
+using Balu.Syntax;
+using Balu.Tests.TestHelper;
+using Mono.Cecil;
+using Xunit;
+
+namespace Balu.Tests.EmitterTests;
+
+public partial class EmitterTests
+{
+    const string AssemblySentinel = "existing assembly";
+    const string SymbolSentinel = "existing symbols";
+
+    [Fact]
+    public void Emitter_ProgramFailure_PreservesExistingFiles()
+    {
+        var directory = Directory.CreateTempSubdirectory("BaluEmitterFiles-");
+        try
+        {
+            var (outputPath, symbolPath) = WriteSentinels(directory);
+            var compilation = Compilation.Create(SyntaxTree.Parse("function main() { missing() }"));
+
+            var diagnostics = compilation.Emit("ProgramFailure", ReferenceProvider.References, outputPath, symbolPath);
+
+            Assert.True(diagnostics.HasErrors());
+            AssertSentinels(outputPath, symbolPath);
+            AssertNoTemporaryFiles(directory);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Emitter_ReferenceFailure_PreservesExistingFiles()
+    {
+        var directory = Directory.CreateTempSubdirectory("BaluEmitterFiles-");
+        try
+        {
+            var (outputPath, symbolPath) = WriteSentinels(directory);
+            var compilation = Compilation.Create(SyntaxTree.Parse("function main() {}"));
+            var missingReference = Path.Combine(directory.FullName, "missing-reference.dll");
+
+            var diagnostics = compilation.Emit("ReferenceFailure", new[] { missingReference }, outputPath, symbolPath);
+
+            Assert.Contains(diagnostics, diagnostic => diagnostic.Id == DiagnosticId.InvalidAssemblyReference);
+            AssertSentinels(outputPath, symbolPath);
+            AssertNoTemporaryFiles(directory);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Emitter_EmitFailure_PreservesExistingFiles()
+    {
+        var directory = Directory.CreateTempSubdirectory("BaluEmitterFiles-");
+        try
+        {
+            var (outputPath, symbolPath) = WriteSentinels(directory);
+            var compilation = Compilation.Create(SyntaxTree.Parse("function main() {}"));
+            using var references = new EmitReferenceSet(ReferenceProvider.References);
+
+            var diagnostics = compilation.EmitWithReferenceSet("EmitFailure", references, outputPath, symbolPath);
+
+            Assert.Contains(diagnostics, diagnostic => diagnostic.Id == DiagnosticId.SourceDocumentNameMissing);
+            AssertSentinels(outputPath, symbolPath);
+            AssertNoTemporaryFiles(directory);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Emitter_Success_ReplacesExistingFiles()
+    {
+        var directory = Directory.CreateTempSubdirectory("BaluEmitterFiles-");
+        try
+        {
+            var sourcePath = Path.Combine(directory.FullName, "source.b");
+            File.WriteAllText(sourcePath, "function main() {}");
+            var (outputPath, symbolPath) = WriteSentinels(directory);
+            var compilation = Compilation.Create(SyntaxTree.Load(sourcePath));
+
+            var diagnostics = compilation.Emit("SuccessfulEmit", ReferenceProvider.References, outputPath, symbolPath);
+
+            Assert.False(diagnostics.HasErrors());
+            Assert.NotEqual(AssemblySentinel, File.ReadAllText(outputPath));
+            Assert.NotEqual(SymbolSentinel, File.ReadAllText(symbolPath));
+            using var assembly = AssemblyDefinition.ReadAssembly(outputPath, new ReaderParameters { ReadSymbols = true });
+            Assert.True(assembly.MainModule.HasSymbols);
+            AssertNoTemporaryFiles(directory);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Emitter_OutputCommitFailure_RestoresExistingSymbols()
+    {
+        var directory = Directory.CreateTempSubdirectory("BaluEmitterFiles-");
+        try
+        {
+            var sourcePath = Path.Combine(directory.FullName, "source.b");
+            File.WriteAllText(sourcePath, "function main() {}");
+            var outputPath = Directory.CreateDirectory(Path.Combine(directory.FullName, "program.dll")).FullName;
+            var symbolPath = Path.Combine(directory.FullName, "program.pdb");
+            File.WriteAllText(symbolPath, SymbolSentinel);
+            var compilation = Compilation.Create(SyntaxTree.Load(sourcePath));
+
+            Assert.ThrowsAny<IOException>(() => compilation.Emit("CommitFailure", ReferenceProvider.References, outputPath, symbolPath));
+
+            Assert.True(Directory.Exists(outputPath));
+            Assert.Equal(SymbolSentinel, File.ReadAllText(symbolPath));
+            AssertNoTemporaryFiles(directory);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Emitter_RejectsCanonicalOutputAndSymbolPathCollision()
+    {
+        var directory = Directory.CreateTempSubdirectory("BaluEmitterFiles-");
+        try
+        {
+            var outputPath = Path.Combine(directory.FullName, "program.dll");
+            File.WriteAllText(outputPath, AssemblySentinel);
+            var equivalentPath = Path.Combine(directory.FullName, "subdirectory", "..", "program.dll");
+            var compilation = Compilation.Create(SyntaxTree.Parse("function main() {}"));
+
+            var diagnostics = compilation.Emit("PathCollision", ReferenceProvider.References, outputPath, equivalentPath);
+
+            Assert.Equal(DiagnosticId.EmitPathCollision, Assert.Single(diagnostics).Id);
+            Assert.Equal(AssemblySentinel, File.ReadAllText(outputPath));
+            AssertNoTemporaryFiles(directory);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Emitter_RejectsSourceAndOutputPathCollision()
+    {
+        var directory = Directory.CreateTempSubdirectory("BaluEmitterFiles-");
+        try
+        {
+            var sourcePath = Path.Combine(directory.FullName, "source.b");
+            const string source = "function main() {}";
+            File.WriteAllText(sourcePath, source);
+            var compilation = Compilation.Create(SyntaxTree.Load(sourcePath));
+
+            var diagnostics = compilation.Emit("PathCollision", ReferenceProvider.References, sourcePath, null);
+
+            Assert.Equal(DiagnosticId.EmitPathCollision, Assert.Single(diagnostics).Id);
+            Assert.Equal(source, File.ReadAllText(sourcePath));
+            AssertNoTemporaryFiles(directory);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Emitter_RejectsSourceAndSymbolPathCollision()
+    {
+        var directory = Directory.CreateTempSubdirectory("BaluEmitterFiles-");
+        try
+        {
+            var sourcePath = Path.Combine(directory.FullName, "source.b");
+            const string source = "function main() {}";
+            File.WriteAllText(sourcePath, source);
+            var outputPath = Path.Combine(directory.FullName, "program.dll");
+            File.WriteAllText(outputPath, AssemblySentinel);
+            var compilation = Compilation.Create(SyntaxTree.Load(sourcePath));
+
+            var diagnostics = compilation.Emit("PathCollision", ReferenceProvider.References, outputPath, sourcePath);
+
+            Assert.Equal(DiagnosticId.EmitPathCollision, Assert.Single(diagnostics).Id);
+            Assert.Equal(source, File.ReadAllText(sourcePath));
+            Assert.Equal(AssemblySentinel, File.ReadAllText(outputPath));
+            AssertNoTemporaryFiles(directory);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    static (string outputPath, string symbolPath) WriteSentinels(DirectoryInfo directory)
+    {
+        var outputPath = Path.Combine(directory.FullName, "program.dll");
+        var symbolPath = Path.Combine(directory.FullName, "program.pdb");
+        File.WriteAllText(outputPath, AssemblySentinel);
+        File.WriteAllText(symbolPath, SymbolSentinel);
+        return (outputPath, symbolPath);
+    }
+
+    static void AssertSentinels(string outputPath, string symbolPath)
+    {
+        Assert.Equal(AssemblySentinel, File.ReadAllText(outputPath));
+        Assert.Equal(SymbolSentinel, File.ReadAllText(symbolPath));
+    }
+
+    static void AssertNoTemporaryFiles(DirectoryInfo directory) =>
+        Assert.Empty(directory.EnumerateFiles().Where(file => file.Extension is ".tmp" or ".bak"));
+}

--- a/src/Balu/Compilation.cs
+++ b/src/Balu/Compilation.cs
@@ -2,6 +2,7 @@
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using Balu.Binding;
 using Balu.Diagnostics;
@@ -17,6 +18,9 @@ namespace Balu;
 
 public sealed class Compilation
 {
+    static readonly StringComparer pathComparer =
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+
     readonly Compilation? previous;
     BoundGlobalScope? globalScope;
     BoundProgram? program;
@@ -73,16 +77,12 @@ public sealed class Compilation
         _ = references ?? throw new ArgumentNullException(nameof(references));
         _ = outputPath ?? throw new ArgumentNullException(nameof(outputPath));
 
-        Stream? symbolStream = string.IsNullOrWhiteSpace(symbolPath) ? null : File.Create(symbolPath);
-        try
-        {
-            using var outputStream = File.Create(outputPath);
-            return Emit(moduleName, references, outputStream, symbolStream, initializedGlobalVariables).Diagnostics;
-        }
-        finally
-        {
-            symbolStream?.Dispose();
-        }
+        var pathDiagnostics = ValidateEmitPaths(outputPath, symbolPath, out var canonicalOutputPath, out var canonicalSymbolPath);
+        if (pathDiagnostics.HasErrors()) return pathDiagnostics;
+        if (Program.Diagnostics.HasErrors()) return Program.Diagnostics;
+
+        using var referenceSet = new EmitReferenceSet(references);
+        return EmitToFiles(moduleName, referenceSet, canonicalOutputPath, canonicalSymbolPath, initializedGlobalVariables);
     }
     public ImmutableArray<Diagnostic> EmitWithReferenceSet(string moduleName, EmitReferenceSet references, string outputPath, string? symbolPath) =>
         EmitWithReferenceSet(moduleName, references, outputPath, symbolPath, ImmutableDictionary<GlobalVariableSymbol, object>.Empty);
@@ -92,16 +92,10 @@ public sealed class Compilation
         _ = references ?? throw new ArgumentNullException(nameof(references));
         _ = outputPath ?? throw new ArgumentNullException(nameof(outputPath));
 
-        Stream? symbolStream = string.IsNullOrWhiteSpace(symbolPath) ? null : File.Create(symbolPath);
-        try
-        {
-            using var outputStream = File.Create(outputPath);
-            return EmitWithReferenceSet(moduleName, references, outputStream, symbolStream, initializedGlobalVariables).Diagnostics;
-        }
-        finally
-        {
-            symbolStream?.Dispose();
-        }
+        var pathDiagnostics = ValidateEmitPaths(outputPath, symbolPath, out var canonicalOutputPath, out var canonicalSymbolPath);
+        if (pathDiagnostics.HasErrors()) return pathDiagnostics;
+        if (Program.Diagnostics.HasErrors()) return Program.Diagnostics;
+        return EmitToFiles(moduleName, references, canonicalOutputPath, canonicalSymbolPath, initializedGlobalVariables);
     }
     public ImmutableArray<Diagnostic> Emit(string moduleName, string[] references, Stream outputStream, Stream? symbolStream)
     {
@@ -130,6 +124,116 @@ public sealed class Compilation
         _ = references ?? throw new ArgumentNullException(nameof(references));
         _ = outputStream ?? throw new ArgumentNullException(nameof(outputStream));
         return Emitter.Emit(Program, moduleName, references, outputStream, symbolStream, initializedGlobalVariables);
+    }
+
+    ImmutableArray<Diagnostic> EmitToFiles(
+        string moduleName,
+        EmitReferenceSet references,
+        string outputPath,
+        string? symbolPath,
+        ImmutableDictionary<GlobalVariableSymbol, object> initializedGlobalVariables)
+    {
+        var referenceDiagnostics = references.GetDiagnostics();
+        if (referenceDiagnostics.HasErrors()) return referenceDiagnostics;
+
+        string? temporaryOutputPath = null;
+        string? temporarySymbolPath = null;
+        string? symbolBackupPath = null;
+        try
+        {
+            EmitterResult result;
+            using (var outputStream = CreateTemporaryFile(outputPath, out temporaryOutputPath))
+            {
+                if (symbolPath is null)
+                    result = EmitWithReferenceSet(moduleName, references, outputStream, null, initializedGlobalVariables);
+                else
+                    using (var symbolStream = CreateTemporaryFile(symbolPath, out temporarySymbolPath))
+                        result = EmitWithReferenceSet(moduleName, references, outputStream, symbolStream, initializedGlobalVariables);
+            }
+
+            if (result.Diagnostics.HasErrors()) return result.Diagnostics;
+
+            if (symbolPath is not null)
+            {
+                if (File.Exists(symbolPath)) symbolBackupPath = CreateTemporaryPath(symbolPath, "bak");
+                CommitTemporaryFile(temporarySymbolPath!, symbolPath, symbolBackupPath);
+                temporarySymbolPath = null;
+            }
+
+            try
+            {
+                CommitTemporaryFile(temporaryOutputPath, outputPath);
+            }
+            catch
+            {
+                if (symbolPath is not null)
+                {
+                    var backupPath = symbolBackupPath;
+                    symbolBackupPath = null;
+                    RestoreFile(symbolPath, backupPath);
+                }
+                throw;
+            }
+
+            temporaryOutputPath = null;
+            return result.Diagnostics;
+        }
+        finally
+        {
+            DeleteTemporaryFile(temporaryOutputPath);
+            DeleteTemporaryFile(temporarySymbolPath);
+            DeleteTemporaryFile(symbolBackupPath);
+        }
+    }
+
+    ImmutableArray<Diagnostic> ValidateEmitPaths(string outputPath, string? symbolPath, out string canonicalOutputPath, out string? canonicalSymbolPath)
+    {
+        canonicalOutputPath = Path.GetFullPath(outputPath);
+        canonicalSymbolPath = string.IsNullOrWhiteSpace(symbolPath) ? null : Path.GetFullPath(symbolPath);
+        var diagnostics = new DiagnosticBag();
+
+        if (canonicalSymbolPath is not null && pathComparer.Equals(canonicalOutputPath, canonicalSymbolPath))
+            diagnostics.ReportEmitPathCollision("assembly output", canonicalOutputPath, "symbol output", canonicalSymbolPath);
+
+        foreach (var sourcePath in SyntaxTrees.Select(tree => tree.Text.FileName).Where(fileName => !string.IsNullOrWhiteSpace(fileName)).Select(Path.GetFullPath))
+        {
+            if (pathComparer.Equals(canonicalOutputPath, sourcePath))
+                diagnostics.ReportEmitPathCollision("assembly output", canonicalOutputPath, "source file", sourcePath);
+            if (canonicalSymbolPath is not null && pathComparer.Equals(canonicalSymbolPath, sourcePath))
+                diagnostics.ReportEmitPathCollision("symbol output", canonicalSymbolPath, "source file", sourcePath);
+        }
+
+        return diagnostics.ToImmutableArray();
+    }
+
+    static FileStream CreateTemporaryFile(string destinationPath, out string temporaryPath)
+    {
+        temporaryPath = CreateTemporaryPath(destinationPath, "tmp");
+        return new(temporaryPath, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+    }
+
+    static string CreateTemporaryPath(string destinationPath, string extension) =>
+        Path.Combine(Path.GetDirectoryName(destinationPath)!, $".{Path.GetFileName(destinationPath)}.{Guid.NewGuid():N}.{extension}");
+
+    static void CommitTemporaryFile(string temporaryPath, string destinationPath, string? backupPath = null)
+    {
+        if (File.Exists(destinationPath))
+            File.Replace(temporaryPath, destinationPath, backupPath);
+        else
+            File.Move(temporaryPath, destinationPath);
+    }
+
+    static void RestoreFile(string destinationPath, string? backupPath)
+    {
+        if (backupPath is null)
+            File.Delete(destinationPath);
+        else
+            File.Replace(backupPath, destinationPath, null);
+    }
+
+    static void DeleteTemporaryFile(string? path)
+    {
+        if (path is not null && File.Exists(path)) File.Delete(path);
     }
 
     public void WriteSyntaxTrees(TextWriter writer)

--- a/src/Balu/Diagnostics/DiagnosticBag.cs
+++ b/src/Balu/Diagnostics/DiagnosticBag.cs
@@ -120,4 +120,6 @@ sealed class DiagnosticBag : List<Diagnostic>
         Add(new(DiagnosticId.SourceDocumentNameMissing, location, "Cannot emit debug symbols for a source document without a name."));
     public void ReportSourceDocumentNameCollision(TextLocation location, string documentName) =>
         Add(new(DiagnosticId.SourceDocumentNameCollision, location, $"Cannot emit debug symbols because document name '{documentName}' identifies different source texts."));
+    public void ReportEmitPathCollision(string pathKind, string path, string conflictingPathKind, string conflictingPath) =>
+        Add(new(DiagnosticId.EmitPathCollision, default, $"The {pathKind} path '{path}' conflicts with the {conflictingPathKind} path '{conflictingPath}'."));
 }

--- a/src/Balu/Diagnostics/DiagnosticId.cs
+++ b/src/Balu/Diagnostics/DiagnosticId.cs
@@ -47,5 +47,6 @@ public enum DiagnosticId
     RequiredTypeAmbiguous,
     RequiredMethodNotFound,
     SourceDocumentNameMissing,
-    SourceDocumentNameCollision
+    SourceDocumentNameCollision,
+    EmitPathCollision
 }

--- a/src/Balu/Emit/EmitReferenceSet.cs
+++ b/src/Balu/Emit/EmitReferenceSet.cs
@@ -81,6 +81,15 @@ public sealed class EmitReferenceSet : IDisposable
         }
     }
 
+    internal ImmutableArray<Diagnostic> GetDiagnostics()
+    {
+        lock (gate)
+        {
+            if (isDisposed) throw new ObjectDisposedException(nameof(EmitReferenceSet));
+            return diagnostics;
+        }
+    }
+
     public void Dispose()
     {
         lock (gate)


### PR DESCRIPTION
## Summary
- validate program, reference, and canonical output/source path collisions before creating output files
- emit assemblies and symbols to temporary files in their destination directories, then atomically publish successful results
- restore an existing PDB if the final assembly commit fails and clean up temporary artifacts
- cover diagnostic failures, reference failures, PDB failures, successful replacement, rollback, and path collisions

## Verification
- `dotnet test src/Balu.Tests/Balu.Tests.csproj --configuration Release --no-build` (21,614 passed)
- `git diff --check`
- `dotnet build src/Balu.sln --configuration Release --no-restore` (all affected projects build; the existing `Balu.VSIX` project fails because local Visual Studio SDK types such as `AsyncPackage` are unavailable)

Closes #77