### PR TITLE
Fix lexer source boundaries

### DIFF
--- a/src/Balu.Tests/EmitterTests/DebugSymbolTests.cs
+++ b/src/Balu.Tests/EmitterTests/DebugSymbolTests.cs
@@ -81,6 +81,31 @@ public partial class EmitterTests
     }
 
     [Fact]
+    public void Emitter_DebugSymbols_RecognizeLoneCarriageReturnAsLineEnding()
+    {
+        const string source = "function main() {\r    println(\"a\")\r}";
+        var compilation = Compilation.Create(SyntaxTree.Parse(SourceText.From(source, "lone-cr.b")));
+        using var outputStream = new MemoryStream();
+        using var symbolStream = new MemoryStream();
+
+        var diagnostics = compilation.Emit("LoneCrDebugSymbols", ReferenceProvider.References, outputStream, symbolStream);
+
+        Assert.Empty(diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
+        outputStream.Position = 0;
+        symbolStream.Position = 0;
+        using var assembly = AssemblyDefinition.ReadAssembly(
+            outputStream,
+            new ReaderParameters { ReadSymbols = true, SymbolReaderProvider = new PortablePdbReaderProvider(), SymbolStream = symbolStream });
+        var sequencePoints = assembly.MainModule.Types
+                                     .SelectMany(type => type.Methods)
+                                     .SelectMany(method => method.DebugInformation.SequencePoints)
+                                     .ToArray();
+
+        Assert.Contains(sequencePoints, sequencePoint => sequencePoint.StartLine == 2);
+        Assert.All(sequencePoints, sequencePoint => Assert.InRange(sequencePoint.StartLine, 1, 3));
+    }
+
+    [Fact]
     public void Emitter_WithoutDebugSymbols_AllowsMissingDocumentName()
     {
         var compilation = Compilation.Create(SyntaxTree.Parse("function main() {}"));

--- a/src/Balu.Tests/LexerTests/RobustnessTests.cs
+++ b/src/Balu.Tests/LexerTests/RobustnessTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Balu.Diagnostics;
+using Balu.Syntax;
+using Balu.Text;
+using Balu.Visualization;
+using Xunit;
+
+namespace Balu.Tests.Syntax.LexerTests;
+
+public partial class LexerTests
+{
+    [Fact]
+    public void Lexer_DiagnosticRenderingRecognizesLoneCarriageReturnAsLineEnding()
+    {
+        SyntaxTree.ParseTokens("a\r?", out var diagnostics);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal(1, diagnostic.Location.StartLine);
+        Assert.Equal(0, diagnostic.Location.StartCharacter);
+        using var writer = new StringWriter();
+        writer.WriteDiagnostics(diagnostics);
+        Assert.Contains("(2,1): error", writer.ToString());
+    }
+
+    [Fact]
+    public void Lexer_GeneratedInputsProduceValidDiagnostics()
+    {
+        ReadOnlySpan<char> alphabet = ['\0', '\r', '\n', '"', '\\', '/', '*', 'a', '1', ' ', '{', '}'];
+        var random = new Random(87);
+
+        for (int test = 0; test < 1_000; test++)
+        {
+            var builder = new StringBuilder();
+            var length = random.Next(33);
+            for (int i = 0; i < length; i++)
+                builder.Append(alphabet[random.Next(alphabet.Length)]);
+
+            var source = SourceText.From(builder.ToString());
+            var tokens = SyntaxTree.ParseTokens(source, out var lexerDiagnostics);
+            var tree = SyntaxTree.Parse(source);
+
+            Assert.All(tokens, token => AssertValidSpan(source, token.Span));
+            Assert.Equal(source.Length, tree.Root.EndOfFileToken.Span.Start);
+            AssertDiagnostics(source, lexerDiagnostics);
+            AssertDiagnostics(source, tree.Diagnostics);
+        }
+    }
+
+    static void AssertDiagnostics(SourceText source, IEnumerable<Diagnostic> diagnostics)
+    {
+        var diagnosticArray = diagnostics is Diagnostic[] array ? array : [.. diagnostics];
+        foreach (var diagnostic in diagnosticArray)
+        {
+            Assert.Same(source, diagnostic.Location.Text);
+            AssertValidSpan(source, diagnostic.Location.Span);
+            _ = diagnostic.Location.StartLine;
+            _ = diagnostic.Location.EndLine;
+            _ = diagnostic.Location.StartCharacter;
+            _ = diagnostic.Location.EndCharacter;
+            _ = source.ToString(diagnostic.Location.Span);
+        }
+
+        using var writer = new StringWriter();
+        writer.WriteDiagnostics(diagnosticArray);
+    }
+
+    static void AssertValidSpan(SourceText source, TextSpan span)
+    {
+        Assert.InRange(span.Start, 0, source.Length);
+        Assert.InRange(span.End, span.Start, source.Length);
+    }
+}

--- a/src/Balu.Tests/LexerTests/StringTestts.cs
+++ b/src/Balu.Tests/LexerTests/StringTestts.cs
@@ -1,5 +1,9 @@
 using Balu.Syntax;
 using Balu.Tests.TestHelper;
+using Balu.Diagnostics;
+using Balu.Text;
+using Balu.Visualization;
+using System.IO;
 using System.Linq;
 using Xunit;
 
@@ -49,5 +53,36 @@ public partial class LexerTests
                 var z = 12
             }";
         input.AssertLexerDiagnostics("String literal not terminated.");
+    }
+    [Fact]
+    public void Lexer_String_AllowsEmbeddedNullCharacter()
+    {
+        const string input = "\"a\0b\"";
+
+        var token = Assert.Single(SyntaxTree.ParseTokens(input, out var diagnostics));
+
+        Assert.Empty(diagnostics);
+        Assert.Equal(SyntaxKind.StringToken, token.Kind);
+        Assert.Equal("a\0b", token.Value);
+        Assert.Equal(input, token.Text);
+    }
+    [Fact]
+    public void Lexer_String_TrailingBackslashProducesValidDiagnostics()
+    {
+        const string input = "\"abc\\";
+
+        SyntaxTree.ParseTokens(input, out var diagnostics);
+
+        Assert.Equal(2, diagnostics.Length);
+        var invalidEscape = Assert.Single(diagnostics, diagnostic => diagnostic.Id == DiagnosticId.InvalidEscapeSequence);
+        Assert.Equal(new TextSpan(input.Length - 1, 1), invalidEscape.Location.Span);
+        Assert.Equal("Invalid escape sequence '\\'.", invalidEscape.Message);
+        var unterminated = Assert.Single(diagnostics, diagnostic => diagnostic.Id == DiagnosticId.UnterminatedString);
+        Assert.Equal(new TextSpan(0, input.Length), unterminated.Location.Span);
+        Assert.All(diagnostics, diagnostic => Assert.InRange(diagnostic.Location.Span.End, diagnostic.Location.Span.Start, input.Length));
+
+        using var writer = new StringWriter();
+        writer.WriteDiagnostics(diagnostics);
+        Assert.NotEmpty(writer.ToString());
     }
 }

--- a/src/Balu.Tests/LexerTests/TokenCombinationTests.cs
+++ b/src/Balu.Tests/LexerTests/TokenCombinationTests.cs
@@ -1,4 +1,5 @@
 using Balu.Syntax;
+using Balu.Text;
 using System;
 using System.Linq;
 using Xunit;
@@ -23,6 +24,35 @@ public partial class LexerTests
     public void Lexer_Lexes_EmptyInput()
     {
         Assert.Empty(SyntaxTree.ParseTokens(string.Empty));
+    }
+    [Fact]
+    public void Lexer_Lexes_PastEmbeddedNullCharacter()
+    {
+        const string text = "a\0b";
+
+        var tokens = SyntaxTree.ParseTokens(text, out var diagnostics);
+
+        Assert.Collection(tokens,
+                          token =>
+                          {
+                              Assert.Equal(SyntaxKind.IdentifierToken, token.Kind);
+                              Assert.Equal("a", token.Text);
+                          },
+                          token =>
+                          {
+                              Assert.Equal(SyntaxKind.BadToken, token.Kind);
+                              Assert.Equal("\0", token.Text);
+                          },
+                          token =>
+                          {
+                              Assert.Equal(SyntaxKind.IdentifierToken, token.Kind);
+                              Assert.Equal("b", token.Text);
+                          });
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal(new TextSpan(1, 1), diagnostic.Location.Span);
+
+        var tree = SyntaxTree.Parse(text);
+        Assert.Equal(text.Length, tree.Root.EndOfFileToken.Span.Start);
     }
     [Theory]
     [MemberData(nameof(ProvideSingleTokens))]

--- a/src/Balu.Tests/LexerTests/TriviaTests.cs
+++ b/src/Balu.Tests/LexerTests/TriviaTests.cs
@@ -18,10 +18,10 @@ public partial class LexerTests
         c /* inline */ d /* next */ e
         /* inline */ f /* next */ g /* end*/
         // end of file must be tested in parser tests, parsetokens does not return the eof token";
-        
+
         var tokens = SyntaxTree.ParseTokens(code);
         Assert.Equal(7, tokens.Length);
-        
+
         // a
         Assert.Equal(5, tokens[0].LeadingTrivia.Length);
         Assert.Equal(SyntaxKind.LineBreakTrivia, tokens[0].LeadingTrivia[0].Kind);
@@ -87,5 +87,43 @@ public partial class LexerTests
         const string code = @"[/*] hera starts some comment
 but it's not terminated";
         code.AssertLexerDiagnostics("Unterminated multiline comment.");
+    }
+    [Theory]
+    [InlineData("\n")]
+    [InlineData("\r\n")]
+    [InlineData("\r")]
+    public void Lexer_Trivia_SingleLineCommentRecognizesAllLineEndings(string lineEnding)
+    {
+        var tokens = SyntaxTree.ParseTokens("a// comment" + lineEnding + "  b");
+
+        Assert.Equal(2, tokens.Length);
+        var comment = Assert.Single(tokens[0].TrailingTrivia);
+        Assert.Equal(SyntaxKind.SingleLineCommentTrivia, comment.Kind);
+        Assert.Equal("// comment" + lineEnding, comment.Text);
+        var whitespace = Assert.Single(tokens[1].LeadingTrivia);
+        Assert.Equal(SyntaxKind.WhiteSpaceTrivia, whitespace.Kind);
+        Assert.Equal("  ", whitespace.Text);
+    }
+    [Fact]
+    public void Lexer_Trivia_SingleLineCommentAllowsEmbeddedNullCharacter()
+    {
+        var tokens = SyntaxTree.ParseTokens("a// x\0y\rb");
+
+        Assert.Equal(2, tokens.Length);
+        var comment = Assert.Single(tokens[0].TrailingTrivia);
+        Assert.Equal(SyntaxKind.SingleLineCommentTrivia, comment.Kind);
+        Assert.Equal("// x\0y\r", comment.Text);
+        Assert.Equal("b", tokens[1].Text);
+    }
+    [Fact]
+    public void Lexer_Trivia_MultiLineCommentAllowsEmbeddedNullCharacter()
+    {
+        var tokens = SyntaxTree.ParseTokens("a/* x\0y */b");
+
+        Assert.Equal(2, tokens.Length);
+        var comment = Assert.Single(tokens[0].TrailingTrivia);
+        Assert.Equal(SyntaxKind.MultiLineCommentTrivia, comment.Kind);
+        Assert.Equal("/* x\0y */", comment.Text);
+        Assert.Equal("b", tokens[1].Text);
     }
 }

--- a/src/Balu.Tests/ParserTests/NullCharacterTests.cs
+++ b/src/Balu.Tests/ParserTests/NullCharacterTests.cs
@@ -1,0 +1,25 @@
+using System.Linq;
+using Balu.Diagnostics;
+using Balu.Syntax;
+using Xunit;
+
+namespace Balu.Tests.CompilationTests.ParserTests;
+
+public partial class ParserTests
+{
+    [Fact]
+    public void Parser_PreservesEmbeddedNullCharacterAndFollowingCode()
+    {
+        const string text = "println()\0println()";
+
+        var tree = SyntaxTree.Parse(text);
+
+        Assert.Equal(2, tree.Root.Members.Length);
+        var diagnostic = Assert.Single(tree.Diagnostics);
+        Assert.Equal(DiagnosticId.UnexpectedToken, diagnostic.Id);
+        var secondMember = tree.Root.Members[1];
+        var skipped = Assert.Single(secondMember.FirstToken.LeadingTrivia.Where(trivia => trivia.Kind == SyntaxKind.SkippedTextTrivia));
+        Assert.Equal("\0", skipped.Text);
+        Assert.Equal(text.Length, tree.Root.EndOfFileToken.Span.Start);
+    }
+}

--- a/src/Balu.Tests/ParserTests/ReturnStatementLineEndingTests.cs
+++ b/src/Balu.Tests/ParserTests/ReturnStatementLineEndingTests.cs
@@ -1,0 +1,23 @@
+using Balu.Syntax;
+using Xunit;
+
+namespace Balu.Tests.CompilationTests.ParserTests;
+
+public partial class ParserTests
+{
+    [Theory]
+    [InlineData("\n")]
+    [InlineData("\r\n")]
+    [InlineData("\r")]
+    public void Parser_ReturnStatement_RecognizesAllLineEndings(string lineEnding)
+    {
+        var tree = SyntaxTree.Parse("function test() { return" + lineEnding + "1 }");
+
+        Assert.Empty(tree.Diagnostics);
+        var function = Assert.IsType<FunctionDeclarationSyntax>(Assert.Single(tree.Root.Members));
+        Assert.Equal(2, function.Body.Statements.Length);
+        var returnStatement = Assert.IsType<ReturnStatementSyntax>(function.Body.Statements[0]);
+        Assert.Null(returnStatement.Expression);
+        Assert.IsType<ExpressionStatementSyntax>(function.Body.Statements[1]);
+    }
+}

--- a/src/Balu.Tests/UnitTests/Text/SourceTextTests.cs
+++ b/src/Balu.Tests/UnitTests/Text/SourceTextTests.cs
@@ -42,14 +42,17 @@ public class SourceTextTests
         {
             ("", new (int start, int length, int incl)[] { (0, 0, 0) }),
             ("\n", new (int start, int length, int incl)[] { (0, 0, 1), (1, 0, 0) }),
+            ("\r", new (int start, int length, int incl)[] { (0, 0, 1), (1, 0, 0) }),
             ("\r\n", new (int start, int length, int incl)[] { (0, 0, 2), (2, 0, 0) }),
             ("\n\n", new (int start, int length, int incl)[] { (0, 0, 1), (1, 0, 1), (2, 0, 0) }),
+            ("\r\r", new (int start, int length, int incl)[] { (0, 0, 1), (1, 0, 1), (2, 0, 0) }),
             ("\n\r\n", new (int start, int length, int incl)[] { (0, 0, 1), (1, 0, 2), (3, 0, 0) }),
             ("\r\n\n", new (int start, int length, int incl)[] { (0, 0, 2), (2, 0, 1), (3, 0, 0) }),
             ("\r\n\r\n", new (int start, int length, int incl)[] { (0, 0, 2), (2, 0, 2), (4, 0, 0) }),
             ("line1a\r1b\nline2\r\nline3_\n\nline5__\r\n\r\nline7___", new (int start, int length, int incl)[]
                 {
-                    (0, 9, 10),
+                    (0, 6, 7),
+                    (7, 2, 3),
                     (10, 5, 7),
                     (17, 6, 7),
                     (24, 0, 1),
@@ -75,14 +78,17 @@ public class SourceTextTests
         {
             ("", new[] { 0 }),
             ("\n", new[] { 0, 1 }),
+            ("\r", new[] { 0, 1 }),
             ("\r\n", new[] { 0, 0, 1 }),
 
             ("\n\n", new[] { 0, 1, 2 }),
+            ("\r\r", new[] { 0, 1, 2 }),
             ("\r\n\n", new[] { 0, 0, 1, 2 }),
             ("\n\r\n", new[] { 0, 1, 1, 2 }),
             ("\r\n\r\n", new[] { 0, 0, 1, 1, 2 }),
 
             ("a\na\n", new[] { 0, 0, 1, 1, 2 }),
+            ("a\ra\r", new[] { 0, 0, 1, 1, 2 }),
             ("a\na\r\n", new[] { 0, 0, 1, 1, 1, 2 }),
             ("a\r\na\n", new[] { 0, 0, 0, 1, 1, 2 }),
             ("a\r\na\r\n", new[] { 0, 0, 0, 1, 1, 1, 2 }),

--- a/src/Balu/Syntax/Lexer.cs
+++ b/src/Balu/Syntax/Lexer.cs
@@ -39,11 +39,11 @@ sealed class Lexer
             var tokenValue = value;
             var tokenLength = position - tokenStart;
             var tokenText = text;
-            
+
             ReadTrivia(false);
             var trailingTrivia = triviaBuilder.ToImmutable();
 
-            yield return new(syntaxTree, tokenKind, new(tokenStart, tokenKind == SyntaxKind.EndOfFileToken ? 0 :  tokenLength), tokenText, tokenValue, leadingTrivia, trailingTrivia);
+            yield return new(syntaxTree, tokenKind, new(tokenStart, tokenKind == SyntaxKind.EndOfFileToken ? 0 : tokenLength), tokenText, tokenValue, leadingTrivia, trailingTrivia);
 
             kind = tokenKind;
 
@@ -66,7 +66,7 @@ sealed class Lexer
                     ReadWhiteSpaces();
                     break;
                 case SyntaxKind.LineBreakTrivia:
-                     ReadLineBreak();
+                    ReadLineBreak();
                     break;
                 case SyntaxKind.SingleLineCommentTrivia:
                     ReadSingleLineComment();
@@ -79,12 +79,12 @@ sealed class Lexer
             }
 
             triviaBuilder.Add(new(syntaxTree, kind, text, new(start, position - start)));
-        } while (leading || !text.Contains("\n"));
+        } while (leading || sourceText.GetLineIndex(start) == sourceText.GetLineIndex(position));
     }
     void ReadToken()
     {
         start = position;
-        value = null; 
+        value = null;
         kind = CurrentKind();
         text = string.Empty;
 
@@ -99,15 +99,17 @@ sealed class Lexer
         else
         {
             text = kind.GetText() ?? Current.ToString();
-            if (Current != '\0') position += text.Length;
+            if (!IsAtEnd) position += text.Length;
         }
     }
     SyntaxKind CurrentKind()
     {
-        if (Current == '\0') 
+        if (IsAtEnd)
             return SyntaxKind.EndOfFileToken;
+        if (sourceText.GetLineBreakWidth(position) > 0)
+            return SyntaxKind.LineBreakTrivia;
         if (char.IsWhiteSpace(Current))
-            return Current is '\r' or '\n' ? SyntaxKind.LineBreakTrivia : SyntaxKind.WhiteSpaceTrivia;
+            return SyntaxKind.WhiteSpaceTrivia;
         if (char.IsDigit(Current))
             return SyntaxKind.NumberToken;
         if (char.IsLetter(Current) || Current == '_')
@@ -116,7 +118,6 @@ sealed class Lexer
 
         return (Current, Peek(1)) switch
         {
-            ('\0', _) => SyntaxKind.EndOfFileToken,
             ('+', '=') => SyntaxKind.PlusEqualsToken,
             ('+', '+') => SyntaxKind.PlusPlusToken,
             ('+', _) => SyntaxKind.PlusToken,
@@ -155,13 +156,14 @@ sealed class Lexer
             _ => SyntaxKind.BadToken
         };
     }
-    
+
     char Peek(int offset)
     {
         var index = position + offset;
         return index >= sourceText.Length ? '\0' : sourceText[index];
     }
     char Current => Peek(0);
+    bool IsAtEnd => position >= sourceText.Length;
     void Next()
     {
         if (position < sourceText.Length) position++;
@@ -180,31 +182,13 @@ sealed class Lexer
     void ReadWhiteSpaces()
     {
         kind = SyntaxKind.WhiteSpaceTrivia;
-        var done = false;
-        while (!done)
-        {
-            switch (Current)
-            {
-                case '\0':
-                case '\r':
-                case '\n':
-                    done = true;
-                    break;
-                default:
-                    if (!char.IsWhiteSpace(Current))
-                        done = true;
-                    else Next();
-                    break;
-            }
-        }
+        while (!IsAtEnd && sourceText.GetLineBreakWidth(position) == 0 && char.IsWhiteSpace(Current)) Next();
         text = sourceText.ToString(start, position - start);
     }
     void ReadLineBreak()
     {
         kind = SyntaxKind.LineBreakTrivia;
-        if (Current == '\r' && Peek(1) == '\n')
-            position++;
-        position++;
+        position += sourceText.GetLineBreakWidth(position);
         text = sourceText.ToString(start, position - start);
     }
     void ReadIdentifierOrKeywordToken()
@@ -222,20 +206,27 @@ sealed class Lexer
     }
     void ReadString()
     {
-        position++; 
+        position++;
         var valueBuilder = new StringBuilder();
-        while (Current != '"')
+        while (!IsAtEnd && Current != '"')
         {
+            if (sourceText.GetLineBreakWidth(position) > 0)
+            {
+                diagnostics.ReportUnterminatedString(new(sourceText, new(start, position - start)));
+                text = sourceText.ToString(start, position - start);
+                kind = SyntaxKind.StringToken;
+                return;
+            }
+
             switch (Current)
             {
-                case '\0':
-                case '\r':
-                case '\n':
-                    diagnostics.ReportUnterminatedString(new (sourceText, new(start, position - start)));
-                    text = sourceText.ToString(start, position - start);
-                    kind = SyntaxKind.StringToken;
-                    return;
                 case '\\':
+                    if (position + 1 >= sourceText.Length)
+                    {
+                        diagnostics.ReportInvalidEscapeSequence(new(sourceText, new(position, 1)), "\\");
+                        break;
+                    }
+
                     char next = Peek(1);
                     if (SyntaxFacts.EscapedToUnescapedCharacter.TryGetValue(next.ToString(), out var unescaped))
                     {
@@ -243,7 +234,7 @@ sealed class Lexer
                         Next();
                     }
                     else
-                        diagnostics.ReportInvalidEscapeSequence(new(sourceText, new(position+1, 1)), next.ToString());
+                        diagnostics.ReportInvalidEscapeSequence(new(sourceText, new(position + 1, 1)), next.ToString());
                     break;
                 default:
                     valueBuilder.Append(Current);
@@ -252,6 +243,15 @@ sealed class Lexer
 
             Next();
         }
+
+        if (IsAtEnd)
+        {
+            diagnostics.ReportUnterminatedString(new(sourceText, new(start, position - start)));
+            text = sourceText.ToString(start, position - start);
+            kind = SyntaxKind.StringToken;
+            return;
+        }
+
         Next(); // skip closing "
         text = sourceText.ToString(start, position - start);
         kind = SyntaxKind.StringToken;
@@ -261,27 +261,21 @@ sealed class Lexer
     {
         value = null;
         kind = SyntaxKind.SingleLineCommentTrivia;
-        while (Current != '\0' && Current != '\n') Next();
-        if (Current != '\0') Next();
+        while (!IsAtEnd && sourceText.GetLineBreakWidth(position) == 0) Next();
+        position += sourceText.GetLineBreakWidth(position);
         text = sourceText.ToString(start, position - start);
     }
     void ReadMultiLineComment()
     {
         kind = SyntaxKind.MultiLineCommentTrivia;
         value = null;
-        char c1, c2;
-        position++;
-        do
-        {
-            Next();
-            c1 = Current;
-            c2 = Peek(1);
-        } while (c2 != '\0' && (c1 != '*' || c2 != '/'));
+        position += 2;
+        while (!IsAtEnd && (Current != '*' || Peek(1) != '/')) Next();
 
-        if (c2 == '\0')
-            diagnostics.ReportUnterminatedMultiLineComment(new(sourceText, new (start, 2)));
-        Next();
-        Next();
+        if (IsAtEnd)
+            diagnostics.ReportUnterminatedMultiLineComment(new(sourceText, new(start, 2)));
+        else
+            position += 2;
         text = sourceText.ToString(start, position - start);
     }
     void ReadBadToken()

--- a/src/Balu/Text/SourceText.cs
+++ b/src/Balu/Text/SourceText.cs
@@ -22,7 +22,7 @@ public sealed class SourceText
         this.text = text;
         FileName = fileName;
         Checksum = checksum;
-        Lines = ParseLines(this, text);
+        Lines = ParseLines(this);
     }
 
     public int GetLineIndex(int position)
@@ -48,13 +48,24 @@ public sealed class SourceText
     public string ToString(int start, int length) => text.Substring(start, length);
     public string ToString(TextSpan span) => ToString(span.Start, span.Length);
 
-    static ImmutableArray<TextLine> ParseLines(SourceText sourceText, string text)
+    internal int GetLineBreakWidth(int position)
+    {
+        if (position < 0 || position >= Length)
+            return 0;
+
+        if (text[position] == '\r')
+            return position + 1 < Length && text[position + 1] == '\n' ? 2 : 1;
+
+        return text[position] == '\n' ? 1 : 0;
+    }
+
+    static ImmutableArray<TextLine> ParseLines(SourceText sourceText)
     {
         int lineStart = 0, position = 0;
         var builder = ImmutableArray.CreateBuilder<TextLine>();
-        while(position < text.Length)
+        while (position < sourceText.Length)
         {
-            int endings = text[position] == '\n' ? 1 : text[position] == '\r' && position + 1 < text.Length && text[position+1] == '\n' ? 2 : 0;
+            var endings = sourceText.GetLineBreakWidth(position);
             if (endings == 0)
             {
                 position++;
@@ -66,7 +77,7 @@ public sealed class SourceText
             lineStart = position;
         }
         if (builder.Count == 0 || builder.Last().LengthIncludingNewLine > builder.Last().Length)
-            builder.Add(new(sourceText, lineStart, text.Length - lineStart, text.Length - lineStart));
+            builder.Add(new(sourceText, lineStart, sourceText.Length - lineStart, sourceText.Length - lineStart));
         return builder.ToImmutable();
     }
 


### PR DESCRIPTION
## Summary
- distinguish physical EOF from embedded NUL characters and continue lexing subsequent source
- centralize LF, CRLF, and lone CR handling across `SourceText`, trivia, strings, and comments
- keep malformed escape diagnostics within source bounds and preserve stable diagnostic rendering
- add regression coverage for parsing, diagnostics, rendering, and PDB line coordinates
- add deterministic generated-input coverage for token and diagnostic span invariants

## Testing
- `dotnet test src/Balu.Tests/Balu.Tests.csproj --no-restore`
- 21,643 tests passed

Closes #87