### PR TITLE
Commit interpreter submissions after successful execution

### DIFF
--- a/src/Balu.Interpretation/Interpreter.cs
+++ b/src/Balu.Interpretation/Interpreter.cs
@@ -39,6 +39,8 @@ public sealed class Interpreter : IDisposable
     {
         submissionCount = 0;
         Compilation = Compilation.CreateScript(null, SyntaxTree.Parse(string.Empty));
+        Result = null;
+        GlobalVariables = [];
     }
     public ImmutableArray<Diagnostic> Execute(string code, bool ignoreWarnings = true)
     {
@@ -70,28 +72,32 @@ public sealed class Interpreter : IDisposable
         if (emitterResult.Diagnostics.HasErrors() || !ignoreWarnings && emitterResult.Diagnostics.Any())
             return emitterResult.Diagnostics;
 
-        submissionCount = submissionNumber;
-        Compilation = compilation;
-
         memoryStream.Seek(0, SeekOrigin.Begin);
         var context = new AssemblyLoadContext(null, true);
+        object? result;
+        ImmutableDictionary<GlobalVariableSymbol, object> globalVariables;
         try
         {
             var asm = context.LoadFromStream(memoryStream);
-            Result = asm.EntryPoint!.Invoke(null, null);
+            result = asm.EntryPoint!.Invoke(null, null);
             var programType = asm.GetType("Program")!;
 
-            GlobalVariables = emitterResult.GlobalSymbolNames
-                                       .Where(x => x.Key is GlobalVariableSymbol && !x.Key.Name.IsBaluSpecialName())
-                                       .ToImmutableDictionary(
-                                           x => (GlobalVariableSymbol)x.Key,
-                                           x => programType.GetField(x.Value, BindingFlags.Static | BindingFlags.NonPublic)!.GetValue(null)!);
-            return emitterResult.Diagnostics;
+            globalVariables = emitterResult.GlobalSymbolNames
+                                           .Where(x => x.Key is GlobalVariableSymbol && !x.Key.Name.IsBaluSpecialName())
+                                           .ToImmutableDictionary(
+                                               x => (GlobalVariableSymbol)x.Key,
+                                               x => programType.GetField(x.Value, BindingFlags.Static | BindingFlags.NonPublic)!.GetValue(null)!);
         }
         finally
         {
             context.Unload();
         }
+
+        submissionCount = submissionNumber;
+        Compilation = compilation;
+        Result = result;
+        GlobalVariables = globalVariables;
+        return emitterResult.Diagnostics;
     }
 
 }

--- a/src/Balu.Tests/InterpreterTests/InterpreterTests.cs
+++ b/src/Balu.Tests/InterpreterTests/InterpreterTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
 using Balu.Diagnostics;
@@ -110,6 +111,48 @@ public sealed class InterpreterTests
         asserter.AssertScriptEvaluation("function a() { var x = [y] }", expectedDiagnostics: "Undefined name 'y'.");
         asserter.AssertScriptEvaluation("function c() : int { return 42 }");
         asserter.AssertScriptEvaluation("c()", value: 42);
+    }
+
+    [Fact]
+    public void Interpreter_RuntimeFailure_RollsBackSubmission()
+    {
+        using var interpreter = new Interpreter(ReferenceProvider.References);
+        Assert.False(interpreter.Execute("var value = 42 value").HasErrors());
+        var compilation = interpreter.Compilation;
+        var globalVariables = interpreter.GlobalVariables;
+
+        var exception = Assert.Throws<TargetInvocationException>(
+            () => interpreter.Execute("value = 0 var divisor = 0 value / divisor"));
+
+        Assert.IsType<System.DivideByZeroException>(exception.InnerException);
+        Assert.Same(compilation, interpreter.Compilation);
+        Assert.Same(globalVariables, interpreter.GlobalVariables);
+        Assert.Equal(42, interpreter.Result);
+        var globalVariable = Assert.Single(interpreter.GlobalVariables);
+        Assert.Equal("value", globalVariable.Key.Name);
+        Assert.Equal(42, globalVariable.Value);
+        Assert.DoesNotContain(interpreter.AllSymbols, symbol => symbol.Name == "divisor");
+
+        Assert.False(interpreter.Execute("value").HasErrors());
+        Assert.Equal("BaluInterpreter/submission-0002.b", Assert.Single(interpreter.Compilation.SyntaxTrees).Text.FileName);
+        Assert.Equal(42, interpreter.Result);
+    }
+
+    [Fact]
+    public void Interpreter_Reset_ClearsResultAndGlobalVariables()
+    {
+        using var interpreter = new Interpreter(ReferenceProvider.References);
+        Assert.False(interpreter.Execute("var value = 42 value").HasErrors());
+
+        interpreter.Reset();
+
+        Assert.Null(interpreter.Result);
+        Assert.Empty(interpreter.GlobalVariables);
+        Assert.DoesNotContain(interpreter.AllSymbols, symbol => symbol.Name == "value");
+        var diagnostics = interpreter.Execute("value");
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Id == DiagnosticId.UndefinedName);
+        Assert.Null(interpreter.Result);
+        Assert.Empty(interpreter.GlobalVariables);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- keep candidate compilation, result, and globals local until assembly loading, invocation, and state capture complete
- preserve the last successful compilation and runtime state when a submission throws
- clear result and global variables when resetting the interpreter
- verify runtime rollback, submission numbering, retained global values, and complete reset behavior

## Verification
- `dotnet build src/bi/bi.csproj --configuration Release --no-restore` (0 warnings, 0 errors)
- `dotnet test src/Balu.Tests/Balu.Tests.csproj --configuration Release --no-restore` (21,616 passed)
- `git diff --check`

Closes #88