### PR TITLE
Write interpreter visualizations to configured output

### DIFF
--- a/src/Balu.Interpretation/Interpreter.cs
+++ b/src/Balu.Interpretation/Interpreter.cs
@@ -54,14 +54,14 @@ public sealed class Interpreter : IDisposable
             {
                 Out.WriteColoredText("Syntax:", ConsoleColor.Yellow);
                 Out.WriteLine();
-                compilation.WriteSyntaxTrees(Console.Out);
+                compilation.WriteSyntaxTrees(Out);
             }
 
             if (WriteProgram)
             {
                 Out.WriteColoredText("Program:", ConsoleColor.Yellow);
                 Out.WriteLine();
-                compilation.WriteBoundGlobalTree(Console.Out);
+                compilation.WriteBoundGlobalTree(Out);
             }
         }
 

--- a/src/Balu.Tests/InterpreterTests/InterpreterTests.cs
+++ b/src/Balu.Tests/InterpreterTests/InterpreterTests.cs
@@ -15,6 +15,40 @@ namespace Balu.Tests.InterpreterTests;
 public sealed class InterpreterTests
 {
     [Fact]
+    public void Interpreter_WriteSyntax_WritesToOut()
+    {
+        using var output = new StringWriter();
+        using var interpreter = new Interpreter(ReferenceProvider.References)
+        {
+            Out = output,
+            WriteSyntax = true
+        };
+
+        var diagnostics = interpreter.Execute("1");
+
+        Assert.False(diagnostics.HasErrors());
+        Assert.Contains("Syntax:", output.ToString());
+        Assert.Contains("CompilationUnit", output.ToString());
+    }
+
+    [Fact]
+    public void Interpreter_WriteProgram_WritesToOut()
+    {
+        using var output = new StringWriter();
+        using var interpreter = new Interpreter(ReferenceProvider.References)
+        {
+            Out = output,
+            WriteProgram = true
+        };
+
+        var diagnostics = interpreter.Execute("1");
+
+        Assert.False(diagnostics.HasErrors());
+        Assert.Contains("Program:", output.ToString());
+        Assert.Contains("function <eval>()", output.ToString());
+    }
+
+    [Fact]
     public void Interpreter_CopiesReferences()
     {
         var references = ReferenceProvider.References.ToArray();


### PR DESCRIPTION
## Summary
- write syntax-tree visualizations to the interpreter's configured `Out` writer
- write bound-program visualizations to the same configured writer
- cover both visualization modes with interpreter regression tests

## Testing
- `dotnet test "src\Balu.Tests\Balu.Tests.csproj" --filter "FullyQualifiedName~Interpreter_WriteSyntax|FullyQualifiedName~Interpreter_WriteProgram"`
- `dotnet test "src\Balu.Tests\Balu.Tests.csproj"`

Closes #112