### PR TITLE
Add initial project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,75 @@
 # Balu
-A compiler from scratch.
 
-This is my implementation of what terrajobst explained in his enlightening [Minsk](https://github.com/terrajobst/minsk) tutorial.
+Balu is a small programming language and an educational compiler targeting
+.NET. It implements the complete pipeline from source text and semantic analysis
+to lowered control flow, managed IL, and portable debug symbols.
+
+```balu
+function factorial(value: int): int {
+    if value <= 1
+        return 1
+
+    return value * factorial(value - 1)
+}
+
+function main() {
+    println(factorial(5))
+}
+```
+
+## What makes Balu interesting
+
+- A lossless syntax tree with tokens, trivia, and parser recovery
+- Static binding, type checking, conversions, and diagnostics
+- Lowering of structured control flow into labels and jumps
+- Control-flow analysis, return analysis, and unreachable-code detection
+- Managed IL and portable PDB emission using Mono.Cecil
+- An incremental REPL that compiles each submission into an in-memory assembly
+- An MSBuild SDK for compiling `.b` files as .NET projects
+- Source-generated syntax and bound-tree visitors and rewriters
+
+## Try it
+
+Balu currently requires the .NET 10 SDK.
+
+Start the interactive REPL from the repository root:
+
+```console
+dotnet run --project src/bi
+```
+
+Then enter Balu code:
+
+```text
+» var value = 21
+» value * 2
+Result: 42
+```
+
+See [Getting started](docs/getting-started.md) for a guided introduction.
+
+## Documentation
+
+- [Documentation overview](docs/index.md)
+- [Language overview](docs/language/overview.md)
+- [Language reference](docs/language/reference.md)
+- [Built-in functions](docs/language/built-in-functions.md)
+- [Diagnostics](docs/language/diagnostics.md)
+- [`bc` command-line compiler](docs/tools/compiler.md)
+
+## Project status
+
+Balu is an experimental, educational hobby project. The language and its tools
+are still evolving, and the documentation describes the current implementation
+rather than a stable language specification.
+
+## Background
+
+Balu started as my implementation of the ideas presented in
+[terrajobst's Minsk compiler tutorial](https://github.com/terrajobst/minsk).
+It has since grown into a complete compiler toolchain with a REPL, IL emission,
+debug symbols, an MSBuild SDK, and extensive compiler tests.
+
+## License
+
+Balu is available under the [MIT License](LICENSE).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,167 @@
+# Getting started
+
+This guide runs Balu directly from the source repository and uses the
+interactive REPL as the shortest path to a working program. It does not require
+installing `Balu.Sdk` or manually selecting .NET reference assemblies.
+
+## Prerequisites
+
+- Git
+- The .NET 10 SDK
+- A terminal with interactive console support
+
+List the installed .NET SDKs:
+
+```console
+dotnet --list-sdks
+```
+
+The installed SDK list must include a .NET 10 SDK.
+
+## Start the REPL
+
+Run the following command from the repository root:
+
+```console
+dotnet run --project src/bi
+```
+
+The first run restores and builds the required projects. The `»` prompt accepts
+Balu code:
+
+```text
+» 1 + 2
+Result: 3
+```
+
+The REPL compiles each submission and keeps the state of successful
+submissions.
+
+## Values and variables
+
+Balu has integer, Boolean, string, and `any` values. An `any` value keeps a
+value without exposing its more specific type to static operations; convert it
+back to a specific type before using type-specific operators:
+
+```text
+» 42
+Result: 42
+» true
+Result: True
+» "Hello, Balu!"
+Result: "Hello, Balu!"
+```
+
+Declare a mutable variable with `var`:
+
+```text
+» var count = 1
+» count += 4
+Result: 5
+» count
+Result: 5
+```
+
+Declare a read-only value with `let`:
+
+```text
+» let answer = 42
+» answer
+Result: 42
+```
+
+Types are normally inferred from the initializer. They can also be written
+explicitly:
+
+```balu
+var name: string = "Balu"
+let enabled: bool = true
+```
+
+## Define a function
+
+Functions use typed parameters. Add a return type after the parameter list when
+the function returns a value:
+
+```balu
+function square(value: int): int {
+    return value * value
+}
+```
+
+After submitting the declaration, call the function:
+
+```text
+» square(6)
+Result: 36
+```
+
+The REPL normally continues onto another line while a construct is incomplete.
+Use `Ctrl+Enter` to insert a new line even when the current submission could
+already be executed.
+
+## Use control flow
+
+Conditions do not require parentheses. Blocks use braces, and statements do
+not end with semicolons:
+
+```balu
+var total = 0
+
+for i = 1 to 5 {
+    total += i
+}
+
+if total == 15
+    println("The total is 15.")
+else
+    println("Unexpected total.")
+```
+
+The upper bound of `for ... to ...` is inclusive, so this loop visits the
+values `1`, `2`, `3`, `4`, and `5`.
+
+## Console input and output
+
+Use `print` or `println` for output and `input` for reading a line:
+
+```balu
+print("What is your name? ")
+var name = input()
+println("Hello, " + name)
+```
+
+See [Built-in functions](language/built-in-functions.md) for all built-ins and
+their signatures.
+
+## Useful REPL commands
+
+REPL commands start with `#` and are case-sensitive:
+
+| Command | Purpose |
+| --- | --- |
+| `#help` | List all available commands |
+| `#ls` | List visible variables and functions |
+| `#showSyntax` | Toggle syntax-tree output |
+| `#showProgram` | Toggle bound-program output |
+| `#showVars` | Toggle global-variable output after evaluation |
+| `#reset` | Reset the interpreter and delete persisted submissions |
+| `#exit` | Exit the REPL |
+
+On Windows, successful submissions are stored below
+`%LOCALAPPDATA%\Balu\Submissions`. On other platforms, they are stored below the
+platform's local application-data directory. They are loaded again when the
+REPL starts. Loading means executing the submissions again, so previous console
+output, calls to `input()`, and other side effects can occur again. Use
+`#reset` when you want to discard that state.
+
+`#clearHistory` only clears the in-memory editor history. It does not reset the
+interpreter and does not delete persisted submissions.
+
+## Next steps
+
+- Read the [language overview](language/overview.md) for a broader tour.
+- Use the [language reference](language/reference.md) for exact syntax and type
+  rules.
+- Use the [compiler command-line reference](tools/compiler.md) to compile `.b`
+  files outside the REPL.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,83 @@
+# Balu documentation
+
+Balu is a small programming language and compiler inspired by the
+[Minsk compiler tutorial](https://github.com/terrajobst/minsk). The project is
+primarily educational: it explores the complete path from source text to a
+managed .NET assembly, including parsing, semantic analysis, lowering, debug
+symbols, and an interactive REPL.
+
+This documentation describes the language and tools as they are implemented
+today. Balu is still experimental, so the documentation is a reference to the
+current behavior rather than a stable, normative language specification.
+
+## Start here
+
+- [Getting started](getting-started.md) builds and starts the Balu REPL from
+  the source repository and introduces the basic language constructs.
+- [Language overview](language/overview.md) gives a guided tour of Balu
+  programs, types, functions, and control flow.
+- [Language reference](language/reference.md) describes the syntax and
+  semantics in detail.
+- [Built-in functions](language/built-in-functions.md) documents console I/O
+  and random-number generation.
+- [Diagnostics](language/diagnostics.md) explains Balu's errors, warnings, and
+  diagnostic IDs.
+- [Compiler command line](tools/compiler.md) is the reference for the `bc`
+  command-line compiler.
+
+## Project components
+
+| Component | Purpose |
+| --- | --- |
+| `Balu` | Compiler library containing the syntax, binding, lowering, diagnostics, and emission pipelines |
+| `bc` | Command-line compiler that emits a .NET assembly and optionally a portable PDB |
+| `bi` | Interactive REPL for incremental Balu submissions |
+| `Balu.Interpretation` | Execution layer used by the REPL and tests |
+| `Balu.Sdk` | MSBuild SDK for compiling `.b` files as part of a .NET project |
+| `Balu.SourceGenerator` | Build-time generator for syntax and bound-tree infrastructure |
+| `Balu.VSIX` | Visual Studio project and item templates |
+| `Balu.Tests` | Lexer, parser, binder, execution, emitter, and interpreter tests |
+
+The interpreter is not an AST evaluator. Each successful submission is
+compiled into an in-memory .NET assembly, loaded, executed, and then used as
+the basis for the next submission.
+
+## Language at a glance
+
+```balu
+function factorial(value: int): int {
+    if value <= 1
+        return 1
+
+    return value * factorial(value - 1)
+}
+
+function main() {
+    println(factorial(5))
+}
+```
+
+Balu currently provides:
+
+- `int`, `bool`, `string`, and `any` values
+- mutable `var` and read-only `let` declarations
+- global functions with typed parameters and optional return types
+- `if`, `while`, `do while`, and inclusive `for ... to ...` control flow
+- global statements or a `main` function as the program entry point
+- multiple source files in one shared global namespace
+- compilation to managed .NET IL
+
+Features such as arrays, user-defined types, modules, imports, exceptions,
+floating-point numbers, and generics are not implemented.
+
+## Documentation scope
+
+The language documentation separates three related concepts:
+
+- A **program** is a normal compilation emitted by `bc` or `Balu.Sdk`.
+- A **script** is an incremental compilation used by the REPL.
+- The **compiler API** is the .NET API exposed by the `Balu` assembly.
+
+Program and script syntax are mostly identical, but their entry points,
+top-level expression rules, and state lifetime differ. These differences are
+called out where relevant.

--- a/docs/language/built-in-functions.md
+++ b/docs/language/built-in-functions.md
@@ -1,0 +1,135 @@
+# Built-in functions
+
+Balu programs can call four built-in functions without declaring or importing
+them:
+
+| Function | Return type | Purpose |
+| --- | --- | --- |
+| `print(value: any)` | no value | Write a value without a line break |
+| `println(value: any)` | no value | Write a value followed by a line break |
+| `input()` | `string` | Read one line from standard input |
+| `random(maximum: int)` | `int` | Generate a pseudo-random integer below `maximum` |
+
+The built-ins are part of the compiler runtime mapping, not functions written
+in Balu source code.
+
+## `print`
+
+```text
+print(value: any)
+```
+
+`print` writes `value` to standard output without appending a line break. It is
+implemented using `.NET`'s `Console.Write(object)`.
+
+```balu
+print("Hello, ")
+print("world")
+```
+
+Output:
+
+```text
+Hello, world
+```
+
+`int`, `bool`, and `string` values are implicitly convertible to `any`, so no
+explicit conversion is needed when printing them:
+
+```balu
+print(42)
+print(true)
+print("text")
+```
+
+## `println`
+
+```text
+println(value: any)
+```
+
+`println` writes `value` to standard output and appends the platform's line
+terminator. It is implemented using `.NET`'s `Console.WriteLine(object)`.
+
+```balu
+println("first line")
+println("second line")
+```
+
+Output:
+
+```text
+first line
+second line
+```
+
+There is no zero-argument overload. To write an empty line, pass an empty
+string:
+
+```balu
+println("")
+```
+
+## `input`
+
+```text
+input(): string
+```
+
+`input` reads one line from standard input. The returned string does not
+contain the line terminator.
+
+```balu
+print("Name: ")
+var name = input()
+println("Hello, " + name)
+```
+
+At the end of the input stream, the underlying `.NET` read returns `null`. The
+compiler converts that result to a string, producing an empty string.
+
+In the REPL, Balu program input and the REPL editor use the same console. Call
+`input()` only when the submitted program is expected to pause and read another
+line.
+
+## `random`
+
+```text
+random(maximum: int): int
+```
+
+For a positive `maximum`, `random` returns a pseudo-random integer in the range
+from zero, inclusive, to `maximum`, exclusive:
+
+```balu
+var die = random(6) + 1
+println(die)
+```
+
+The generated program owns one `.NET` `Random` instance and calls
+`Random.Next(maximum)` for each invocation.
+
+The current runtime behavior follows `.NET`:
+
+- a positive maximum produces `0 <= result < maximum`
+- a maximum of zero produces zero
+- a negative maximum throws a runtime exception
+
+Balu does not currently provide a way to set the random seed.
+
+## Name lookup and shadowing
+
+Built-in functions live in the outer global scope. A user declaration can hide
+a built-in, but the compiler reports a warning:
+
+```balu
+function print(value: int) {
+}
+```
+
+After that declaration, calls in its scope resolve according to the normal
+symbol lookup rules. Avoid reusing built-in names unless shadowing is
+intentional.
+
+Built-ins cannot be overloaded. For example, `println()` is an argument-count
+error rather than a call to a separate zero-argument overload.

--- a/docs/language/diagnostics.md
+++ b/docs/language/diagnostics.md
@@ -1,0 +1,150 @@
+# Diagnostics
+
+Balu reports lexical, syntactic, semantic, control-flow, and emission problems
+as diagnostics. Each diagnostic has an ID, severity, message, and, where
+possible, a source location.
+
+## Diagnostic IDs
+
+IDs use the format `BLdddd` and are grouped by compiler phase:
+
+| Range | Area |
+| --- | --- |
+| `BL0001`-`BL0999` | Lexer and parser |
+| `BL1001`-`BL1999` | Binding and lowering |
+| `BL2001`-`BL2999` | Assembly and debug-symbol emission |
+
+The numeric ID is the useful external identifier. The corresponding .NET enum
+member names are implementation details and may be corrected or renamed as the
+project evolves.
+
+## Severity
+
+Most diagnostics are errors. An error prevents assembly emission or execution
+of a REPL submission.
+
+The current warnings are:
+
+| ID | Meaning |
+| --- | --- |
+| `BL1009` | A declaration hides a symbol from an outer scope |
+| `BL1030` | Code is unreachable |
+
+Warnings do not prevent emission or execution. `bc` exits successfully when a
+compilation contains warnings but no errors. There is currently no
+warnings-as-errors option.
+
+## Display format
+
+A source diagnostic is displayed with a one-based line and column:
+
+```text
+program.b(3,5): error BL1005: Undefined name 'value'.
+    value
+```
+
+Warnings use `warning` instead of `error`. For a diagnostic with a non-empty
+source span, the compiler also prints the affected source text and highlights
+it when writing to an interactive console. Colors are disabled when output is
+redirected.
+
+Diagnostics without a source location use this format:
+
+```text
+[BL2002]: The required type 'System.Object' could not be resolved among the referenced assemblies.
+```
+
+For example, missing runtime types and path collisions are not necessarily tied
+to one source span.
+
+## Lexer and parser diagnostics
+
+| ID | Condition |
+| --- | --- |
+| `BL0001` | An unexpected character or token was found, or an expected token is missing |
+| `BL0002` | A number is not a valid signed 32-bit integer |
+| `BL0003` | A string contains an unsupported escape sequence |
+| `BL0004` | A string literal is not terminated |
+| `BL0005` | A multi-line comment is not terminated |
+
+The parser attempts to recover after errors by creating missing tokens and
+preserving skipped source text. One malformed construct can therefore produce
+more than one diagnostic.
+
+## Binding and lowering diagnostics
+
+| ID | Severity | Condition |
+| --- | --- | --- |
+| `BL1001` | Error | A unary operator does not support its operand type |
+| `BL1002` | Error | A binary operator does not support its operand types |
+| `BL1003` | Error | Prefix increment or decrement does not support the variable type |
+| `BL1004` | Error | Postfix increment or decrement does not support the variable type |
+| `BL1005` | Error | A name is not defined in the current scope |
+| `BL1006` | Error | No conversion exists between two types |
+| `BL1007` | Error | A conversion exists but must be written explicitly |
+| `BL1008` | Error | A symbol is already declared in the same scope |
+| `BL1009` | Warning | A declaration hides a symbol in an outer scope |
+| `BL1010` | Error | An assignment targets a read-only `let` variable |
+| `BL1011` | Error | A function has the wrong number of arguments, or an argument has the wrong type |
+| `BL1012` | Error | An expression that must produce a value has no value |
+| `BL1013` | Error | A symbol used as a variable has another symbol kind |
+| `BL1014` | Error | A symbol called as a function has another symbol kind |
+| `BL1015` | Error | A type name is not defined |
+| `BL1016` | Error | A required variable is not defined |
+| `BL1017` | Error | A required function is not defined |
+| `BL1018` | Error | A parameter name is duplicated in a function declaration |
+| `BL1019` | Error | A function with the same name is already declared |
+| `BL1020` | Error | `break` or `continue` is used outside a loop |
+| `BL1021` | Error | A value-bearing `return` is used in global statements of a normal program |
+| `BL1022` | Error | A value-returning function uses `return` without a value |
+| `BL1023` | Error | A returned value has the wrong type, or a value is returned from a no-value function |
+| `BL1024` | Error | Not all reachable paths of a value-returning function return a value |
+| `BL1025` | Error | An unsupported expression is used as a statement |
+| `BL1026` | Error | Global statements are mixed with an explicit `main` function |
+| `BL1027` | Error | `main` has parameters or a return type |
+| `BL1028` | Error | Without an explicit `main`, global statements occur in more than one source file |
+| `BL1029` | Error | A normal program has neither `main` nor global statements |
+| `BL1030` | Warning | Control-flow analysis found unreachable code |
+
+`BL1011` currently covers both argument-count and argument-type mismatches. A
+future compiler version may assign a separate ID to argument-type errors.
+
+The binder intends to report `BL1020` for `break` or `continue` outside a loop.
+It currently records the diagnostic and then can terminate unexpectedly while
+accessing the missing loop context. This is a known compiler issue.
+
+## Emitter diagnostics
+
+| ID | Condition |
+| --- | --- |
+| `BL2001` | A reference has an invalid assembly image or encounters a handled I/O load failure |
+| `BL2002` | A required .NET runtime type cannot be found in the references |
+| `BL2003` | A required .NET runtime type is ambiguous across references |
+| `BL2004` | A required .NET runtime method cannot be found |
+| `BL2005` | A source document has no name and cannot be represented in debug symbols |
+| `BL2006` | One document name identifies different source texts in debug symbols |
+| `BL2007` | An assembly, PDB, or source path conflicts with another emit path |
+
+Emitter diagnostics are produced only when emitting an assembly or PDB. They do
+not appear merely by parsing or binding a `Compilation`.
+
+## Tools and exit behavior
+
+The command-line compiler writes diagnostics to standard error. Its exit code
+is:
+
+| Exit code | Meaning |
+| ---: | --- |
+| `0` | Help was displayed, or compilation succeeded, possibly with warnings |
+| `1` | An error occurred or no source file was supplied |
+
+The `bc` quiet option suppresses diagnostics as well as informational output;
+the exit code is then the only error indication. See the
+[compiler command-line reference](../tools/compiler.md) for details.
+
+Malformed options are parsed before normal error handling. They can produce
+output despite quiet mode and terminate with a different nonzero process code.
+
+The REPL displays diagnostics and does not commit a submission that has errors.
+Warnings are displayed but do not prevent execution or persistence of the
+submission.

--- a/docs/language/overview.md
+++ b/docs/language/overview.md
@@ -1,0 +1,285 @@
+# Language overview
+
+Balu is a small, statically checked, imperative language. Source code is parsed,
+bound to typed symbols, lowered to simple control flow, and emitted as managed
+.NET IL.
+
+This page is a guided tour. See the [language reference](reference.md) for the
+complete syntax and semantic rules.
+
+## A complete program
+
+```balu
+function greet(name: string) {
+    println("Hello, " + name)
+}
+
+function main() {
+    print("What is your name? ")
+    var name = input()
+    greet(name)
+}
+```
+
+Functions start with `function`. Parameters always have a type. A function
+without a written return type returns no value.
+
+`main` is the entry point of this program. It must have no parameters and no
+return value.
+
+## Values and types
+
+Balu has four types that can be used in source code:
+
+| Type | Description | Example |
+| --- | --- | --- |
+| `int` | 32-bit signed integer | `42` |
+| `bool` | Boolean value | `true` |
+| `string` | Text | `"hello"` |
+| `any` | A value stored without its more specific static type | `any(42)` |
+
+Functions without a return type use an internal `void` type. `void` currently
+cannot be written in a type clause.
+
+Types are checked at compile time. Balu does not use truthiness, so an `if` or
+loop condition must be a `bool`:
+
+```balu
+var ready = true
+
+if ready
+    println("Ready")
+```
+
+## Variables and constants
+
+`var` declares a mutable variable. `let` declares a read-only variable:
+
+```balu
+var counter = 0
+counter = counter + 1
+
+let maximum = 10
+```
+
+The type is inferred from the initializer unless it is written explicitly:
+
+```balu
+var counter: int = 0
+let title: string = "Balu"
+```
+
+Every variable declaration requires an initializer.
+
+Declarations at the top level create global variables. Declarations in a
+function or block create local variables.
+
+## Expressions
+
+Balu provides arithmetic, comparison, equality, Boolean, and bitwise
+operators:
+
+```balu
+var arithmetic = 2 + 3 * 4
+var comparison = arithmetic >= 10
+var logic = comparison && true
+var bits = 6 & 3
+var text = "Hello, " + "world"
+```
+
+Strings only concatenate with strings. Convert another value explicitly when
+needed:
+
+```balu
+var message = "The answer is " + string(42)
+```
+
+Assignments are expressions and produce a value:
+
+```balu
+var x = 1
+var y = (x = 5)
+```
+
+Mutable integer variables also support prefix and postfix increment and
+decrement:
+
+```balu
+++x
+y--
+```
+
+## Control flow
+
+Conditions do not require parentheses. The controlled body can be one statement
+or a block.
+
+### `if` and `else`
+
+```balu
+var score = 75
+
+if score >= 50 {
+    println("passed")
+} else {
+    println("failed")
+}
+```
+
+### `while`
+
+```balu
+var i = 0
+
+while i < 3 {
+    println(i)
+    i++
+}
+```
+
+### `do while`
+
+```balu
+var i = 3
+
+do {
+    println(i)
+    i--
+} while i > 0
+```
+
+The body of a `do while` loop runs at least once.
+
+### `for ... to ...`
+
+```balu
+for i = 1 to 5 {
+    println(i)
+}
+```
+
+The lower and upper bounds are evaluated once. The loop counts upward by one,
+and the upper bound is inclusive. The current unchecked increment has an edge
+case at `2147483647`; see the detailed reference before using `int` limits as
+loop bounds.
+
+Use `break` to leave the innermost loop and `continue` to begin its next
+iteration.
+
+## Functions
+
+Function parameters require type annotations. A return type is required only
+when the function returns a value:
+
+```balu
+function add(left: int, right: int): int {
+    return left + right
+}
+
+function show(value: int) {
+    println(value)
+}
+```
+
+Functions are global. They can call functions declared later in the source,
+and recursion is supported:
+
+```balu
+function fibonacci(n: int): int {
+    if n <= 1
+        return n
+
+    return fibonacci(n - 1) + fibonacci(n - 2)
+}
+```
+
+Balu does not currently support overloads, local functions, optional
+parameters, or function values.
+
+## Program entry points
+
+A normal Balu program has one of two forms.
+
+An explicit `main` function:
+
+```balu
+function main() {
+    println("Hello")
+}
+```
+
+Or top-level global statements, which produce an implicit entry point:
+
+```balu
+println("Hello")
+```
+
+An explicit `main` cannot be mixed with global statements. In a multi-file
+program, global statements may occur in at most one file.
+
+## Multiple source files
+
+All source files in a compilation share one global namespace. There are no
+module or import declarations:
+
+```balu
+// math.b
+function double(value: int): int {
+    return value * 2
+}
+```
+
+```balu
+// program.b
+function main() {
+    println(double(21))
+}
+```
+
+Functions and global variables are visible across file boundaries. The order
+of global variable initializers can matter; see the
+[multi-file rules](reference.md#source-files-and-programs) in the reference.
+
+## REPL and script mode
+
+The REPL compiles each input as a script submission. Successful submissions
+can see variables and functions from earlier submissions:
+
+```text
+» var value = 10
+» value * 2
+Result: 20
+```
+
+Unlike a normal program, a top-level value expression is valid in script mode
+and becomes the submission result. Compile-time and runtime failures do not
+commit the interpreter's symbols or global values. I/O that already happened
+before a runtime failure cannot be rolled back.
+
+## Built-in functions
+
+Balu includes four built-in functions:
+
+```text
+print(value: any)
+println(value: any)
+input(): string
+random(maximum: int): int
+```
+
+See [Built-in functions](built-in-functions.md) for their behavior and examples.
+
+## Current limits
+
+Balu does not currently provide:
+
+- arrays or collections
+- user-defined types
+- modules, imports, or namespaces
+- floating-point values
+- `null`
+- exceptions or exception handling
+- lambdas, closures, or local functions
+- function overloads or generics
+- member access or .NET interop syntax
+- `switch`, `foreach`, or configurable `for` steps

--- a/docs/language/reference.md
+++ b/docs/language/reference.md
@@ -1,0 +1,710 @@
+# Language reference
+
+This document describes the language implemented by the current Balu compiler.
+It is a descriptive reference, not a versioned or normative specification.
+Implementation details that may require a future language-design decision are
+identified as such.
+
+## Source text
+
+Balu source files conventionally use the `.b` extension. The command-line
+compiler does not enforce the extension.
+
+Whitespace and comments separate tokens but are otherwise ignored. Line breaks
+usually have no syntactic meaning. The exception is the expression following a
+`return`, which must begin on the same source line as `return`.
+
+Statements have no semicolon terminator.
+
+### Comments
+
+Single-line comments begin with `//` and continue to the end of the line:
+
+```balu
+// A single-line comment
+var value = 1 // A trailing comment
+```
+
+Multi-line comments begin with `/*` and end with `*/`:
+
+```balu
+/* A comment that
+   spans multiple lines. */
+```
+
+Multi-line comments do not nest. An unclosed multi-line comment is a lexical
+error.
+
+## Identifiers and keywords
+
+An identifier begins with a letter or underscore. Further characters may be
+letters, digits, or underscores. The lexer uses the .NET Unicode definitions of
+letters and digits.
+
+Identifiers and keywords are case-sensitive. `value` and `Value` are different
+names.
+
+The reserved keywords are:
+
+```text
+break       continue    do          else
+false       for         function    if
+let         return      to          true
+var         while
+```
+
+The type names `int`, `bool`, `string`, and `any` are lexed as identifiers and
+interpreted as types in type and conversion contexts.
+
+## Literals
+
+### Integer literals
+
+Integer literals are decimal sequences of digits:
+
+```balu
+0
+42
+1000000
+```
+
+They represent signed 32-bit `int` values. There are no hexadecimal, binary, or
+octal forms and no digit separators. A leading sign is a separate unary
+operator rather than part of the literal.
+
+An integer outside the range accepted by the lexer produces a diagnostic.
+Because a leading minus is a separate token, the positive magnitude is parsed
+first. Consequently, `-2147483648` cannot currently be written directly: the
+`2147483648` token is already outside the accepted literal range.
+
+### Boolean literals
+
+The Boolean literals are `true` and `false`.
+
+### String literals
+
+String literals use double quotes:
+
+```balu
+"Balu"
+""
+"first line\nsecond line"
+```
+
+The supported escape sequences are:
+
+| Escape | Value |
+| --- | --- |
+| `\r` | Carriage return |
+| `\n` | Line feed |
+| `\t` | Horizontal tab |
+| `\v` | Vertical tab |
+| `\\` | Backslash |
+| `\"` | Double quote |
+
+A string literal cannot contain an unescaped source line break. Unsupported
+escape sequences and unclosed strings produce diagnostics.
+
+## Grammar
+
+The following EBNF summarizes the implemented grammar. `identifier`, `number`,
+and `string` represent lexical tokens.
+
+```ebnf
+compilation-unit       = { member }, end-of-file ;
+
+member                 = function-declaration
+                       | statement ;
+
+function-declaration   = "function", identifier,
+                         "(", [ parameter-list ], ")",
+                         [ type-clause ], block-statement ;
+
+parameter-list         = parameter, { ",", parameter } ;
+parameter              = identifier, type-clause ;
+type-clause            = ":", identifier ;
+
+statement              = block-statement
+                       | variable-declaration
+                       | if-statement
+                       | while-statement
+                       | do-while-statement
+                       | for-statement
+                       | break-statement
+                       | continue-statement
+                       | return-statement
+                       | expression-statement ;
+
+block-statement        = "{", { statement }, "}" ;
+
+variable-declaration   = ( "let" | "var" ), identifier,
+                         [ type-clause ], "=", expression ;
+
+if-statement           = "if", expression, statement,
+                         [ "else", statement ] ;
+
+while-statement        = "while", expression, statement ;
+do-while-statement     = "do", statement, "while", expression ;
+
+for-statement          = "for", identifier, "=", expression,
+                         "to", expression, statement ;
+
+break-statement        = "break" ;
+continue-statement     = "continue" ;
+return-statement       = "return", [ expression-on-the-same-line ] ;
+
+expression-statement   = expression ;
+
+expression             = assignment-expression
+                       ;
+
+assignment-expression  = identifier, assignment-operator, expression
+                       | binary-expression ;
+assignment-operator    = "=" | "+=" | "-=" | "*=" | "/="
+                       | "&=" | "|=" | "^=" ;
+
+binary-expression      = unary-expression,
+                         { binary-operator, unary-expression } ;
+binary-operator        = "+" | "-" | "*" | "/"
+                       | "&" | "&&" | "|" | "||" | "^"
+                       | "==" | "!=" | "<" | "<=" | ">" | ">=" ;
+
+unary-expression       = unary-operator, unary-expression
+                       | primary-expression ;
+unary-operator         = "+" | "-" | "!" | "~" ;
+
+primary-expression     = number | string | "true" | "false"
+                       | identifier
+                       | "(", expression, ")"
+                       | call-expression
+                       | prefix-expression
+                       | postfix-expression ;
+
+call-expression        = identifier, "(", [ argument-list ], ")" ;
+argument-list          = expression, { ",", expression } ;
+prefix-expression      = ( "++" | "--" ), identifier ;
+postfix-expression     = identifier, ( "++" | "--" ) ;
+```
+
+The compact `binary-expression` production does not encode precedence.
+Precedence and associativity are defined by the table in
+[Precedence and associativity](#precedence-and-associativity).
+
+Function and call argument lists do not allow a trailing comma. Function
+declarations are only recognized at the compilation-unit level; functions
+cannot be declared inside blocks or other functions.
+
+## Types
+
+### Source types
+
+| Type | Meaning | CLR representation |
+| --- | --- | --- |
+| `int` | Signed 32-bit integer | `System.Int32` |
+| `bool` | Boolean value | `System.Boolean` |
+| `string` | String value | `System.String` |
+| `any` | A boxed or reference value without its more specific static type | `System.Object` |
+
+`void` represents the absence of a return value. It is assigned internally to
+functions without a return-type clause, but `void` is not currently recognized
+as a source type. Write `function run() { ... }`, not
+`function run(): void { ... }`.
+
+There is no `null` literal.
+
+### Type inference
+
+A variable declaration without a type clause takes the static type of its
+initializer:
+
+```balu
+var count = 1          // int
+let message = "hello" // string
+```
+
+Function parameters always require a type. Function return types are never
+inferred: omitting the return type declares a function that returns no value.
+
+### Conversions
+
+Identity conversions exist from every type to itself.
+
+The following conversions are implicit:
+
+| From | To |
+| --- | --- |
+| `int` | `any` |
+| `bool` | `any` |
+| `string` | `any` |
+
+The following conversions are explicit:
+
+| From | To |
+| --- | --- |
+| `any` | `int`, `bool`, or `string` |
+| `int` | `string` |
+| `bool` | `string` |
+| `string` | `int` or `bool` |
+
+An explicit conversion uses call-like syntax:
+
+```balu
+var text = string(42)
+var number = int("42")
+var flag = bool("true")
+var value: any = 42
+var restored = int(value)
+```
+
+Conversions use the corresponding .NET conversion behavior. A conversion can
+therefore fail at runtime, for example when converting `"not a number"` to
+`int`. Balu does not currently provide exception handling.
+
+A one-argument call whose name is a known type is treated as a conversion
+before normal function lookup. This behavior may be refined in a future
+language design.
+
+There are no implicit conversions to `bool`; conditions must already have type
+`bool`.
+
+## Declarations and names
+
+### Variables
+
+Every variable declaration has an initializer:
+
+```balu
+var mutable = 1
+let readOnly = 2
+var explicitType: int = 3
+```
+
+`var` variables can be assigned after declaration. `let` variables cannot.
+
+Parameters are mutable and can be assigned inside their function.
+
+The initializer is bound before the new variable is declared. If an outer
+variable has the same name, the initializer can therefore refer to that outer
+variable:
+
+```balu
+var value = 1
+{
+    var value = value + 1
+    println(value)
+}
+```
+
+### Name spaces
+
+Variables, parameters, and functions share a symbol namespace within each
+scope. Balu does not support function overloads. Two symbols with the same name
+cannot be declared in the same scope.
+
+A declaration may hide a symbol in an outer scope. This is allowed but produces
+a warning. Built-in functions can also be hidden.
+
+Type lookup is separate from ordinary symbol lookup.
+
+### Scopes
+
+An explicit `{ ... }` block creates a lexical scope. A `for` statement creates
+a scope containing its loop variable. A function has scopes for its parameters
+and body.
+
+In the current implementation, an unbraced body does not create an additional
+lexical scope. Consequently, a variable declared as the single body of an
+`if` or loop can enter the surrounding scope. This is an implementation
+behavior under review rather than a recommended coding style; use braces when
+scope boundaries matter.
+
+## Expressions
+
+### Primary expressions
+
+Primary expressions are:
+
+- integer, Boolean, and string literals
+- variable and parameter names
+- parenthesized expressions
+- function calls
+- prefix increment and decrement of a direct variable name
+- postfix increment and decrement of a direct variable name
+
+Calls have the form:
+
+```balu
+name(argument1, argument2)
+```
+
+Only a direct function name can be called. There are no member calls, callable
+values, or call chains.
+
+### Unary operators
+
+| Operator | Operand | Result | Meaning |
+| --- | --- | --- | --- |
+| `+` | `int` | `int` | Identity |
+| `-` | `int` | `int` | Arithmetic negation |
+| `~` | `int` | `int` | Bitwise complement |
+| `!` | `bool` | `bool` | Logical negation |
+
+### Binary operators
+
+Arithmetic and string operators:
+
+| Operator | Operands | Result |
+| --- | --- | --- |
+| `+` | `int`, `int` | `int` |
+| `-` | `int`, `int` | `int` |
+| `*` | `int`, `int` | `int` |
+| `/` | `int`, `int` | `int` |
+| `+` | `string`, `string` | `string` |
+
+Boolean and bitwise operators:
+
+| Operator | Operands | Result | Short-circuiting |
+| --- | --- | --- | --- |
+| `&` | `int`, `int` | `int` | No |
+| `|` | `int`, `int` | `int` | No |
+| `^` | `int`, `int` | `int` | No |
+| `&` | `bool`, `bool` | `bool` | No |
+| `|` | `bool`, `bool` | `bool` | No |
+| `^` | `bool`, `bool` | `bool` | No |
+| `&&` | `bool`, `bool` | `bool` | Yes |
+| `||` | `bool`, `bool` | `bool` | Yes |
+
+Equality and relational operators:
+
+| Operator | Operands | Result |
+| --- | --- | --- |
+| `==`, `!=` | two `int` values | `bool` |
+| `==`, `!=` | two `bool` values | `bool` |
+| `==`, `!=` | two `string` values | `bool` |
+| `==`, `!=` | two `any` values | `bool` |
+| `<`, `<=`, `>`, `>=` | two `int` values | `bool` |
+
+Both operands must have the same supported static type. String equality is
+value equality. `any` equality uses .NET object equality.
+
+### Precedence and associativity
+
+The precedence levels, from highest to lowest, are:
+
+| Precedence | Operators | Associativity |
+| ---: | --- | --- |
+| primary | calls, parentheses, `++x`, `--x`, `x++`, `x--` | n/a |
+| 100 | unary `+`, `-`, `!`, `~` | right |
+| 11 | `*`, `/` | left |
+| 10 | `+`, `-` | left |
+| 5 | `==`, `!=`, `<`, `<=`, `>`, `>=` | left |
+| 2 | `&`, `&&` | left |
+| 1 | `|`, `||`, `^` | left |
+| assignment | `=`, `+=`, `-=`, `*=`, `/=`, `&=`, `|=`, `^=` | right |
+
+Several operators intentionally share a precedence level that differs from
+common C-family precedence tables. Use parentheses when mixing equality and
+relational operators or different Boolean operator forms.
+
+### Assignment
+
+The left side of an assignment must be a direct mutable variable or parameter
+name. Assignment is an expression and evaluates to the assigned value:
+
+```balu
+var a = 0
+var b = 0
+a = b = 5
+```
+
+The compound assignment operators are:
+
+```text
++=  -=  *=  /=  &=  |=  ^=
+```
+
+Supported combinations are:
+
+| Type | Compound assignments |
+| --- | --- |
+| `int` | `+=`, `-=`, `*=`, `/=`, `&=`, `|=`, `^=` |
+| `string` | `+=` |
+| `bool` | `&=`, `|=`, `^=` |
+
+In the current implementation, Boolean `&=` and `|=` are internally bound as
+logical operations. Their exact relationship to the non-short-circuiting `&`
+and `|` operators should not yet be treated as a stable language guarantee.
+
+### Increment and decrement
+
+Prefix and postfix increment and decrement apply only to direct mutable `int`
+variables or parameters:
+
+```balu
+var value = 1
+var old = value++ // old is 1, value is 2
+var next = ++value // value and next are 3
+```
+
+Prefix form evaluates to the new value. Postfix form evaluates to the old
+value. The operators cannot be applied to a `let`, call, or parenthesized
+expression.
+
+## Statements
+
+### Blocks
+
+A block contains zero or more statements and introduces a lexical scope:
+
+```balu
+{
+    var value = 1
+    println(value)
+}
+```
+
+### Expression statements
+
+In a normal program or function, only assignments, calls, increments, and
+decrements can be used as statements:
+
+```balu
+value = 10
+println(value)
+value++
+```
+
+A value expression such as `1 + 2` is permitted as a top-level script
+submission, where it becomes the script result.
+
+### `if`
+
+```balu
+if condition
+    statement
+else
+    statement
+```
+
+The condition must be `bool`. An `else` binds to the nearest preceding `if`
+that does not already have an `else`. `else if` works by placing another `if`
+statement after `else`.
+
+### `while`
+
+```balu
+while condition {
+    statements
+}
+```
+
+The `bool` condition is checked before every iteration. `continue` returns to
+the condition check.
+
+### `do while`
+
+```balu
+do {
+    statements
+} while condition
+```
+
+The body executes before the `bool` condition is checked and therefore runs at
+least once. There is no trailing semicolon.
+
+### `for ... to ...`
+
+```balu
+for i = lowerBound to upperBound {
+    statements
+}
+```
+
+Both bounds must have type `int`. They are each evaluated once before the loop.
+The loop variable begins at the lower bound, increases by one, and continues
+while it is less than or equal to the stored upper bound.
+
+The loop variable is mutable and scoped to the `for` statement. `continue`
+performs the increment before checking the next iteration.
+
+There is no descending form or configurable step.
+
+The increment currently uses unchecked 32-bit arithmetic. If the inclusive
+upper bound is `2147483647`, incrementing after that iteration wraps the loop
+variable to `-2147483648`, so the loop does not terminate normally. This is a
+known implementation limitation.
+
+### `break` and `continue`
+
+`break` exits the innermost enclosing loop. `continue` begins the next
+iteration of the innermost enclosing loop. Both are invalid outside a loop.
+
+Known compiler issue: the binder currently records `BL1020` and then attempts
+to access a missing loop context, which can terminate compilation instead of
+returning the diagnostic normally.
+
+### `return`
+
+```balu
+return
+return expression
+```
+
+A function without a return type accepts only `return` without a value. A
+function with a return type requires a compatible return value, and all
+reachable paths must return.
+
+At the top level of a normal program, `return` without a value exits the
+implicit entry point. A top-level return value is allowed only in script mode.
+
+The expression must begin on the same physical source line as `return`:
+
+```balu
+return value // returns value
+```
+
+```balu
+return
+value        // a separate statement
+```
+
+This is the only generally line-sensitive statement rule in the current
+grammar.
+
+## Functions
+
+A function declaration has a name, zero or more typed parameters, an optional
+return type, and a block body:
+
+```balu
+function name(first: int, second: string): bool {
+    return second == string(first)
+}
+```
+
+Functions are declared globally. Their names are available before bodies are
+bound, so functions can call later declarations, call themselves recursively,
+and participate in mutual recursion.
+
+Arguments are evaluated from left to right. Their count must exactly match the
+parameter count, and each argument must be implicitly convertible to its
+parameter type.
+
+Parameters are passed by value and are mutable within the function.
+
+Balu does not support overloads, default arguments, named arguments, variadic
+parameters, local functions, or function values.
+
+## Source files and programs
+
+### Shared global namespace
+
+All syntax trees passed to one compilation share a global namespace. There are
+no source-level modules, imports, namespaces, exports, or file-local symbols.
+
+Functions can refer to functions and global variables in other files.
+
+Global variable declarations are bound in syntax-tree and source order. A
+global initializer can refer to functions and to global variables already
+declared, but not to a global variable declared later. The order in which
+source files are supplied can therefore affect global initializers. This is a
+current implementation characteristic that may be constrained by a future
+language specification.
+
+### Entry point
+
+A normal compilation needs exactly one effective entry point.
+
+An explicit entry point is a function named `main` with no parameters and no
+return type:
+
+```balu
+function main() {
+    println("Hello")
+}
+```
+
+If there is no explicit `main`, global statements create an implicit entry
+point:
+
+```balu
+println("Hello")
+```
+
+The following rules apply:
+
+- an explicit `main` cannot be mixed with global statements
+- global statements may occur in at most one source file
+- a compilation with neither form reports that no entry point is defined
+- command-line arguments are not passed to `main`
+- `main` cannot return an exit code
+
+The module name accepted by `bc` is the emitted .NET assembly name. It is not a
+Balu module declaration.
+
+## Script mode
+
+Script mode is used by `Compilation.CreateScript` and the REPL. It creates a
+synthetic entry point that returns `any`.
+
+Compared with a normal program:
+
+- a top-level value expression is allowed and becomes the submission result
+- a top-level `return expression` is allowed
+- visible symbols from a successful previous submission form the parent scope
+  of `Compilation.CreateScript`
+- `Balu.Interpretation.Interpreter` copies global variable values into the next
+  emitted submission
+- failed compilation or execution does not commit the interpreter's compilation
+  or global-variable state
+
+Redeclaring a name in a later submission hides the previous symbol. Functions
+that were bound in an earlier submission retain their references to the older
+symbols.
+
+The REPL persists successful source submissions and executes them again on the
+next process start. This persistence behavior belongs to `bi`, not to the core
+language.
+
+State rollback cannot undo external effects that occurred before a runtime
+failure. Console output remains visible and input already read remains
+consumed.
+
+## Runtime behavior
+
+Balu currently emits managed .NET IL. Observable runtime behavior includes:
+
+- integer addition, subtraction, multiplication, negation, and increment use
+  normal unchecked 32-bit IL operations
+- integer division truncates toward zero
+- nonconstant division by zero fails at runtime
+- dividing `-2147483648` by `-1` overflows and fails at runtime
+- `&&` and `||` evaluate the right operand only when required
+- ordinary binary operands and call arguments are evaluated left to right
+- string concatenation uses .NET string concatenation
+- string and `any` equality use .NET equality behavior
+- explicit conversions use .NET conversion methods and can fail at runtime
+
+These statements describe the current backend. A future normative language
+specification may define equivalent behavior independently of .NET.
+
+Constant folding currently attempts to evaluate a constant expression such as
+`1 / 0` while binding. The resulting exception is not converted into a normal
+diagnostic. This is a known compiler issue rather than defined language
+behavior.
+
+## Unsupported constructs
+
+The grammar has no syntax for:
+
+- arrays, indexing, or collection literals
+- user-defined types or members
+- modules or imports
+- floating-point or character literals
+- `null`
+- exceptions
+- lambdas or closures
+- function overloads or generics
+- member access
+- `switch`, `foreach`, or a ternary expression
+- string interpolation or raw strings

--- a/docs/tools/compiler.md
+++ b/docs/tools/compiler.md
@@ -1,0 +1,300 @@
+# Compiler command line
+
+`bc` is the Balu command-line compiler. It parses one or more source files,
+creates a normal Balu compilation, and emits a managed .NET assembly. It can
+also emit a portable PDB.
+
+`bc` is a low-level compiler interface. It does not create a complete modern
+.NET application layout: there is no app host, `.runtimeconfig.json`,
+`.deps.json`, or publish directory. `Balu.Sdk` integrates the same compiler into
+the regular .NET build pipeline when a complete application layout is needed.
+
+## Invocation
+
+When working from the repository, run:
+
+```console
+dotnet run --project src/bc -- <source-paths> [options]
+```
+
+When using a built `bc.dll` from its complete build or package output directory,
+run:
+
+```console
+dotnet exec path/to/bc.dll <source-paths> [options]
+```
+
+Keep `bc.runtimeconfig.json`, `bc.deps.json`, and the compiler dependencies next
+to the DLL. This invocation also requires the .NET 10 runtime.
+
+If `bc` is available as an executable on `PATH`, the equivalent form is:
+
+```console
+bc <source-paths> [options]
+```
+
+Display the built-in help:
+
+```console
+dotnet run --project src/bc -- --help
+```
+
+At least one source path is required unless help is requested. Source paths are
+positional arguments. `bc` does not require the conventional `.b` extension.
+
+## Options
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-r=PATH`, `/r PATH` | Assembly path | Add a .NET reference assembly; repeat for every reference |
+| `-o=PATH`, `/o PATH` | Assembly path | Set the emitted assembly path |
+| `-s=PATH`, `/s PATH` | PDB path | Emit a portable PDB at this path |
+| `-m=NAME`, `/m NAME` | Name | Set the emitted assembly/module name |
+| `-q`, `/q` | none | Suppress informational output and diagnostics |
+| `-?`, `-h`, `--help`, `/help` | none | Display help and exit |
+
+Mono.Options accepts both dash-style and slash-style options. The repository's
+MSBuild task uses slash-style options, while the development launch profile
+uses dash-style options with `=`.
+
+### References: `-r`
+
+`bc` does not add default runtime references. Every required reference assembly
+must be supplied explicitly, using one `-r` or `/r` option per file.
+
+The emitter resolves these runtime types and their required members:
+
+```text
+System.Object
+System.Console
+System.String
+System.Convert
+System.Int32
+System.Boolean
+System.Void
+System.Random
+System.Diagnostics.DebuggableAttribute
+```
+
+For a modern .NET reference pack, Balu normally needs:
+
+```text
+System.Runtime.dll
+System.Runtime.Extensions.dll
+System.Console.dll
+```
+
+All references must belong to a compatible target framework. Do not mix .NET
+Framework and modern .NET reference assemblies.
+
+On a machine with the .NET 10 SDK, the modern reference assemblies are normally
+below a directory of this form:
+
+```text
+<dotnet-root>/packs/Microsoft.NETCore.App.Ref/<version>/ref/net10.0/
+```
+
+On Windows, a .NET Framework reference assembly such as the following can
+provide the required framework surface in one file:
+
+```text
+C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7.2\mscorlib.dll
+```
+
+References are used to resolve the runtime types and methods needed by emitted
+Balu code. They do not expose arbitrary .NET APIs to Balu source code; Balu has
+no general .NET interop syntax.
+
+### Assembly output: `-o`
+
+`-o` selects the assembly output path. If omitted, the first source path is
+changed to use the `.dll` extension:
+
+```text
+sources/program.b -> sources/program.dll
+```
+
+The output path is converted to an absolute path. The target directory must
+already exist.
+
+The emitter creates a managed DLL module and assigns the Balu entry point to the
+assembly. Changing the output extension does not change the module kind.
+
+### Debug symbols: `-s`
+
+`-s` requests a portable PDB. If omitted, no debug-symbol file is created.
+
+The PDB contains source document names, SHA-256 source checksums, sequence
+points, and local-variable scopes. A document name must be non-empty and cannot
+identify sources with different checksums. Reusing a name is allowed when the
+checksums are identical.
+
+### Module name: `-m`
+
+`-m` sets the emitted .NET assembly and module name. If omitted, the name is the
+file name of the assembly output path without its extension.
+
+This name is .NET metadata. Balu has no source-level module system.
+
+### Quiet mode: `-q`
+
+Quiet mode suppresses all output produced by `bc`, including:
+
+- the compiler banner
+- compilation and emission progress
+- warnings and errors
+- caught exception messages
+
+The process exit code is the only success or failure indication in quiet mode.
+Use it only when the caller reliably checks the exit code.
+
+Malformed options are parsed before `bc` enters its normal error-handling path.
+For example, an option that is missing its required value can produce an
+unhandled Mono.Options error, output despite `-q`, and a platform-dependent
+failure exit code.
+
+## Compile one source file
+
+This PowerShell example uses the .NET Framework reference assembly from the
+repository's development launch profile:
+
+```powershell
+New-Item -ItemType Directory -Path "out" -Force
+
+dotnet run --project src/bc -- `
+  "src/HelloWorld/hello.b" `
+  -r="C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7.2\mscorlib.dll" `
+  -o="out/hello.dll" `
+  -s="out/hello.pdb"
+```
+
+An equivalent modern .NET invocation supplies each required assembly:
+
+```console
+bc program.b \
+  -r=<reference-pack>/System.Runtime.dll \
+  -r=<reference-pack>/System.Runtime.Extensions.dll \
+  -r=<reference-pack>/System.Console.dll \
+  -o=out/program.dll \
+  -s=out/program.pdb
+```
+
+The angle-bracket path is a placeholder and must be replaced with the installed
+.NET 10 reference-pack directory.
+
+## Compile multiple source files
+
+Pass every source file as a positional argument:
+
+```console
+bc math.b program.b \
+  -r=<reference-pack>/System.Runtime.dll \
+  -r=<reference-pack>/System.Runtime.Extensions.dll \
+  -r=<reference-pack>/System.Console.dll \
+  -o=out/program.dll
+```
+
+All files form one compilation and share one global namespace. Functions and
+global variables can be referenced across file boundaries.
+
+Only one source file may contain global statements. Alternatively, declare a
+single valid `main` function. See
+[Source files and programs](../language/reference.md#source-files-and-programs)
+for the language rules.
+
+Global variable declarations are bound in syntax-tree order, but `bc` currently
+parses source paths in unordered parallel processing. It therefore does not
+guarantee that cross-file globals are bound in command-line order. Avoid global
+initializers that depend on declarations in another file.
+
+## Entry point requirements
+
+A normal compilation needs one of these entry-point forms:
+
+```balu
+function main() {
+    // Program body
+}
+```
+
+Or global statements:
+
+```balu
+println("Program body")
+```
+
+The compiler rejects:
+
+- a `main` with parameters
+- a `main` with a return type
+- an explicit `main` mixed with global statements
+- global statements in more than one file
+- a program with neither `main` nor global statements
+
+## Output and file safety
+
+On a successful emit, `bc` writes the assembly and optional PDB. Existing output
+files are replaced only after the new output has been emitted successfully.
+Compiler or emitter errors leave existing output files intact.
+
+The normalized assembly and PDB paths must differ from each other and from every
+source path. Path comparison is case-insensitive on Windows. File-system aliases
+such as symbolic links are not resolved when checking collisions.
+
+Reference paths are not included in this collision check. Do not set `-o` or
+`-s` to the path of a reference assembly, because a successful emit can replace
+that file.
+
+The target directories are not created by `bc`. Create them before invoking the
+compiler.
+
+## Console output
+
+A normal successful invocation produces output similar to:
+
+```text
+Balu compiler v0.1.0.0
+Compiling 'program.b'...
+Emitting assembly 'C:\work\out\program.dll' and symbol file 'out/program.pdb'.
+Done.
+```
+
+With multiple sources, parsing happens in parallel, so the order of
+`Compiling ...` messages is not guaranteed.
+
+Source diagnostics are written to standard error in an MSBuild-compatible
+format:
+
+```text
+C:\work\program.b(3,5): error BL1005: Undefined name 'value'.
+    value
+```
+
+See [Diagnostics](../language/diagnostics.md) for diagnostic IDs and severities.
+
+`Done.` currently indicates that the compiler completed its normal pipeline;
+it can still be printed when diagnostics contain errors. Always use the exit
+code to determine success.
+
+## Exit codes
+
+| Exit code | Meaning |
+| ---: | --- |
+| `0` | Help was displayed, or compilation completed without errors |
+| `1` | No source was supplied, diagnostics contain errors, or a handled failure occurred |
+
+Warnings do not change a successful exit code.
+
+Malformed options can terminate before this normal exit-code handling and may
+produce a different nonzero process code.
+
+## Running the result
+
+Direct `bc` output is an assembly and optional PDB, not a complete application
+deployment. A modern .NET host usually also needs framework and runtime metadata
+such as a `.runtimeconfig.json` file.
+
+For a normal `dotnet build`, `dotnet run`, or application publishing workflow,
+use a project based on `Balu.Sdk`. The SDK invokes `bc` for the intermediate
+assembly and then lets the standard .NET SDK produce the remaining application
+artifacts.

--- a/src/HelloWorld/hello.b
+++ b/src/HelloWorld/hello.b
@@ -1,6 +1,12 @@
 function main()
 {
 	test()
+	if false
+	{
+		println("This will never be printed")
+		// comment
+		println("This neither")
+	}
 }
 
 function test()

--- a/src/HelloWorld/world.b
+++ b/src/HelloWorld/world.b
@@ -1,2 +1,7 @@
+function test2()
+{
+	return
+	println("This will never be printed")
+}
 
 


### PR DESCRIPTION
## Summary

- add a documentation landing page and REPL-based getting-started guide
- document the current Balu language, built-in functions, and diagnostics
- add a complete reference for the `bc` command-line compiler
- expand the repository README with project highlights and key entry points

## Testing

- `dotnet test src/Balu.Tests/Balu.Tests.csproj` (21,648 tests passed)
- verified `bc --help`, internal documentation links, and Markdown whitespace