### PR TITLE
Separate test projects

### DIFF
--- a/src/Balu.Interpretation.Tests/Balu.Interpretation.Tests.csproj
+++ b/src/Balu.Interpretation.Tests/Balu.Interpretation.Tests.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+		<PackageReference Include="Mono.Cecil" Version="0.11.4" />
+		<PackageReference Include="xunit" Version="2.4.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.2.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Balu.Interpretation\Balu.Interpretation.csproj" />
+		<ProjectReference Include="..\TestHelpers\TestHelpers.csproj" />
+	</ItemGroup>
+
+	<Target Name="CopyReferenceAssembliesForInterpreterTests" AfterTargets="CopyFilesToOutputDirectory">
+		<ItemGroup>
+			<_InterpreterTestReference Include="@(ReferencePath)" Condition="'%(Filename)' == 'System.Runtime' OR '%(Filename)' == 'System.Runtime.Extensions' OR '%(Filename)' == 'System.Console'" />
+		</ItemGroup>
+		<MakeDir Directories="$(TargetDir)reference-assemblies" />
+		<Copy SourceFiles="@(_InterpreterTestReference)" DestinationFolder="$(TargetDir)reference-assemblies" SkipUnchangedFiles="true">
+			<Output TaskParameter="CopiedFiles" ItemName="FileWrites" />
+		</Copy>
+	</Target>
+
+</Project>

--- a/src/Balu.Interpretation.Tests/InterpreterTests.cs
+++ b/src/Balu.Interpretation.Tests/InterpreterTests.cs
@@ -5,12 +5,12 @@ using System.Security.Cryptography;
 using System.Text;
 using Balu.Diagnostics;
 using Balu.Interpretation;
-using Balu.Tests.TestHelper;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
+using TestHelpers;
 using Xunit;
 
-namespace Balu.Tests.InterpreterTests;
+namespace Balu.Interpretation.Tests;
 
 public sealed class InterpreterTests
 {

--- a/src/Balu.Tests/Balu.Tests.csproj
+++ b/src/Balu.Tests/Balu.Tests.csproj
@@ -22,9 +22,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\Balu.Interpretation\Balu.Interpretation.csproj" />
 		<ProjectReference Include="..\Balu\Balu.csproj" />
-		<ProjectReference Include="..\bc\bc.csproj" />
+		<ProjectReference Include="..\TestHelpers\TestHelpers.csproj" />
 	</ItemGroup>
 
 	<Target Name="CopyReferenceAssembliesForEmitterTests" AfterTargets="CopyFilesToOutputDirectory">

--- a/src/Balu.Tests/BinderTests/ShadowedSymbolDiagnosticTests.cs
+++ b/src/Balu.Tests/BinderTests/ShadowedSymbolDiagnosticTests.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using Balu.Tests.TestHelper;
+using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.BinderTests;

--- a/src/Balu.Tests/BinderTests/UnreachableCodeTests.cs
+++ b/src/Balu.Tests/BinderTests/UnreachableCodeTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.BinderTests;

--- a/src/Balu.Tests/EmitterTests/AssignmentStatementTests.cs
+++ b/src/Balu.Tests/EmitterTests/AssignmentStatementTests.cs
@@ -1,5 +1,5 @@
 ﻿using Balu.Symbols;
-using Balu.Tests.TestHelper;
+using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.EmitterTests;

--- a/src/Balu.Tests/EmitterTests/ConstantFoldingTests.cs
+++ b/src/Balu.Tests/EmitterTests/ConstantFoldingTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.EmitterTests;

--- a/src/Balu.Tests/EmitterTests/DebugSymbolTests.cs
+++ b/src/Balu.Tests/EmitterTests/DebugSymbolTests.cs
@@ -4,7 +4,7 @@ using System.Security.Cryptography;
 using System.Text;
 using Balu.Diagnostics;
 using Balu.Syntax;
-using Balu.Tests.TestHelper;
+using TestHelpers;
 using Balu.Text;
 using Mono.Cecil;
 using Mono.Cecil.Cil;

--- a/src/Balu.Tests/EmitterTests/DoWhileTests.cs
+++ b/src/Balu.Tests/EmitterTests/DoWhileTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.EmitterTests;

--- a/src/Balu.Tests/EmitterTests/FileEmissionTests.cs
+++ b/src/Balu.Tests/EmitterTests/FileEmissionTests.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using Balu.Diagnostics;
 using Balu.Emit;
 using Balu.Syntax;
-using Balu.Tests.TestHelper;
+using TestHelpers;
 using Mono.Cecil;
 using Xunit;
 

--- a/src/Balu.Tests/EmitterTests/ForTests.cs
+++ b/src/Balu.Tests/EmitterTests/ForTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.EmitterTests;

--- a/src/Balu.Tests/EmitterTests/FunctionDeclarationTests.cs
+++ b/src/Balu.Tests/EmitterTests/FunctionDeclarationTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.EmitterTests;

--- a/src/Balu.Tests/EmitterTests/GlobalScopeTests.cs
+++ b/src/Balu.Tests/EmitterTests/GlobalScopeTests.cs
@@ -1,5 +1,5 @@
 ﻿using Balu.Symbols;
-using Balu.Tests.TestHelper;
+using TestHelpers;
 using System;
 using Xunit;
 

--- a/src/Balu.Tests/EmitterTests/IfStatementTests.cs
+++ b/src/Balu.Tests/EmitterTests/IfStatementTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.EmitterTests;

--- a/src/Balu.Tests/EmitterTests/LocalVariableScopeTests.cs
+++ b/src/Balu.Tests/EmitterTests/LocalVariableScopeTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.EmitterTests;

--- a/src/Balu.Tests/EmitterTests/PostfixOperatorTests.cs
+++ b/src/Balu.Tests/EmitterTests/PostfixOperatorTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.EmitterTests;

--- a/src/Balu.Tests/EmitterTests/PrefixOperatorTests.cs
+++ b/src/Balu.Tests/EmitterTests/PrefixOperatorTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.EmitterTests;

--- a/src/Balu.Tests/EmitterTests/ReferenceLifetimeTests.cs
+++ b/src/Balu.Tests/EmitterTests/ReferenceLifetimeTests.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using Balu.Diagnostics;
 using Balu.Emit;
 using Balu.Syntax;
-using Balu.Tests.TestHelper;
+using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.EmitterTests;

--- a/src/Balu.Tests/EmitterTests/ShortCircuitedLogicalBinaryExpressionTests.cs
+++ b/src/Balu.Tests/EmitterTests/ShortCircuitedLogicalBinaryExpressionTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.EmitterTests;

--- a/src/Balu.Tests/EmitterTests/StringConcatTests.cs
+++ b/src/Balu.Tests/EmitterTests/StringConcatTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.EmitterTests;

--- a/src/Balu.Tests/EmitterTests/WhileTests.cs
+++ b/src/Balu.Tests/EmitterTests/WhileTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.EmitterTests;

--- a/src/Balu.Tests/ExecutionTests/AssignmentExpressionTests.cs
+++ b/src/Balu.Tests/ExecutionTests/AssignmentExpressionTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.CompilationTests.ExecutionTests;

--- a/src/Balu.Tests/ExecutionTests/BinaryOperatorTests.cs
+++ b/src/Balu.Tests/ExecutionTests/BinaryOperatorTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.CompilationTests.ExecutionTests;

--- a/src/Balu.Tests/ExecutionTests/BlockStatementTests.cs
+++ b/src/Balu.Tests/ExecutionTests/BlockStatementTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.CompilationTests.ExecutionTests;

--- a/src/Balu.Tests/ExecutionTests/BreakStatementTests.cs
+++ b/src/Balu.Tests/ExecutionTests/BreakStatementTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.CompilationTests.ExecutionTests;

--- a/src/Balu.Tests/ExecutionTests/CallExpressionTests.cs
+++ b/src/Balu.Tests/ExecutionTests/CallExpressionTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.CompilationTests.ExecutionTests;

--- a/src/Balu.Tests/ExecutionTests/ContinueStatementTests.cs
+++ b/src/Balu.Tests/ExecutionTests/ContinueStatementTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.CompilationTests.ExecutionTests;

--- a/src/Balu.Tests/ExecutionTests/DoWhileStatementTests.cs
+++ b/src/Balu.Tests/ExecutionTests/DoWhileStatementTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.CompilationTests.ExecutionTests;

--- a/src/Balu.Tests/ExecutionTests/ForStatementTests.cs
+++ b/src/Balu.Tests/ExecutionTests/ForStatementTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.CompilationTests.ExecutionTests;

--- a/src/Balu.Tests/ExecutionTests/FunctionDeclarationTests.cs
+++ b/src/Balu.Tests/ExecutionTests/FunctionDeclarationTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.CompilationTests.ExecutionTests;

--- a/src/Balu.Tests/ExecutionTests/GlobalStatementsTests.cs
+++ b/src/Balu.Tests/ExecutionTests/GlobalStatementsTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.CompilationTests.ExecutionTests;

--- a/src/Balu.Tests/ExecutionTests/IfStatementTests.cs
+++ b/src/Balu.Tests/ExecutionTests/IfStatementTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.CompilationTests.ExecutionTests;

--- a/src/Balu.Tests/ExecutionTests/MiscellaneousTests.cs
+++ b/src/Balu.Tests/ExecutionTests/MiscellaneousTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.CompilationTests.ExecutionTests;

--- a/src/Balu.Tests/ExecutionTests/NameExpressionTests.cs
+++ b/src/Balu.Tests/ExecutionTests/NameExpressionTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.CompilationTests.ExecutionTests;

--- a/src/Balu.Tests/ExecutionTests/PostfixExpressionTests.cs
+++ b/src/Balu.Tests/ExecutionTests/PostfixExpressionTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.CompilationTests.ExecutionTests;

--- a/src/Balu.Tests/ExecutionTests/PrefixExpressionTests.cs
+++ b/src/Balu.Tests/ExecutionTests/PrefixExpressionTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.CompilationTests.ExecutionTests;

--- a/src/Balu.Tests/ExecutionTests/RedeclaringSymbolsTests.cs
+++ b/src/Balu.Tests/ExecutionTests/RedeclaringSymbolsTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.CompilationTests.ExecutionTests;

--- a/src/Balu.Tests/ExecutionTests/ReturnStatementTests.cs
+++ b/src/Balu.Tests/ExecutionTests/ReturnStatementTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.CompilationTests.ExecutionTests;

--- a/src/Balu.Tests/ExecutionTests/UnaryOperatorTests.cs
+++ b/src/Balu.Tests/ExecutionTests/UnaryOperatorTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.CompilationTests.ExecutionTests;

--- a/src/Balu.Tests/ExecutionTests/VariableDeclarationStatementTests.cs
+++ b/src/Balu.Tests/ExecutionTests/VariableDeclarationStatementTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.CompilationTests.ExecutionTests;

--- a/src/Balu.Tests/ExecutionTests/WhileStatementTests.cs
+++ b/src/Balu.Tests/ExecutionTests/WhileStatementTests.cs
@@ -1,4 +1,4 @@
-﻿using Balu.Tests.TestHelper;
+﻿using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.CompilationTests.ExecutionTests;

--- a/src/Balu.Tests/LexerTests/StringTestts.cs
+++ b/src/Balu.Tests/LexerTests/StringTestts.cs
@@ -1,5 +1,5 @@
 using Balu.Syntax;
-using Balu.Tests.TestHelper;
+using TestHelpers;
 using Balu.Diagnostics;
 using Balu.Text;
 using Balu.Visualization;

--- a/src/Balu.Tests/LexerTests/TriviaTests.cs
+++ b/src/Balu.Tests/LexerTests/TriviaTests.cs
@@ -1,5 +1,5 @@
 using Balu.Syntax;
-using Balu.Tests.TestHelper;
+using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.Syntax.LexerTests;

--- a/src/Balu.Tests/ParserTests/BinaryExpressionTests.cs
+++ b/src/Balu.Tests/ParserTests/BinaryExpressionTests.cs
@@ -1,7 +1,7 @@
 using Balu.Syntax;
 using System.Collections.Generic;
 using System.Linq;
-using Balu.Tests.TestHelper;
+using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.CompilationTests.ParserTests;

--- a/src/Balu.Tests/ParserTests/BooleanKeywordsTests.cs
+++ b/src/Balu.Tests/ParserTests/BooleanKeywordsTests.cs
@@ -1,5 +1,5 @@
 using Balu.Syntax;
-using Balu.Tests.TestHelper;
+using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.CompilationTests.ParserTests;

--- a/src/Balu.Tests/ParserTests/PostfixExpressionTests.cs
+++ b/src/Balu.Tests/ParserTests/PostfixExpressionTests.cs
@@ -1,5 +1,5 @@
 using Balu.Syntax;
-using Balu.Tests.TestHelper;
+using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.CompilationTests.ParserTests;

--- a/src/Balu.Tests/ParserTests/PrefixExpressionTests.cs
+++ b/src/Balu.Tests/ParserTests/PrefixExpressionTests.cs
@@ -1,5 +1,5 @@
 using Balu.Syntax;
-using Balu.Tests.TestHelper;
+using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.CompilationTests.ParserTests;

--- a/src/Balu.Tests/ParserTests/TriviaTests.cs
+++ b/src/Balu.Tests/ParserTests/TriviaTests.cs
@@ -1,5 +1,5 @@
 using Balu.Syntax;
-using Balu.Tests.TestHelper;
+using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.CompilationTests.ParserTests;

--- a/src/Balu.Tests/ParserTests/UnaryExpressionTests.cs
+++ b/src/Balu.Tests/ParserTests/UnaryExpressionTests.cs
@@ -1,7 +1,7 @@
 using Balu.Syntax;
 using System.Collections.Generic;
 using System.Linq;
-using Balu.Tests.TestHelper;
+using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.CompilationTests.ParserTests;

--- a/src/Balu.sln
+++ b/src/Balu.sln
@@ -35,6 +35,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Balu.Interpretation", "Balu
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Balu.VSIX", "Balu.VSIX\Balu.VSIX.csproj", "{00324CA7-F14B-496A-AC3F-D9BBA72DE241}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestHelpers", "TestHelpers\TestHelpers.csproj", "{AE678D2A-C682-4265-9CFA-124058499D68}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "bc.Tests", "bc.Tests\bc.Tests.csproj", "{4A911B71-77DE-4938-998E-031523D9196D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Balu.Interpretation.Tests", "Balu.Interpretation.Tests\Balu.Interpretation.Tests.csproj", "{7C47C45E-FBEE-4F65-AB4A-B6BFEC4EF605}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -153,6 +159,42 @@ Global
 		{00324CA7-F14B-496A-AC3F-D9BBA72DE241}.Release|arm64.Build.0 = Release|arm64
 		{00324CA7-F14B-496A-AC3F-D9BBA72DE241}.Release|x86.ActiveCfg = Release|x86
 		{00324CA7-F14B-496A-AC3F-D9BBA72DE241}.Release|x86.Build.0 = Release|x86
+		{AE678D2A-C682-4265-9CFA-124058499D68}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AE678D2A-C682-4265-9CFA-124058499D68}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AE678D2A-C682-4265-9CFA-124058499D68}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{AE678D2A-C682-4265-9CFA-124058499D68}.Debug|arm64.Build.0 = Debug|Any CPU
+		{AE678D2A-C682-4265-9CFA-124058499D68}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AE678D2A-C682-4265-9CFA-124058499D68}.Debug|x86.Build.0 = Debug|Any CPU
+		{AE678D2A-C682-4265-9CFA-124058499D68}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AE678D2A-C682-4265-9CFA-124058499D68}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AE678D2A-C682-4265-9CFA-124058499D68}.Release|arm64.ActiveCfg = Release|Any CPU
+		{AE678D2A-C682-4265-9CFA-124058499D68}.Release|arm64.Build.0 = Release|Any CPU
+		{AE678D2A-C682-4265-9CFA-124058499D68}.Release|x86.ActiveCfg = Release|Any CPU
+		{AE678D2A-C682-4265-9CFA-124058499D68}.Release|x86.Build.0 = Release|Any CPU
+		{4A911B71-77DE-4938-998E-031523D9196D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4A911B71-77DE-4938-998E-031523D9196D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4A911B71-77DE-4938-998E-031523D9196D}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{4A911B71-77DE-4938-998E-031523D9196D}.Debug|arm64.Build.0 = Debug|Any CPU
+		{4A911B71-77DE-4938-998E-031523D9196D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4A911B71-77DE-4938-998E-031523D9196D}.Debug|x86.Build.0 = Debug|Any CPU
+		{4A911B71-77DE-4938-998E-031523D9196D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4A911B71-77DE-4938-998E-031523D9196D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4A911B71-77DE-4938-998E-031523D9196D}.Release|arm64.ActiveCfg = Release|Any CPU
+		{4A911B71-77DE-4938-998E-031523D9196D}.Release|arm64.Build.0 = Release|Any CPU
+		{4A911B71-77DE-4938-998E-031523D9196D}.Release|x86.ActiveCfg = Release|Any CPU
+		{4A911B71-77DE-4938-998E-031523D9196D}.Release|x86.Build.0 = Release|Any CPU
+		{7C47C45E-FBEE-4F65-AB4A-B6BFEC4EF605}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7C47C45E-FBEE-4F65-AB4A-B6BFEC4EF605}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7C47C45E-FBEE-4F65-AB4A-B6BFEC4EF605}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{7C47C45E-FBEE-4F65-AB4A-B6BFEC4EF605}.Debug|arm64.Build.0 = Debug|Any CPU
+		{7C47C45E-FBEE-4F65-AB4A-B6BFEC4EF605}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7C47C45E-FBEE-4F65-AB4A-B6BFEC4EF605}.Debug|x86.Build.0 = Debug|Any CPU
+		{7C47C45E-FBEE-4F65-AB4A-B6BFEC4EF605}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7C47C45E-FBEE-4F65-AB4A-B6BFEC4EF605}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7C47C45E-FBEE-4F65-AB4A-B6BFEC4EF605}.Release|arm64.ActiveCfg = Release|Any CPU
+		{7C47C45E-FBEE-4F65-AB4A-B6BFEC4EF605}.Release|arm64.Build.0 = Release|Any CPU
+		{7C47C45E-FBEE-4F65-AB4A-B6BFEC4EF605}.Release|x86.ActiveCfg = Release|Any CPU
+		{7C47C45E-FBEE-4F65-AB4A-B6BFEC4EF605}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/TestHelpers/AnnotatedText.cs
+++ b/src/TestHelpers/AnnotatedText.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Text;
 using Balu.Text;
 
-namespace Balu.Tests.TestHelper;
+namespace TestHelpers;
 
 sealed class AnnotatedText
 {

--- a/src/TestHelpers/CompilationAsserter.cs
+++ b/src/TestHelpers/CompilationAsserter.cs
@@ -5,17 +5,17 @@ using Balu.Diagnostics;
 using Balu.Interpretation;
 using Balu.Symbols;
 using Xunit;
-namespace Balu.Tests.TestHelper;
+namespace TestHelpers;
 
-class CompilationAsserter : IDisposable
+public sealed class CompilationAsserter : IDisposable
 {
     public Interpreter Interpreter { get; } = new(ReferenceProvider.References);
 
     public void Dispose() => Interpreter.Dispose();
 
-    internal void AssertScriptEvaluation(string code, string? expectedDiagnostics = null,
-                                         IDictionary<GlobalVariableSymbol, object>? expectedGlobalVariables = null, object? value = null,
-                                         bool ignoreWarnings = true)
+    public void AssertScriptEvaluation(string code, string? expectedDiagnostics = null,
+                                       IDictionary<GlobalVariableSymbol, object>? expectedGlobalVariables = null, object? value = null,
+                                       bool ignoreWarnings = true)
     {
         var annotatedText = AnnotatedText.Parse(code);
         var actualDiagnostics = Interpreter.Execute(annotatedText.Text, ignoreWarnings);

--- a/src/TestHelpers/DiagnosticAsserter.cs
+++ b/src/TestHelpers/DiagnosticAsserter.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using Balu.Diagnostics;
 using Xunit;
 
-namespace Balu.Tests.TestHelper;
+namespace TestHelpers;
 
 static class DiagnosticAsserter
 {

--- a/src/TestHelpers/IlAsserter.cs
+++ b/src/TestHelpers/IlAsserter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
+using Balu;
 using Balu.Syntax;
 using System.IO;
 using System.Linq;
@@ -11,9 +12,9 @@ using Mono.Cecil.Cil;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Balu.Tests.TestHelper;
+namespace TestHelpers;
 
-static class IlAsserter
+public static class IlAsserter
 {
     public static void AssertIl(this string code, string methodToAssert, string expectedIL, bool script = false, bool debug = false, ITestOutputHelper? output = null)
     {

--- a/src/TestHelpers/ReferenceProvider.cs
+++ b/src/TestHelpers/ReferenceProvider.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.IO;
 
-namespace Balu.Tests.TestHelper;
+namespace TestHelpers;
 
-static class ReferenceProvider
+public static class ReferenceProvider
 {
     static readonly string referenceDirectory = Path.Combine(AppContext.BaseDirectory, "reference-assemblies");
 

--- a/src/TestHelpers/StaticCompilationAsserter.cs
+++ b/src/TestHelpers/StaticCompilationAsserter.cs
@@ -1,16 +1,17 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Balu;
 using Balu.Diagnostics;
 using Balu.Interpretation;
 using Balu.Syntax;
 using Balu.Text;
 using Xunit;
 
-namespace Balu.Tests.TestHelper;
+namespace TestHelpers;
 
-static class StaticCompilationAsserter{
+public static class StaticCompilationAsserter{
 
-    internal static void AssertScriptEvaluation(this string code, string? expectedDiagnostics = null, object? value = null, bool ignoreWarnings = true)
+    public static void AssertScriptEvaluation(this string code, string? expectedDiagnostics = null, object? value = null, bool ignoreWarnings = true)
     {
         var annotatedText = AnnotatedText.Parse(code);
         using var interpreter = new Interpreter(ReferenceProvider.References);
@@ -21,19 +22,19 @@ static class StaticCompilationAsserter{
             
         Assert.Equal(value, interpreter.Result);
     }
-    internal static void AssertProgramDiagnostics(this IEnumerable<(string hintName, string code)> files, string? diagnostics = null)
+    public static void AssertProgramDiagnostics(this IEnumerable<(string hintName, string code)> files, string? diagnostics = null)
     {
         var inputs = files.Select(x => (x.hintName, annotated: AnnotatedText.Parse(x.code))).OrderBy(x => x.hintName).ToArray();
         var compilation = Compilation.Create([.. inputs.Select(x => SyntaxTree.Parse(SourceText.From(x.annotated.Text, x.hintName)))]);
         DiagnosticAsserter.AssertDiagnostics(inputs, compilation.Diagnostics, diagnostics);
     }
-    internal static void AssertScriptDiagnostics(this IEnumerable<(string hintName, string code)> files, string? diagnostics = null, bool ignoreWarnings = true)
+    public static void AssertScriptDiagnostics(this IEnumerable<(string hintName, string code)> files, string? diagnostics = null, bool ignoreWarnings = true)
     {
         var inputs = files.Select(x => (x.hintName, annotated: AnnotatedText.Parse(x.code))).OrderBy(x => x.hintName).ToArray();
         var compilation = Compilation.CreateScript(null, [.. inputs.Select(x => SyntaxTree.Parse(SourceText.From(x.annotated.Text, x.hintName)))]);
         DiagnosticAsserter.AssertDiagnostics(inputs, compilation.Diagnostics, diagnostics, ignoreWarnings);
     }
-    internal static void AssertLexerDiagnostics(this string code, string expected)
+    public static void AssertLexerDiagnostics(this string code, string expected)
     {
         var annotatedText = AnnotatedText.Parse(code);
         SyntaxTree.ParseTokens(annotatedText.Text, out var actualDiagnostics);

--- a/src/TestHelpers/SyntaxTreeAsserter.cs
+++ b/src/TestHelpers/SyntaxTreeAsserter.cs
@@ -6,9 +6,9 @@ using Balu.Text;
 using Xunit;
 using Balu.Diagnostics;
 
-namespace Balu.Tests.TestHelper;
+namespace TestHelpers;
 
-sealed class SyntaxTreeAsserter : IDisposable
+public sealed class SyntaxTreeAsserter : IDisposable
 {
     readonly IEnumerator<object> enumerator;
     readonly bool includeTrivia, includeDiagnostics;

--- a/src/TestHelpers/TestHelpers.csproj
+++ b/src/TestHelpers/TestHelpers.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Mono.Cecil" Version="0.11.4" />
+		<PackageReference Include="xunit" Version="2.4.2" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Balu.Interpretation\Balu.Interpretation.csproj" />
+		<ProjectReference Include="..\Balu\Balu.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/bc.Tests/CommandLineTests.cs
+++ b/src/bc.Tests/CommandLineTests.cs
@@ -1,7 +1,7 @@
 using System.IO;
 using Xunit;
 
-namespace Balu.Tests.CompilerTests;
+namespace Balu.Compiler.Tests;
 
 public sealed class CommandLineTests
 {

--- a/src/bc.Tests/bc.Tests.csproj
+++ b/src/bc.Tests/bc.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+		<PackageReference Include="xunit" Version="2.4.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.2.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\bc\bc.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/bc/bc.csproj
+++ b/src/bc/bc.csproj
@@ -20,7 +20,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<InternalsVisibleTo Include="Balu.Tests" />
+		<InternalsVisibleTo Include="bc.Tests" />
 	</ItemGroup>
 
 	<Target Name="GetBaluCompilerPackageFiles"


### PR DESCRIPTION
## Summary
- move shared test helpers into a neutral `TestHelpers` project
- move `bc` command-line tests into a dedicated `bc.Tests` project
- move interpreter tests into a dedicated `Balu.Interpretation.Tests` project
- update project references and solution entries accordingly

## Verification
- `dotnet test src\bc.Tests\bc.Tests.csproj`
- `dotnet test src\Balu.Interpretation.Tests\Balu.Interpretation.Tests.csproj --no-build`
- `dotnet test src\Balu.Tests\Balu.Tests.csproj`