### PR TITLE
Handle EOF in `input()`

### DIFF
--- a/src/Balu.Sdk/Balu.Sdk.csproj
+++ b/src/Balu.Sdk/Balu.Sdk.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<PropertyGroup>
 		<IsPackable>true</IsPackable>
-		<Version>0.2.2</Version>
+		<Version>0.2.3</Version>
 		<Title>Balu.Sdk</Title>
 		<Authors>René Vogt</Authors>
 		<Description>The Balu language SDK.</Description>

--- a/src/Balu.Tests/InterpreterTests/InterpreterTests.cs
+++ b/src/Balu.Tests/InterpreterTests/InterpreterTests.cs
@@ -139,6 +139,26 @@ public sealed class InterpreterTests
     }
 
     [Fact]
+    public void Interpreter_InputAtEndOfStream_ReturnsEmptyString()
+    {
+        var originalIn = System.Console.In;
+        try
+        {
+            System.Console.SetIn(new StringReader(string.Empty));
+            using var interpreter = new Interpreter(ReferenceProvider.References);
+
+            Assert.False(interpreter.Execute("var value = input()").HasErrors());
+            Assert.Equal(string.Empty, Assert.Single(interpreter.GlobalVariables).Value);
+            Assert.False(interpreter.Execute("value").HasErrors());
+            Assert.Equal(string.Empty, interpreter.Result);
+        }
+        finally
+        {
+            System.Console.SetIn(originalIn);
+        }
+    }
+
+    [Fact]
     public void Interpreter_Reset_ClearsResultAndGlobalVariables()
     {
         using var interpreter = new Interpreter(ReferenceProvider.References);

--- a/src/Balu/Emit/Emitter.cs
+++ b/src/Balu/Emit/Emitter.cs
@@ -521,7 +521,10 @@ sealed class Emitter : IDisposable
         else if (expression.Function == BuiltInFunctions.PrintLine)
             processor.Emit(OpCodes.Call, referencedMembers.ConsoleWriteLine);
         else if (expression.Function == BuiltInFunctions.Input)
+        {
             processor.Emit(OpCodes.Call, referencedMembers.ConsoleReadLine);
+            processor.Emit(OpCodes.Call, referencedMembers.ConvertToString);
+        }
         else if (expression.Function == BuiltInFunctions.Random)
             processor.Emit(OpCodes.Callvirt, referencedMembers.RandomNext);
         else

--- a/src/HelloWorld/helloworld.csproj
+++ b/src/HelloWorld/helloworld.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.2.2">
+﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.2.3">
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
 		<OutputType>Exe</OutputType>


### PR DESCRIPTION
## Summary
- normalize the nullable `Console.ReadLine()` result through `Convert.ToString`
- make `input()` return an empty string at EOF
- cover persistence and reuse of the EOF result across interpreter submissions

## Testing
- `dotnet test src/Balu.Tests/Balu.Tests.csproj`
- 21,644 tests passed

Fixes #106