### PR TITLE
Package the current compiler with the SDK

### DIFF
--- a/src/Balu.Sdk/Balu.Sdk.csproj
+++ b/src/Balu.Sdk/Balu.Sdk.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<PropertyGroup>
 		<IsPackable>true</IsPackable>
-		<Version>0.1.0</Version>
+		<Version>0.2.0</Version>
 		<Title>Balu.Sdk</Title>
 		<Authors>René Vogt</Authors>
 		<Description>The Balu language SDK.</Description>

--- a/src/Balu.Sdk/Balu.Sdk.csproj
+++ b/src/Balu.Sdk/Balu.Sdk.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<PropertyGroup>
 		<IsPackable>true</IsPackable>
-		<Version>0.2.0</Version>
+		<Version>0.2.1</Version>
 		<Title>Balu.Sdk</Title>
 		<Authors>René Vogt</Authors>
 		<Description>The Balu language SDK.</Description>

--- a/src/Balu.Sdk/Balu.Sdk.csproj
+++ b/src/Balu.Sdk/Balu.Sdk.csproj
@@ -21,20 +21,21 @@
 		<NoWarn>NU5100,NU5128</NoWarn>
 		<GenerateDependencyFile>true</GenerateDependencyFile>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<BaluCompilerProject>$([MSBuild]::NormalizePath($(MSBuildThisFileDirectory)..\bc\bc.csproj))</BaluCompilerProject>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.4.0" PrivateAssets="all" ExcludeAssets="Runtime" />
 	</ItemGroup>
 	<ItemGroup>
-		<!-- bc is a build tool, so it participates in the build without being referenced by the netstandard task assembly. -->
-		<ProjectReference Include="..\bc\bc.csproj"
+		<!-- Keep bc in the restore graph; the package target builds it explicitly to work inside and outside Visual Studio. -->
+		<ProjectReference Include="$(BaluCompilerProject)"
 					  ReferenceOutputAssembly="false"
+					  BuildReference="false"
+					  Private="false"
 					  PrivateAssets="all"
 					  SkipGetTargetFrameworkProperties="true"
-					  GlobalPropertiesToRemove="TargetFramework"
-					  Targets="GetBaluCompilerPackageFiles"
-					  OutputItemType="_BaluCompilerPackageFile" />
+					  GlobalPropertiesToRemove="TargetFramework" />
 	</ItemGroup>
 	<ItemGroup>
 		<!-- these lines pack the build props/targets files to the `build` folder in the generated package.
@@ -45,6 +46,13 @@
 	</ItemGroup>
 
 	<Target Name="CollectPackageBuildOutput" DependsOnTargets="ResolveReferences">
+		<MSBuild Projects="$(BaluCompilerProject)"
+				 Targets="GetBaluCompilerPackageFiles"
+				 BuildInParallel="$(BuildInParallel)"
+				 Properties="Configuration=$(Configuration);Platform=$(Platform)"
+				 RemoveProperties="TargetFramework">
+			<Output TaskParameter="TargetOutputs" ItemName="_BaluCompilerPackageFile" />
+		</MSBuild>
 		<ItemGroup>
 			<!-- The TargetPath is the path inside the package that the source file will be placed. This is already precomputed in the ReferenceCopyLocalPaths items' DestinationSubPath, so reuse it here. -->
 			<BuildOutputInPackage Include="@(ReferenceCopyLocalPaths)" TargetPath="%(ReferenceCopyLocalPaths.DestinationSubPath)" />

--- a/src/Balu.Sdk/Balu.Sdk.csproj
+++ b/src/Balu.Sdk/Balu.Sdk.csproj
@@ -21,7 +21,7 @@
 		<NoWarn>NU5100,NU5128</NoWarn>
 		<GenerateDependencyFile>true</GenerateDependencyFile>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-		<BaluCompilerProject>$([MSBuild]::NormalizePath($(MSBuildThisFileDirectory)..\bc\bc.csproj))</BaluCompilerProject>
+		<BaluCompilerProject>$([MSBuild]::NormalizePath($(MSBuildThisFileDirectory)../bc/bc.csproj))</BaluCompilerProject>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -41,28 +41,28 @@
 		<!-- these lines pack the build props/targets files to the `build` folder in the generated package.
  		by convention, the .NET SDK will look for build\<Package Id>.props and build\<Package Id>.targets
  		for automatic inclusion in the build. -->
-		<Content Include="Sdk.props" PackagePath="sdk\" />
-		<Content Include="Sdk.targets" PackagePath="sdk\" />
+		<Content Include="Sdk.props" PackagePath="sdk/" />
+		<Content Include="Sdk.targets" PackagePath="sdk/" />
 	</ItemGroup>
 
 	<Target Name="CollectPackageBuildOutput" DependsOnTargets="ResolveReferences">
 		<MSBuild Projects="$(BaluCompilerProject)"
 				 Targets="GetBaluCompilerPackageFiles"
 				 BuildInParallel="$(BuildInParallel)"
-				 Properties="Configuration=$(Configuration);Platform=$(Platform)"
+				 Properties="Configuration=$(Configuration);Platform=$(Platform);UseAppHost=false"
 				 RemoveProperties="TargetFramework">
 			<Output TaskParameter="TargetOutputs" ItemName="_BaluCompilerPackageFile" />
 		</MSBuild>
 		<ItemGroup>
 			<!-- The TargetPath is the path inside the package that the source file will be placed. This is already precomputed in the ReferenceCopyLocalPaths items' DestinationSubPath, so reuse it here. -->
 			<BuildOutputInPackage Include="@(ReferenceCopyLocalPaths)" TargetPath="%(ReferenceCopyLocalPaths.DestinationSubPath)" />
-			<_BaluCompilerEntryPoint Include="@(_BaluCompilerPackageFile)" Condition="'%(_BaluCompilerPackageFile.TargetPath)' == 'bc.exe'" />
+			<_BaluCompilerEntryPoint Include="@(_BaluCompilerPackageFile)" Condition="'%(_BaluCompilerPackageFile.TargetPath)' == 'bc.dll'" />
 			<_BaluCompilerDependencyFile Include="@(_BaluCompilerPackageFile)" Condition="'%(_BaluCompilerPackageFile.TargetPath)' == 'bc.deps.json'" />
 			<_BaluCompilerRuntimeConfig Include="@(_BaluCompilerPackageFile)" Condition="'%(_BaluCompilerPackageFile.TargetPath)' == 'bc.runtimeconfig.json'" />
-			<BuildOutputInPackage Include="@(_BaluCompilerPackageFile)" TargetPath="compiler\%(_BaluCompilerPackageFile.TargetPath)" />
+			<BuildOutputInPackage Include="@(_BaluCompilerPackageFile)" TargetPath="compiler/%(_BaluCompilerPackageFile.TargetPath)" />
 		</ItemGroup>
 		<Error Condition="'@(_BaluCompilerPackageFile)' == ''" Text="The Balu compiler produced no files to package." />
-		<Error Condition="'@(_BaluCompilerEntryPoint)' == ''" Text="The Balu compiler entry point bc.exe is missing from the package output." />
+		<Error Condition="'@(_BaluCompilerEntryPoint)' == ''" Text="The Balu compiler entry point bc.dll is missing from the package output." />
 		<Error Condition="'@(_BaluCompilerDependencyFile)' == ''" Text="The Balu compiler dependency file bc.deps.json is missing from the package output." />
 		<Error Condition="'@(_BaluCompilerRuntimeConfig)' == ''" Text="The Balu compiler runtime configuration bc.runtimeconfig.json is missing from the package output." />
 		<Error Condition="!Exists('%(_BaluCompilerPackageFile.Identity)')" Text="The Balu compiler package file '%(_BaluCompilerPackageFile.Identity)' does not exist." />

--- a/src/Balu.Sdk/Balu.Sdk.csproj
+++ b/src/Balu.Sdk/Balu.Sdk.csproj
@@ -13,7 +13,7 @@
 		<Description>The Balu language SDK.</Description>
 		<PackageTags>Balu</PackageTags>
 		<TargetsForTfmSpecificBuildOutput>
-			$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage
+			$(TargetsForTfmSpecificBuildOutput);CollectPackageBuildOutput
 		</TargetsForTfmSpecificBuildOutput>
 		<!-- This property tells MSBuild where the root folder of the package's build assets should be. Because we are not a library package, we should not pack to 'lib'. Instead, we choose 'tasks' by convention. -->
 		<BuildOutputTargetFolder>tasks</BuildOutputTargetFolder>
@@ -27,6 +27,16 @@
 		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.4.0" PrivateAssets="all" ExcludeAssets="Runtime" />
 	</ItemGroup>
 	<ItemGroup>
+		<!-- bc is a build tool, so it participates in the build without being referenced by the netstandard task assembly. -->
+		<ProjectReference Include="..\bc\bc.csproj"
+					  ReferenceOutputAssembly="false"
+					  PrivateAssets="all"
+					  SkipGetTargetFrameworkProperties="true"
+					  GlobalPropertiesToRemove="TargetFramework"
+					  Targets="GetBaluCompilerPackageFiles"
+					  OutputItemType="_BaluCompilerPackageFile" />
+	</ItemGroup>
+	<ItemGroup>
 		<!-- these lines pack the build props/targets files to the `build` folder in the generated package.
  		by convention, the .NET SDK will look for build\<Package Id>.props and build\<Package Id>.targets
  		for automatic inclusion in the build. -->
@@ -34,12 +44,20 @@
 		<Content Include="Sdk.targets" PackagePath="sdk\" />
 	</ItemGroup>
 
-	<Target Name="CopyProjectReferencesToPackage" DependsOnTargets="ResolveReferences">
+	<Target Name="CollectPackageBuildOutput" DependsOnTargets="ResolveReferences">
 		<ItemGroup>
 			<!-- The TargetPath is the path inside the package that the source file will be placed. This is already precomputed in the ReferenceCopyLocalPaths items' DestinationSubPath, so reuse it here. -->
 			<BuildOutputInPackage Include="@(ReferenceCopyLocalPaths)" TargetPath="%(ReferenceCopyLocalPaths.DestinationSubPath)" />
-			<BuildOutputInPackage Include="../bc/bin/$(Configuration)/net6.0/*" TargetPath="%(ReferenceCopyLocalPaths.DestinationSubPath)"/>
+			<_BaluCompilerEntryPoint Include="@(_BaluCompilerPackageFile)" Condition="'%(_BaluCompilerPackageFile.TargetPath)' == 'bc.exe'" />
+			<_BaluCompilerDependencyFile Include="@(_BaluCompilerPackageFile)" Condition="'%(_BaluCompilerPackageFile.TargetPath)' == 'bc.deps.json'" />
+			<_BaluCompilerRuntimeConfig Include="@(_BaluCompilerPackageFile)" Condition="'%(_BaluCompilerPackageFile.TargetPath)' == 'bc.runtimeconfig.json'" />
+			<BuildOutputInPackage Include="@(_BaluCompilerPackageFile)" TargetPath="compiler\%(_BaluCompilerPackageFile.TargetPath)" />
 		</ItemGroup>
+		<Error Condition="'@(_BaluCompilerPackageFile)' == ''" Text="The Balu compiler produced no files to package." />
+		<Error Condition="'@(_BaluCompilerEntryPoint)' == ''" Text="The Balu compiler entry point bc.exe is missing from the package output." />
+		<Error Condition="'@(_BaluCompilerDependencyFile)' == ''" Text="The Balu compiler dependency file bc.deps.json is missing from the package output." />
+		<Error Condition="'@(_BaluCompilerRuntimeConfig)' == ''" Text="The Balu compiler runtime configuration bc.runtimeconfig.json is missing from the package output." />
+		<Error Condition="!Exists('%(_BaluCompilerPackageFile.Identity)')" Text="The Balu compiler package file '%(_BaluCompilerPackageFile.Identity)' does not exist." />
 	</Target>
 	<Target Name="AddBuildDependencyFileToBuiltProjectOutputGroupOutput" BeforeTargets="BuiltProjectOutputGroup" Condition=" '$(GenerateDependencyFile)' == 'true'">
 		<ItemGroup>

--- a/src/Balu.Sdk/BaluCompiler.cs
+++ b/src/Balu.Sdk/BaluCompiler.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -7,10 +6,13 @@ namespace Balu.Sdk;
 
 public sealed class BaluCompiler : ToolTask
 {
-    protected override string ToolName => "bc";
+    protected override string ToolName => "dotnet";
 
     [Required]
-    public string BcPath { get; set; } = string.Empty;
+    public string DotNetPath { get; set; } = string.Empty;
+
+    [Required]
+    public string CompilerPath { get; set; } = string.Empty;
 
     [Required]
     public ITaskItem[] SourceFiles { get; set; } = [];
@@ -25,7 +27,24 @@ public sealed class BaluCompiler : ToolTask
 
     public bool Debug { get; set; }
 
-    protected override string GenerateFullPathToTool() => Path.GetFullPath(BcPath);
-    protected override string GenerateCommandLineCommands() =>
-        $"/o \"{OutputPath}\" {(string.IsNullOrWhiteSpace(SymbolPath) ? "" : $"/s \"{SymbolPath}\"")} {string.Join(" ", ReferencedAssemblies.Select(item => $"/r \"{item.GetMetadata("FullPath")}\""))} {string.Join(" ", SourceFiles.Select(item => $"\"{item.GetMetadata("FullPath")}\""))}";
+    protected override string GenerateFullPathToTool() => Path.GetFullPath(DotNetPath);
+
+    protected override string GenerateCommandLineCommands()
+    {
+        var builder = new CommandLineBuilder();
+        builder.AppendTextUnquoted("exec");
+        builder.AppendFileNameIfNotNull(Path.GetFullPath(CompilerPath));
+        builder.AppendSwitchIfNotNull("/o ", OutputPath);
+
+        if (!string.IsNullOrWhiteSpace(SymbolPath))
+            builder.AppendSwitchIfNotNull("/s ", SymbolPath);
+
+        foreach (var reference in ReferencedAssemblies)
+            builder.AppendSwitchIfNotNull("/r ", reference.GetMetadata("FullPath"));
+
+        foreach (var sourceFile in SourceFiles)
+            builder.AppendFileNameIfNotNull(sourceFile.GetMetadata("FullPath"));
+
+        return builder.ToString();
+    }
 }

--- a/src/Balu.Sdk/Sdk.props
+++ b/src/Balu.Sdk/Sdk.props
@@ -4,7 +4,7 @@
 	<PropertyGroup>
 		<!--The folder where the custom task will be present. It points to inside the nuget package. -->
 		<BaluCompilerTaskFolder>$(MSBuildThisFileDirectory)..\tasks\netstandard2.0</BaluCompilerTaskFolder>
-		<BaluCompilerPath>$(MSBuildThisFileDirectory)..\tasks\netstandard2.0</BaluCompilerPath>
+		<BaluCompilerPath>$(MSBuildThisFileDirectory)..\tasks\netstandard2.0\compiler</BaluCompilerPath>
 		<!--Reference to the assembly which contains the MSBuild Task-->
 		<CustomTasksAssembly>$(BaluCompilerTaskFolder)\Balu.Sdk.dll</CustomTasksAssembly>
 	</PropertyGroup>

--- a/src/Balu.Sdk/Sdk.props
+++ b/src/Balu.Sdk/Sdk.props
@@ -3,10 +3,10 @@
 	<!--defining properties interesting for my task-->
 	<PropertyGroup>
 		<!--The folder where the custom task will be present. It points to inside the nuget package. -->
-		<BaluCompilerTaskFolder>$(MSBuildThisFileDirectory)..\tasks\netstandard2.0</BaluCompilerTaskFolder>
-		<BaluCompilerPath>$(MSBuildThisFileDirectory)..\tasks\netstandard2.0\compiler</BaluCompilerPath>
+		<BaluCompilerTaskFolder>$(MSBuildThisFileDirectory)../tasks/netstandard2.0</BaluCompilerTaskFolder>
+		<BaluCompilerPath>$(BaluCompilerTaskFolder)/compiler</BaluCompilerPath>
 		<!--Reference to the assembly which contains the MSBuild Task-->
-		<CustomTasksAssembly>$(BaluCompilerTaskFolder)\Balu.Sdk.dll</CustomTasksAssembly>
+		<CustomTasksAssembly>$(BaluCompilerTaskFolder)/Balu.Sdk.dll</CustomTasksAssembly>
 	</PropertyGroup>
 	<PropertyGroup>
 		<DefaultLanguageSourceExtension>.b</DefaultLanguageSourceExtension>

--- a/src/Balu.Sdk/Sdk.targets
+++ b/src/Balu.Sdk/Sdk.targets
@@ -17,6 +17,6 @@
 		<PropertyGroup>
 			<BaluSymbolPath Condition="'$(Configuration)' == 'Debug' AND '$(BaluSymbolPath)' == ''">@(IntermediateAssembly -> '%(RootDir)%(Directory)%(filename).pdb')</BaluSymbolPath>
 		</PropertyGroup>
-		<BaluCompiler BcPath="$(BaluCompilerPath)/bc.exe" SourceFiles="@(BaluFiles)" OutputPath="@(IntermediateAssembly)" ReferencedAssemblies="@(ReferencePath)" SymbolPath="$(BaluSymbolPath)"/>
+		<BaluCompiler DotNetPath="$(DOTNET_HOST_PATH)" CompilerPath="$(BaluCompilerPath)/bc.dll" SourceFiles="@(BaluFiles)" OutputPath="@(IntermediateAssembly)" ReferencedAssemblies="@(ReferencePath)" SymbolPath="$(BaluSymbolPath)"/>
 	</Target>
 </Project>

--- a/src/HelloWorld/helloworld.csproj
+++ b/src/HelloWorld/helloworld.csproj
@@ -2,6 +2,5 @@
 	<PropertyGroup>
 		<TargetFramework>net9.0</TargetFramework>
 		<OutputType>Exe</OutputType>
-		<BaluCompilerPath>$([MSBuild]::NormalizePath($(MSBuildThisFileDirectory)../bc/bin/debug/net9.0/))</BaluCompilerPath>
 	</PropertyGroup>
 </Project>

--- a/src/HelloWorld/helloworld.csproj
+++ b/src/HelloWorld/helloworld.csproj
@@ -1,6 +1,6 @@
-﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.1.0">
+﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.2.0">
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<OutputType>Exe</OutputType>
 	</PropertyGroup>
 </Project>

--- a/src/HelloWorld/helloworld.csproj
+++ b/src/HelloWorld/helloworld.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.2.0">
+﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.2.1">
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
 		<OutputType>Exe</OutputType>

--- a/src/bc/bc.csproj
+++ b/src/bc/bc.csproj
@@ -18,4 +18,12 @@
 	<ItemGroup>
 		<ProjectReference Include="..\Balu\Balu.csproj" />
 	</ItemGroup>
+
+	<Target Name="GetBaluCompilerPackageFiles"
+			DependsOnTargets="Build;ComputeFilesToPublish"
+			Returns="@(_BaluCompilerPackageFile)">
+		<ItemGroup>
+			<_BaluCompilerPackageFile Include="@(ResolvedFileToPublish->'%(FullPath)')" TargetPath="%(ResolvedFileToPublish.RelativePath)" />
+		</ItemGroup>
+	</Target>
 </Project>


### PR DESCRIPTION
## Summary
- build `bc` as an explicit SDK packaging dependency in both CLI and Visual Studio builds
- derive compiler package contents from `ResolvedFileToPublish` instead of a hard-coded target framework directory
- package the managed compiler without a platform-specific apphost
- invoke the packaged compiler through `dotnet exec bc.dll`
- fail packaging when the managed compiler entry point or required runtime metadata is missing
- use platform-neutral paths in the packaged SDK assets

## Verification
- clean direct Release build of `src/Balu.Sdk/Balu.Sdk.csproj`
- Full Framework MSBuild with `BuildingInsideVisualStudio=true` to exercise Visual Studio's project-reference path
- inspected the generated package for `bc.dll`, runtime metadata, and compiler dependencies, with no `bc.exe`
- restored and built an isolated Balu consumer against only the generated package
- confirmed the consumer build invokes `dotnet exec .../compiler/bc.dll`
- ran the generated consumer successfully
- `dotnet test src/Balu.Tests/Balu.Tests.csproj -c Release` (21,616 passed)

Closes #84