### PR TITLE
Fix persisted any global boxing

### DIFF
--- a/src/Balu.Tests/InterpreterTests/InterpreterTests.cs
+++ b/src/Balu.Tests/InterpreterTests/InterpreterTests.cs
@@ -113,6 +113,18 @@ public sealed class InterpreterTests
         asserter.AssertScriptEvaluation("c()", value: 42);
     }
 
+    [Theory]
+    [InlineData("42", 42)]
+    [InlineData("true", true)]
+    [InlineData("\"text\"", "text")]
+    public void Interpreter_PersistsAnyGlobalsAcrossSubmissions(string literal, object expected)
+    {
+        using var asserter = new CompilationAsserter();
+
+        asserter.AssertScriptEvaluation($"var value: any = {literal}");
+        asserter.AssertScriptEvaluation("value", value: expected);
+    }
+
     [Fact]
     public void Interpreter_RuntimeFailure_RollsBackSubmission()
     {

--- a/src/Balu/Emit/Emitter.cs
+++ b/src/Balu/Emit/Emitter.cs
@@ -688,28 +688,31 @@ sealed class Emitter : IDisposable
         {
             EmitField(global);
             if (!initializedGlobalVariables.TryGetValue(global, out var value)) continue;
-            bool box = true;
+            TypeReference? boxingType;
             switch (value)
             {
                 case false:
                     processor.Emit(OpCodes.Ldc_I4_0);
+                    boxingType = MapType(TypeSymbol.Boolean);
                     break;
                 case true:
                     processor.Emit(OpCodes.Ldc_I4_1);
+                    boxingType = MapType(TypeSymbol.Boolean);
                     break;
                 case int i:
                     processor.Emit(OpCodes.Ldc_I4, i);
+                    boxingType = MapType(TypeSymbol.Integer);
                     break;
                 case string s:
                     processor.Emit(OpCodes.Ldstr, s);
-                    box = false;
+                    boxingType = null;
                     break;
                 default:
                     throw new EmitterException($"Invalid value type '{value.GetType().Name}' in global variables.");
             }
 
-            if (box && global.Type == TypeSymbol.Any)
-                processor.Emit(OpCodes.Box);
+            if (boxingType is not null && global.Type == TypeSymbol.Any)
+                processor.Emit(OpCodes.Box, boxingType);
             processor.Emit(OpCodes.Stsfld, globals[global]);
         }
 


### PR DESCRIPTION
## Summary
- emit the required Cecil type operand when boxing persisted `bool` and `int` values for `any` globals
- cover persisted `int`, `bool`, and `string` values across interpreter submissions

## Testing
- `dotnet test src/Balu.Tests/Balu.Tests.csproj`
- 21,647 tests passed

Closes #81