### PR TITLE
Report unreachable code per source file #92

### DIFF
--- a/src/Balu.Tests/BinderTests/UnreachableCodeTests.cs
+++ b/src/Balu.Tests/BinderTests/UnreachableCodeTests.cs
@@ -26,6 +26,17 @@ public sealed partial class BinderTests
     {
         code.AssertScriptEvaluation(expectedDiagnostics: "Unreachable code detected.", ignoreWarnings: false);
     }
+    [Fact]
+    public void Lowerer_ReportsUnreachableCodeInEachFile()
+    {
+        const string text1 = "while false [println(\"unreachable\")]";
+        const string text2 = "while false [println(\"unreachable\")]";
+        const string diagnostics = @"
+            Unreachable code detected.
+            Unreachable code detected.";
+
+        new[] { ("file1.b", text1), ("file2.b", text2) }.AssertScriptDiagnostics(diagnostics, ignoreWarnings: false);
+    }
     [Theory]
     [InlineData("while true { return 42 }", 42)]
     [InlineData("function test() { while true { return \r\n } }", null)]

--- a/src/Balu.Tests/TestHelper/StaticCompilationAsserter.cs
+++ b/src/Balu.Tests/TestHelper/StaticCompilationAsserter.cs
@@ -27,6 +27,12 @@ static class StaticCompilationAsserter{
         var compilation = Compilation.Create([.. inputs.Select(x => SyntaxTree.Parse(SourceText.From(x.annotated.Text, x.hintName)))]);
         DiagnosticAsserter.AssertDiagnostics(inputs, compilation.Diagnostics, diagnostics);
     }
+    internal static void AssertScriptDiagnostics(this IEnumerable<(string hintName, string code)> files, string? diagnostics = null, bool ignoreWarnings = true)
+    {
+        var inputs = files.Select(x => (x.hintName, annotated: AnnotatedText.Parse(x.code))).OrderBy(x => x.hintName).ToArray();
+        var compilation = Compilation.CreateScript(null, [.. inputs.Select(x => SyntaxTree.Parse(SourceText.From(x.annotated.Text, x.hintName)))]);
+        DiagnosticAsserter.AssertDiagnostics(inputs, compilation.Diagnostics, diagnostics, ignoreWarnings);
+    }
     internal static void AssertLexerDiagnostics(this string code, string expected)
     {
         var annotatedText = AnnotatedText.Parse(code);

--- a/src/Balu/Lowering/Lowerer.cs
+++ b/src/Balu/Lowering/Lowerer.cs
@@ -269,15 +269,16 @@ sealed class Lowerer : BoundTreeRewriter
                 builder.RemoveAt(i--);
         }
 
-        var list = unreachableStatements.Where(ShoudBeReported).ToList();
-        while (list.Count > 0)
-        {
-            var consecutive = list.Where(s => s.Syntax.FullSpan.OverlapsWithOrTouches(list[0].Syntax.FullSpan)).ToList();
-            foreach (var s in consecutive) list.Remove(s);
-            var start = consecutive.Min(s => s.Syntax.Span.Start);
-            var end = consecutive.Max(s => s.Syntax.Span.End);
-            diagnostics.ReportUnreachableCode(new(consecutive[0].Syntax.SyntaxTree.Text, new(start, end - start)));
-        }
+        var listPerFile = unreachableStatements.Where(ShoudBeReported).GroupBy(statement => statement.Syntax.SyntaxTree).Select(g => g.ToList()).ToList();
+        foreach(var list in listPerFile)
+            while (list.Count > 0)
+            {
+                var consecutive = list.Where(s => s.Syntax.FullSpan.OverlapsWithOrTouches(list[0].Syntax.FullSpan)).ToList();
+                foreach (var s in consecutive) list.Remove(s);
+                var start = consecutive.Min(s => s.Syntax.Span.Start);
+                var end = consecutive.Max(s => s.Syntax.Span.End);
+                diagnostics.ReportUnreachableCode(new(consecutive[0].Syntax.SyntaxTree.Text, new(start, end - start)));
+            }
 
         return new(statement.Syntax, builder.ToImmutable());
 


### PR DESCRIPTION
## Summary
- group unreachable statements by syntax tree before combining diagnostic spans
- add a diagnostic assertion helper for multi-file scripts
- add a regression test verifying each source file receives its own unreachable-code warning

## Tests
- `dotnet test src/Balu.Tests/Balu.Tests.csproj --no-restore`
- 21,648 passed

Fixes #92.