### PR TITLE
Fix REPL rendering at console buffer bottom

### DIFF
--- a/src/bi/BaluRepl.cs
+++ b/src/bi/BaluRepl.cs
@@ -121,7 +121,6 @@ sealed class BaluRepl : Repl, IDisposable
 
         var line = syntaxTree.Text.Lines[lineIndex];
         var classifiedSpans = Classifier.Classify(syntaxTree, line.Span);
-        int width = 0;
         foreach (var classifiedSpan in classifiedSpans)
         {
             var color = classifiedSpan.Classification switch
@@ -136,9 +135,7 @@ sealed class BaluRepl : Repl, IDisposable
             };
 
             Console.Out.WriteColoredText(syntaxTree.Text.ToString(classifiedSpan.Span), color);
-            width += classifiedSpan.Span.Length;
         }
-        Console.Out.Write(new string(' ', Console.WindowWidth-2-width));
         return syntaxTree;
     }
 

--- a/src/bi/Repl.cs
+++ b/src/bi/Repl.cs
@@ -55,8 +55,7 @@ abstract class Repl
         }
 
         readonly LineRenderHandler lineRenderer;
-        readonly int cursorTop;
-        int renderedLinesCount, cursorX, cursorY, updatesInProgress;
+        int cursorTop, renderedLinesCount, cursorX, cursorY, updatesInProgress;
 
         public Document SubmissionDocument { get; }
         public int CursorX
@@ -98,21 +97,37 @@ abstract class Repl
         {
             if (updatesInProgress > 0) return;
             Console.CursorVisible = false;
-            Console.SetCursorPosition(0, cursorTop);
             object? state = null;
             for (int i = 0; i < SubmissionDocument.Count; i++)
             {
+                EnsureLineFitsInConsoleBuffer(i);
+                Console.SetCursorPosition(0, cursorTop + i);
                 Console.ForegroundColor = ConsoleColor.Green;
                 Console.Write(i == 0 ? "» " : "· ");
                 Console.ResetColor();
                 state = lineRenderer(SubmissionDocument, i, state);
+                Console.Write(new string(' ', Console.WindowWidth - SubmissionDocument[i].Length - 2));
             }
 
             int blankLines = renderedLinesCount - SubmissionDocument.Count;
-            while (blankLines-- > 0) Console.WriteLine(new string(' ', Console.WindowWidth));
+            for (int i = 0; i < blankLines; i++)
+            {
+                int lineIndex = SubmissionDocument.Count + i;
+                EnsureLineFitsInConsoleBuffer(lineIndex);
+                Console.SetCursorPosition(0, cursorTop + lineIndex);
+                Console.Write(new string(' ', Console.WindowWidth));
+            }
             renderedLinesCount = SubmissionDocument.Count;
             Console.CursorVisible = true;
             UpdateCursorPosition();
+        }
+        void EnsureLineFitsInConsoleBuffer(int lineIndex)
+        {
+            if (cursorTop + lineIndex < Console.BufferHeight) return;
+
+            Console.SetCursorPosition(0, Console.BufferHeight - 1);
+            Console.WriteLine();
+            if (cursorTop > 0) cursorTop--;
         }
 
         void UpdateCursorPosition()
@@ -256,7 +271,7 @@ abstract class Repl
 
     protected virtual object? RenderLine(IReadOnlyList<string> lines, int lineIndex, object? state)
     {
-        Console.WriteLine(lines[lineIndex]);
+        Console.Write(lines[lineIndex]);
         return state;
     }
 


### PR DESCRIPTION
## Summary

- keep the submission view's console anchor in sync when rendering reaches the buffer bottom
- position and clear each submission line explicitly instead of relying on renderer-induced line wrapping
- keep syntax coloring renderers focused on writing content without advancing the cursor

## Cause

`SubmissionView` captured `Console.CursorTop` once and treated it as immutable. When a multiline submission started at the last buffer row, rendering the next line scrolled the console but left that anchor unchanged. `UpdateCursorPosition` then attempted to set `CursorTop` to `BufferHeight`, causing an `ArgumentOutOfRangeException`.

## Testing

- `dotnet build src/bi/bi.csproj --no-restore`
- `dotnet test src/Balu.Tests/Balu.Tests.csproj` (21,657 passed)

The interactive regression scenario requires a real console: move the prompt to the final buffer row, enter `function test()`, and press Enter to start the second line.