### PR TITLE
Handle compiler command-line errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,14 @@
 
 Balu is a from-scratch compiler and language project inspired by terrajobst's Minsk tutorial. The repository is a .NET/Visual Studio solution centered around `src/Balu.sln`.
 
+## GitHub Repository
+
+- The canonical GitHub repository is `ReneVogt/Balu`.
+- Unqualified issue and pull request numbers refer to `ReneVogt/Balu` unless the user explicitly names another repository.
+- The reference to terrajobst describes the project's inspiration; do not infer that GitHub issues or pull requests belong to terrajobst's repository.
+- Use the configured GitHub MCP for all remote GitHub queries and actions, including issues, pull requests, comments, branches, releases, and repository content. Do not use direct web requests for these operations.
+- Continue to use the local Git CLI for operations on the local worktree and local branches.
+
 ## Main Projects
 
 - `src/Balu`: Backend compiler library. Contains syntax trees, parser/lexer, binder, symbols, lowering, diagnostics, IL emission, visualization, source text handling, and editor-oriented classification.

--- a/docs/language/diagnostics.md
+++ b/docs/language/diagnostics.md
@@ -136,14 +136,17 @@ is:
 | Exit code | Meaning |
 | ---: | --- |
 | `0` | Help was displayed, or compilation succeeded, possibly with warnings |
-| `1` | An error occurred or no source file was supplied |
+| `1` | Compilation completed with error diagnostics |
+| `2` | The command-line invocation is invalid |
+| `3` | The compiler tool could not complete |
 
 The `bc` quiet option suppresses diagnostics as well as informational output;
 the exit code is then the only error indication. See the
 [compiler command-line reference](../tools/compiler.md) for details.
 
-Malformed options are parsed before normal error handling. They can produce
-output despite quiet mode and terminate with a different nonzero process code.
+Invocation and tool failures are reported without a `BLxxxx` diagnostic ID or
+source location. This lets callers distinguish them from source and emitter
+diagnostics.
 
 The REPL displays diagnostics and does not commit a submission that has errors.
 Warnings are displayed but do not prevent execution or persistence of the

--- a/docs/tools/compiler.md
+++ b/docs/tools/compiler.md
@@ -143,15 +143,10 @@ Quiet mode suppresses all output produced by `bc`, including:
 - the compiler banner
 - compilation and emission progress
 - warnings and errors
-- caught exception messages
+- invocation and tool error messages
 
 The process exit code is the only success or failure indication in quiet mode.
 Use it only when the caller reliably checks the exit code.
-
-Malformed options are parsed before `bc` enters its normal error-handling path.
-For example, an option that is missing its required value can produce an
-unhandled Mono.Options error, output despite `-q`, and a platform-dependent
-failure exit code.
 
 ## Compile one source file
 
@@ -272,6 +267,13 @@ C:\work\program.b(3,5): error BL1005: Undefined name 'value'.
 
 See [Diagnostics](../language/diagnostics.md) for diagnostic IDs and severities.
 
+Invalid invocations and tool failures are not compiler diagnostics and have no
+`BLxxxx` ID or source location. They are written to standard error in this form:
+
+```text
+bc: error: Missing required value for option '-o'.
+```
+
 `Done.` currently indicates that the compiler completed its normal pipeline;
 it can still be printed when diagnostics contain errors. Always use the exit
 code to determine success.
@@ -281,12 +283,11 @@ code to determine success.
 | Exit code | Meaning |
 | ---: | --- |
 | `0` | Help was displayed, or compilation completed without errors |
-| `1` | No source was supplied, diagnostics contain errors, or a handled failure occurred |
+| `1` | Compilation completed with error diagnostics |
+| `2` | The command-line invocation is invalid, for example because an option value or source file argument is missing |
+| `3` | The compiler tool could not complete, for example because an input file could not be read |
 
 Warnings do not change a successful exit code.
-
-Malformed options can terminate before this normal exit-code handling and may
-produce a different nonzero process code.
 
 ## Running the result
 

--- a/src/Balu.Tests/Balu.Tests.csproj
+++ b/src/Balu.Tests/Balu.Tests.csproj
@@ -24,6 +24,7 @@
 	<ItemGroup>
 		<ProjectReference Include="..\Balu.Interpretation\Balu.Interpretation.csproj" />
 		<ProjectReference Include="..\Balu\Balu.csproj" />
+		<ProjectReference Include="..\bc\bc.csproj" />
 	</ItemGroup>
 
 	<Target Name="CopyReferenceAssembliesForEmitterTests" AfterTargets="CopyFilesToOutputDirectory">

--- a/src/Balu.Tests/CompilerTests/CommandLineTests.cs
+++ b/src/Balu.Tests/CompilerTests/CommandLineTests.cs
@@ -1,0 +1,100 @@
+using System.IO;
+using Xunit;
+
+namespace Balu.Tests.CompilerTests;
+
+public sealed class CommandLineTests
+{
+    [Fact]
+    public void Compiler_MissingOptionValue_ReturnsInvocationError()
+    {
+        var (ExitCode, _, Error)= Run(["-o"]);
+
+        Assert.Equal(2, ExitCode);
+        Assert.StartsWith("bc: error: ", Error);
+        Assert.DoesNotContain("Exception", Error);
+    }
+
+    [Fact]
+    public void Compiler_UnknownOption_ReturnsInvocationError()
+    {
+        var (ExitCode, Output, Error)= Run(["--bogus"]);
+
+        Assert.Equal(2, ExitCode);
+        Assert.StartsWith("bc: error: ", Error);
+        Assert.DoesNotContain("Compiling", Output);
+    }
+
+    [Fact]
+    public void Compiler_NoSourceFiles_ReturnsInvocationError()
+    {
+        var (ExitCode, _, Error)= Run([]);
+
+        Assert.Equal(2, ExitCode);
+        Assert.Contains("bc: error: need at least one source file.", Error);
+    }
+
+    [Fact]
+    public void Compiler_QuietInvocationError_SuppressesOutput()
+    {
+        var (ExitCode, Output, Error)= Run(["-o", "-q"]);
+
+        Assert.Equal(2, ExitCode);
+        Assert.Empty(Output);
+        Assert.Empty(Error);
+    }
+
+    [Fact]
+    public void Compiler_MissingSourceFile_ReturnsToolError()
+    {
+        var missingPath = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.b");
+
+        var (ExitCode, Output, Error)= Run([missingPath, "-q"]);
+
+        Assert.Equal(3, ExitCode);
+        Assert.Empty(Output);
+        Assert.Empty(Error);
+    }
+
+    [Fact]
+    public void Compiler_SourceDiagnostic_ReturnsCompilationError()
+    {
+        var directory = Directory.CreateTempSubdirectory("BaluCompilerTests-");
+        try
+        {
+            var sourcePath = Path.Combine(directory.FullName, "program.b");
+            File.WriteAllText(sourcePath, "function main() { missing() }");
+
+            var (ExitCode, Output, Error)= Run([sourcePath, "-q"]);
+
+            Assert.Equal(1, ExitCode);
+            Assert.Empty(Output);
+            Assert.Empty(Error);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Compiler_Help_ReturnsSuccess()
+    {
+        var (ExitCode, Output, Error)= Run(["--help"]);
+
+        Assert.Equal(0, ExitCode);
+        Assert.Contains("Usage: bc <source-paths> [options]", Output);
+        Assert.Empty(Error);
+    }
+
+    static (int ExitCode, string Output, string Error) Run(string[] arguments)
+    {
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+        var program = new global::Program(output, error);
+
+        var exitCode = program.Run(arguments);
+
+        return (exitCode, output.ToString(), error.ToString());
+    }
+}

--- a/src/HelloWorld/hello.b
+++ b/src/HelloWorld/hello.b
@@ -1,12 +1,6 @@
 function main()
 {
 	test()
-	if false
-	{
-		println("This will never be printed")
-		// comment
-		println("This neither")
-	}
 }
 
 function test()

--- a/src/HelloWorld/world.b
+++ b/src/HelloWorld/world.b
@@ -1,7 +1,6 @@
 function test2()
 {
 	return
-	println("This will never be printed")
 }
 
 

--- a/src/bc/Program.cs
+++ b/src/bc/Program.cs
@@ -12,8 +12,24 @@ using Mono.Options;
 
 sealed class Program
 {
-    static bool quiet;
-    public static int Main(string[] args)
+    const int Success = 0;
+    const int CompilationError = 1;
+    const int InvocationError = 2;
+    const int ToolError = 3;
+
+    readonly TextWriter output;
+    readonly TextWriter error;
+    bool quiet;
+
+    internal Program(TextWriter output, TextWriter error)
+    {
+        this.output = output;
+        this.error = error;
+    }
+
+    public static int Main(string[] args) => new Program(Console.Out, Console.Error).Run(args);
+
+    internal int Run(string[] args)
     {
         List<string> references = [];
         string outputPath = string.Empty;
@@ -24,22 +40,36 @@ sealed class Program
 
         var options = new OptionSet
         {
-            "Usage: bc <soure-paths> [options]",
+            "Usage: bc <source-paths> [options]",
             { "r=", "The {path} of an assembly to reference.", v => references.Add(v) },
             { "o=", "The output {path} of the assembly to create.", v => outputPath = v },
             { "s=", "The optional symbol {path} of the pdb to create.", v => symbolPath = v },
             { "m=", "The module {name} of the assembly to create.", v => moduleName = v },
             { "q", _ => quiet = true },
-            { "<>", v => sourcePaths.Add(v) },
             { "?|h|help", "Shows help.", _ => helpRequested = true }
         };
 
-        options.Parse(args);
+        quiet = args.TakeWhile(argument => argument != "--").Any(IsQuietOption);
+        try
+        {
+            sourcePaths.AddRange(options.Parse(args));
+            var unknownOption = sourcePaths.FirstOrDefault(path => path.StartsWith('-'));
+            if (unknownOption is not null)
+            {
+                LogError($"Unknown option '{unknownOption}'.");
+                return InvocationError;
+            }
+        }
+        catch (OptionException parseError)
+        {
+            LogError(parseError.Message);
+            return InvocationError;
+        }
 
         if (helpRequested)
         {
-            options.WriteOptionDescriptions(Console.Out);
-            return 0;
+            options.WriteOptionDescriptions(output);
+            return Success;
         }
 
         LogInfo($"Balu compiler v{Assembly.GetExecutingAssembly().GetName().Version}");
@@ -49,7 +79,7 @@ sealed class Program
             if (sourcePaths.Count == 0)
             {
                 LogError("need at least one source file.");
-                return 1;
+                return InvocationError;
             }
 
             if (string.IsNullOrWhiteSpace(outputPath))
@@ -67,37 +97,39 @@ sealed class Program
             var diagnostics = compilation.Emit(moduleName, [.. references], outputPath, symbolPath);
             LogDiagnostics(diagnostics);
             LogInfo("Done.");
-            return diagnostics.HasErrors() ? 1 : 0;
+            return diagnostics.HasErrors() ? CompilationError : Success;
         }
         catch (Exception error)
         {
             LogError(error.Message);
-            return 1;
+            return ToolError;
         }
     }
 
-    static SyntaxTree Parse(string path)
+    static bool IsQuietOption(string argument) => argument is "-q" or "/q" or "--q";
+
+    SyntaxTree Parse(string path)
     {
         LogInfo($"Compiling '{path}'...");
         return SyntaxTree.Load(Path.GetFullPath(path));
     }
 
-    static void LogInfo(string message)
+    void LogInfo(string message)
     {
         if (!quiet)
-            Console.WriteLine(message);
+            output.WriteLine(message);
     }
 
-    static void LogError(string message)
+    void LogError(string message)
     {
         if (quiet) return;
-        Console.Error.WriteColoredText("error: ", ConsoleColor.Red);
-        Console.Error.WriteColoredText(message, ConsoleColor.Red);
-        Console.Error.WriteLine();
+        error.WriteColoredText("bc: error: ", ConsoleColor.Red);
+        error.WriteColoredText(message, ConsoleColor.Red);
+        error.WriteLine();
     }
-    static void LogDiagnostics(IEnumerable<Diagnostic> diagnostics)
+    void LogDiagnostics(IEnumerable<Diagnostic> diagnostics)
     {
-        if (!quiet) 
-            Console.Error.WriteDiagnostics(diagnostics);
+        if (!quiet)
+            error.WriteDiagnostics(diagnostics);
     }
 }

--- a/src/bc/bc.csproj
+++ b/src/bc/bc.csproj
@@ -19,6 +19,10 @@
 		<ProjectReference Include="..\Balu\Balu.csproj" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<InternalsVisibleTo Include="Balu.Tests" />
+	</ItemGroup>
+
 	<Target Name="GetBaluCompilerPackageFiles"
 			DependsOnTargets="Build;ComputeFilesToPublish"
 			Returns="@(_BaluCompilerPackageFile)">


### PR DESCRIPTION
Closes #113

## Summary

- handle malformed and unknown command-line options without unhandled exceptions
- distinguish compilation errors, invalid invocations, and tool failures with exit codes 1, 2, and 3
- keep invocation and tool errors separate from `BLxxxx` compiler diagnostics
- document the CLI error format and exit-code contract
- add regression coverage for command-line behavior

## Testing

- `dotnet test src/Balu.Tests/Balu.Tests.csproj`
- `dotnet build src/bc/bc.csproj --configuration Release`