### PR TITLE
Fix debug symbol output handling

### DIFF
--- a/docs/tools/compiler.md
+++ b/docs/tools/compiler.md
@@ -49,6 +49,7 @@ positional arguments. `bc` does not require the conventional `.b` extension.
 | `-r=PATH`, `/r PATH` | Assembly path | Add a .NET reference assembly; repeat for every reference |
 | `-o=PATH`, `/o PATH` | Assembly path | Set the emitted assembly path |
 | `-s=PATH`, `/s PATH` | PDB path | Emit a portable PDB at this path |
+| `-debug=BOOL`, `/debug BOOL` | Boolean | Control debugger-friendly IL when a PDB is emitted |
 | `-m=NAME`, `/m NAME` | Name | Set the emitted assembly/module name |
 | `-q`, `/q` | none | Suppress informational output and diagnostics |
 | `-?`, `-h`, `--help`, `/help` | none | Display help and exit |
@@ -128,6 +129,31 @@ The PDB contains source document names, SHA-256 source checksums, sequence
 points, and local-variable scopes. A document name must be non-empty and cannot
 identify sources with different checksums. Reusing a name is allowed when the
 checksums are identical.
+
+When `-s` is used without `-debug`, `bc` defaults to debugger-friendly IL. Use
+`-debug=false` to emit the PDB while keeping the method bodies closer to the
+symbol-free release shape.
+
+### Debugger-friendly IL: `-debug`
+
+`-debug` controls whether `bc` emits debugger-friendly IL. The option accepts a
+boolean value such as `true` or `false`.
+
+With `-debug=true`, the emitter adds debug-only NOPs, a shared return epilogue,
+local-variable scope information, and `DebuggableAttribute`. This is the default
+when `-s` is specified.
+
+With `-debug=false`, `bc` can still emit a portable PDB and sequence points for
+real emitted instructions, but optimized-away source locations do not receive
+debug-only NOPs. This is useful for builds that need symbols without changing
+the generated IL shape as much:
+
+```console
+bc program.b -s=out/program.pdb -debug=false
+```
+
+Specifying `-debug=true` without `-s` has no practical effect, because no symbol
+file or sequence points are emitted.
 
 ### Module name: `-m`
 

--- a/src/Balu.Interpretation/Balu.Interpretation.csproj
+++ b/src/Balu.Interpretation/Balu.Interpretation.csproj
@@ -12,8 +12,8 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<Version>0.1.0</Version>
-		<AssemblyVersion>0.1.0</AssemblyVersion>
+		<Version>0.4.0</Version>
+		<AssemblyVersion>0.4.0</AssemblyVersion>
 	</PropertyGroup>
 
 

--- a/src/Balu.Sdk.Tests/Balu.Sdk.Tests.csproj
+++ b/src/Balu.Sdk.Tests/Balu.Sdk.Tests.csproj
@@ -26,17 +26,42 @@
 		<_BaluSdkPackageInput Include="..\Balu\**\*;..\Balu.SourceGenerator\**\*;..\Balu.Sdk\**\*;..\bc\**\*" Exclude="..\**\bin\**;..\**\obj\**" />
 	</ItemGroup>
 
+	<Target Name="ResolveBaluSdkPackageIdentity">
+		<MSBuild Projects="..\Balu.Sdk\Balu.Sdk.csproj" Targets="GetBaluSdkPackageIdentity" Properties="Configuration=$(Configuration)">
+			<Output TaskParameter="TargetOutputs" ItemName="_BaluSdkPackageIdentity" />
+		</MSBuild>
+		<PropertyGroup>
+			<BaluSdkPackageId>@(_BaluSdkPackageIdentity)</BaluSdkPackageId>
+			<BaluSdkPackageVersion>%(_BaluSdkPackageIdentity.Version)</BaluSdkPackageVersion>
+			<BaluSdkPackagePath>%(_BaluSdkPackageIdentity.PackagePath)</BaluSdkPackagePath>
+		</PropertyGroup>
+	</Target>
+
+	<Target Name="AddBaluSdkPackageMetadata" BeforeTargets="GetAssemblyAttributes" DependsOnTargets="ResolveBaluSdkPackageIdentity">
+		<ItemGroup>
+			<AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+				<_Parameter1>BaluSdkPackageId</_Parameter1>
+				<_Parameter2>$(BaluSdkPackageId)</_Parameter2>
+			</AssemblyAttribute>
+			<AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+				<_Parameter1>BaluSdkPackageVersion</_Parameter1>
+				<_Parameter2>$(BaluSdkPackageVersion)</_Parameter2>
+			</AssemblyAttribute>
+		</ItemGroup>
+	</Target>
+
 	<Target Name="EnsureCurrentBaluSdkPackage"
 			BeforeTargets="CopyBaluSdkPackage"
+			DependsOnTargets="ResolveBaluSdkPackageIdentity"
 			Inputs="@(_BaluSdkPackageInput)"
-			Outputs="..\Balu.Sdk\bin\$(Configuration)\Balu.Sdk.0.3.1.nupkg">
-		<Delete Files="..\Balu.Sdk\bin\$(Configuration)\Balu.Sdk.0.3.1.nupkg" />
+			Outputs="$(BaluSdkPackagePath)">
+		<Delete Files="$(BaluSdkPackagePath)" />
 		<MSBuild Projects="..\Balu.Sdk\Balu.Sdk.csproj" Targets="Build" Properties="Configuration=$(Configuration)" />
 	</Target>
 
-	<Target Name="CopyBaluSdkPackage" AfterTargets="Build">
+	<Target Name="CopyBaluSdkPackage" AfterTargets="Build" DependsOnTargets="ResolveBaluSdkPackageIdentity">
 		<ItemGroup>
-			<_BaluSdkPackage Include="..\Balu.Sdk\bin\$(Configuration)\Balu.Sdk.0.3.1.nupkg" />
+			<_BaluSdkPackage Include="$(BaluSdkPackagePath)" />
 		</ItemGroup>
 		<Error Condition="'@(_BaluSdkPackage)' == ''" Text="The Balu SDK package is missing." />
 		<Copy SourceFiles="@(_BaluSdkPackage)" DestinationFolder="$(OutDir)packages" SkipUnchangedFiles="true">

--- a/src/Balu.Sdk.Tests/Balu.Sdk.Tests.csproj
+++ b/src/Balu.Sdk.Tests/Balu.Sdk.Tests.csproj
@@ -1,0 +1,47 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+		<PackageReference Include="Mono.Cecil" Version="0.11.4" />
+		<PackageReference Include="xunit" Version="2.4.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.2.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Balu.Sdk\Balu.Sdk.csproj" ReferenceOutputAssembly="false" />
+		<_BaluSdkPackageInput Include="..\Balu\**\*;..\Balu.SourceGenerator\**\*;..\Balu.Sdk\**\*;..\bc\**\*" Exclude="..\**\bin\**;..\**\obj\**" />
+	</ItemGroup>
+
+	<Target Name="EnsureCurrentBaluSdkPackage"
+			BeforeTargets="CopyBaluSdkPackage"
+			Inputs="@(_BaluSdkPackageInput)"
+			Outputs="..\Balu.Sdk\bin\$(Configuration)\Balu.Sdk.0.3.1.nupkg">
+		<Delete Files="..\Balu.Sdk\bin\$(Configuration)\Balu.Sdk.0.3.1.nupkg" />
+		<MSBuild Projects="..\Balu.Sdk\Balu.Sdk.csproj" Targets="Build" Properties="Configuration=$(Configuration)" />
+	</Target>
+
+	<Target Name="CopyBaluSdkPackage" AfterTargets="Build">
+		<ItemGroup>
+			<_BaluSdkPackage Include="..\Balu.Sdk\bin\$(Configuration)\Balu.Sdk.0.3.1.nupkg" />
+		</ItemGroup>
+		<Error Condition="'@(_BaluSdkPackage)' == ''" Text="The Balu SDK package is missing." />
+		<Copy SourceFiles="@(_BaluSdkPackage)" DestinationFolder="$(OutDir)packages" SkipUnchangedFiles="true">
+			<Output TaskParameter="CopiedFiles" ItemName="FileWrites" />
+		</Copy>
+	</Target>
+
+</Project>

--- a/src/Balu.Sdk.Tests/Balu.Sdk.Tests.csproj
+++ b/src/Balu.Sdk.Tests/Balu.Sdk.Tests.csproj
@@ -50,11 +50,7 @@
 		</ItemGroup>
 	</Target>
 
-	<Target Name="EnsureCurrentBaluSdkPackage"
-			BeforeTargets="CopyBaluSdkPackage"
-			DependsOnTargets="ResolveBaluSdkPackageIdentity"
-			Inputs="@(_BaluSdkPackageInput)"
-			Outputs="$(BaluSdkPackagePath)">
+	<Target Name="EnsureCurrentBaluSdkPackage" BeforeTargets="CopyBaluSdkPackage" DependsOnTargets="ResolveBaluSdkPackageIdentity" Inputs="@(_BaluSdkPackageInput)" Outputs="$(BaluSdkPackagePath)">
 		<Delete Files="$(BaluSdkPackagePath)" />
 		<MSBuild Projects="..\Balu.Sdk\Balu.Sdk.csproj" Targets="Build" Properties="Configuration=$(Configuration)" />
 	</Target>

--- a/src/Balu.Sdk.Tests/SdkBuildTests.cs
+++ b/src/Balu.Sdk.Tests/SdkBuildTests.cs
@@ -1,0 +1,251 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Security;
+using System.Threading;
+using System.Threading.Tasks;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Xunit;
+
+namespace Balu.Sdk.Tests;
+
+public sealed class SdkBuildTests
+{
+    [Fact]
+    public void Sdk_DefaultConfigurations_HonorSymbolAndOptimizeProperties()
+    {
+        using var project = new TestProject();
+
+        project.Build("Debug");
+
+        Assert.True(File.Exists(project.IntermediateAssembly("Debug")));
+        Assert.True(File.Exists(project.IntermediatePdb("Debug")), project.DescribePdbs());
+        Assert.True(File.Exists(project.OutputPdb("Debug")));
+        AssertDebuggerFriendly(project.IntermediateAssembly("Debug"), expected: true, project.DescribePdbs());
+
+        project.Build("Release");
+
+        Assert.True(File.Exists(project.IntermediateAssembly("Release")));
+        Assert.True(File.Exists(project.IntermediatePdb("Release")), project.DescribePdbs());
+        Assert.True(File.Exists(project.OutputPdb("Release")));
+        AssertDebuggerFriendly(project.IntermediateAssembly("Release"), expected: false);
+    }
+
+    [Theory]
+    [InlineData("<DebugType>None</DebugType>")]
+    [InlineData("<DebugSymbols>false</DebugSymbols><DebugType></DebugType>")]
+    public void Sdk_DisabledSymbols_DoNotEmitPdb(string properties)
+    {
+        using var project = new TestProject(properties);
+
+        project.Build("Debug");
+
+        Assert.True(File.Exists(project.IntermediateAssembly("Debug")));
+        Assert.False(File.Exists(project.IntermediatePdb("Debug")));
+        Assert.False(File.Exists(project.OutputPdb("Debug")));
+        AssertDebuggerFriendly(project.IntermediateAssembly("Debug"), expected: false, project.DescribePdbs());
+    }
+
+    [Fact]
+    public void Sdk_CustomConfiguration_HonorsStandardProperties()
+    {
+        using var project = new TestProject("<DebugSymbols>true</DebugSymbols><DebugType>portable</DebugType><Optimize>false</Optimize>");
+
+        project.Build("Staging");
+
+        Assert.True(File.Exists(project.IntermediatePdb("Staging")), project.DescribePdbs());
+        Assert.True(File.Exists(project.OutputPdb("Staging")));
+        AssertDebuggerFriendly(project.IntermediateAssembly("Staging"), expected: true);
+    }
+
+    [Fact]
+    public void Sdk_PropertyChanges_InvalidateCompilerOutputs()
+    {
+        using var project = new TestProject();
+        project.Build("Debug");
+        var assemblyPath = project.IntermediateAssembly("Debug");
+        var initialWrite = File.GetLastWriteTimeUtc(assemblyPath);
+
+        Thread.Sleep(1100);
+        project.SetProperties("<DebugType>None</DebugType>");
+        project.Build("Debug", noRestore: true);
+
+        Assert.True(File.GetLastWriteTimeUtc(assemblyPath) > initialWrite);
+        Assert.False(File.Exists(project.IntermediatePdb("Debug")));
+        Assert.False(File.Exists(project.OutputPdb("Debug")));
+
+        project.SetProperties("<DebugType>portable</DebugType><Optimize>true</Optimize>");
+        project.Build("Debug", noRestore: true);
+
+        Assert.True(File.Exists(project.IntermediatePdb("Debug")));
+        AssertDebuggerFriendly(assemblyPath, expected: false);
+    }
+
+    [Fact]
+    public void Sdk_EmbeddedSymbols_ReportUnsupportedConfiguration()
+    {
+        using var project = new TestProject("<DebugType>embedded</DebugType>");
+
+        var result = project.TryBuild("Debug");
+
+        Assert.NotEqual(0, result.exitCode);
+        Assert.Contains("Balu does not support embedded PDBs", result.output);
+    }
+
+    [Fact]
+    public void Sdk_DisablingSymbols_RemovesCustomPdbOutputs()
+    {
+        const string customSymbolPath = "obj/custom-symbols.pdb";
+        using var project = new TestProject($"<BaluSymbolPath>{customSymbolPath}</BaluSymbolPath>");
+        project.Build("Debug");
+        var intermediatePdb = project.PathFromProject(customSymbolPath);
+        var outputPdb = project.PathFromProject("bin/Debug/net10.0/custom-symbols.pdb");
+        Assert.True(File.Exists(intermediatePdb));
+        Assert.True(File.Exists(outputPdb));
+
+        project.SetProperties("<DebugType>None</DebugType>");
+        project.Build("Debug", noRestore: true);
+
+        Assert.False(File.Exists(intermediatePdb));
+        Assert.False(File.Exists(outputPdb));
+    }
+
+    [Fact]
+    public void Sdk_FailedRecompilation_PreservesLastSuccessfulOutputs()
+    {
+        using var project = new TestProject();
+        project.Build("Debug");
+        var assemblyPath = project.IntermediateAssembly("Debug");
+        var pdbPath = project.IntermediatePdb("Debug");
+        var assemblyWrite = File.GetLastWriteTimeUtc(assemblyPath);
+        var pdbWrite = File.GetLastWriteTimeUtc(pdbPath);
+
+        project.SetSource("missing()");
+        var result = project.TryBuild("Debug", noRestore: true);
+
+        Assert.NotEqual(0, result.exitCode);
+        Assert.True(File.Exists(assemblyPath));
+        Assert.True(File.Exists(pdbPath));
+        Assert.Equal(assemblyWrite, File.GetLastWriteTimeUtc(assemblyPath));
+        Assert.Equal(pdbWrite, File.GetLastWriteTimeUtc(pdbPath));
+    }
+
+    [Fact]
+    public void Sdk_MissingPdb_RecompilesAndCleanRemovesOutputs()
+    {
+        using var project = new TestProject();
+        project.Build("Debug");
+        var assemblyPath = project.IntermediateAssembly("Debug");
+        var intermediatePdb = project.IntermediatePdb("Debug");
+        var outputPdb = project.OutputPdb("Debug");
+        var initialWrite = File.GetLastWriteTimeUtc(assemblyPath);
+
+        File.Delete(intermediatePdb);
+        File.Delete(outputPdb);
+        Thread.Sleep(1100);
+        project.Build("Debug", noRestore: true);
+
+        Assert.True(File.Exists(intermediatePdb), project.DescribePdbs());
+        Assert.True(File.Exists(outputPdb));
+        var regeneratedWrite = File.GetLastWriteTimeUtc(assemblyPath);
+        Assert.True(regeneratedWrite > initialWrite);
+
+        Thread.Sleep(1100);
+        project.Build("Debug", noRestore: true);
+        Assert.Equal(regeneratedWrite, File.GetLastWriteTimeUtc(assemblyPath));
+
+        project.Clean("Debug");
+        Assert.False(File.Exists(assemblyPath));
+        Assert.False(File.Exists(intermediatePdb));
+        Assert.False(File.Exists(outputPdb));
+    }
+
+    static void AssertDebuggerFriendly(string assemblyPath, bool expected, string? details = null)
+    {
+        using var assembly = AssemblyDefinition.ReadAssembly(assemblyPath);
+        var hasDebuggableAttribute = assembly.CustomAttributes.Any(attribute => attribute.AttributeType.FullName == "System.Diagnostics.DebuggableAttribute");
+        var hasNop = assembly.EntryPoint.Body.Instructions.Any(instruction => instruction.OpCode == OpCodes.Nop);
+        Assert.True(hasDebuggableAttribute == expected, details);
+        Assert.True(hasNop == expected, details);
+    }
+
+    sealed class TestProject : IDisposable
+    {
+        const string ProjectName = "TestProject";
+        readonly string directory;
+        readonly string packageCache;
+        string lastBuildOutput = string.Empty;
+
+        public TestProject(string properties = "")
+        {
+            directory = Directory.CreateTempSubdirectory("BaluSdkTests-").FullName;
+            packageCache = Path.Combine(directory, "packages-cache");
+            var packageSource = Path.Combine(AppContext.BaseDirectory, "packages");
+            File.WriteAllText(
+                Path.Combine(directory, "NuGet.config"),
+                $"<configuration><packageSources><clear/><add key=\"BaluSdk\" value=\"{SecurityElement.Escape(packageSource)}\"/></packageSources></configuration>");
+            SetProperties(properties);
+            SetSource("println(\"hello\")");
+        }
+
+        public string IntermediateAssembly(string configuration) => Path.Combine(directory, "obj", configuration, "net10.0", $"{ProjectName}.dll");
+        public string IntermediatePdb(string configuration) => Path.Combine(directory, "obj", configuration, "net10.0", $"{ProjectName}.pdb");
+        public string OutputPdb(string configuration) => Path.Combine(directory, "bin", configuration, "net10.0", $"{ProjectName}.pdb");
+        public string PathFromProject(string relativePath) => Path.GetFullPath(relativePath, directory);
+        public string DescribePdbs() => string.Join(Environment.NewLine, Directory.GetFiles(directory, "*.pdb", SearchOption.AllDirectories)) + Environment.NewLine + lastBuildOutput;
+        public void SetProperties(string properties) => File.WriteAllText(
+            Path.Combine(directory, $"{ProjectName}.csproj"),
+            $"<Project Sdk=\"Balu.Sdk/0.3.1\"><PropertyGroup><TargetFramework>net10.0</TargetFramework><OutputType>Exe</OutputType>{properties}</PropertyGroup></Project>");
+        public void SetSource(string source) => File.WriteAllText(Path.Combine(directory, "main.b"), source);
+
+        public void Build(string configuration, bool noRestore = false) => Run("build", configuration, noRestore);
+        public void Clean(string configuration) => Run("clean", configuration, noRestore: false);
+        public (int exitCode, string output) TryBuild(string configuration, bool noRestore = false) => RunProcess("build", configuration, noRestore);
+
+        void Run(string command, string configuration, bool noRestore)
+        {
+            var result = RunProcess(command, configuration, noRestore);
+            Assert.True(result.exitCode == 0, $"dotnet {command} failed.{Environment.NewLine}{result.output}");
+        }
+
+        (int exitCode, string output) RunProcess(string command, string configuration, bool noRestore)
+        {
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                WorkingDirectory = directory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            };
+            startInfo.ArgumentList.Add(command);
+            startInfo.ArgumentList.Add($"{ProjectName}.csproj");
+            startInfo.ArgumentList.Add("--configuration");
+            startInfo.ArgumentList.Add(configuration);
+            startInfo.ArgumentList.Add("--verbosity");
+            startInfo.ArgumentList.Add("normal");
+            if (noRestore)
+                startInfo.ArgumentList.Add("--no-restore");
+            startInfo.Environment["NUGET_PACKAGES"] = packageCache;
+
+            using var process = Process.Start(startInfo)!;
+            Task<string> outputTask = process.StandardOutput.ReadToEndAsync();
+            Task<string> errorTask = process.StandardError.ReadToEndAsync();
+            if (!process.WaitForExit(60_000))
+            {
+                process.Kill(entireProcessTree: true);
+                process.WaitForExit();
+                Task.WaitAll(outputTask, errorTask);
+                Assert.Fail($"dotnet {command} timed out.");
+            }
+            Task.WaitAll(outputTask, errorTask);
+            var output = outputTask.Result;
+            var error = errorTask.Result;
+            lastBuildOutput = output + Environment.NewLine + error;
+            return (process.ExitCode, lastBuildOutput);
+        }
+
+        public void Dispose() => Directory.Delete(directory, recursive: true);
+    }
+}

--- a/src/Balu.Sdk.Tests/SdkBuildTests.cs
+++ b/src/Balu.Sdk.Tests/SdkBuildTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,6 +14,9 @@ namespace Balu.Sdk.Tests;
 
 public sealed class SdkBuildTests
 {
+    static readonly string SdkPackageId = GetAssemblyMetadata("BaluSdkPackageId");
+    static readonly string SdkPackageVersion = GetAssemblyMetadata("BaluSdkPackageVersion");
+
     [Fact]
     public void Sdk_DefaultConfigurations_HonorSymbolAndOptimizeProperties()
     {
@@ -197,7 +201,7 @@ public sealed class SdkBuildTests
         public string DescribePdbs() => string.Join(Environment.NewLine, Directory.GetFiles(directory, "*.pdb", SearchOption.AllDirectories)) + Environment.NewLine + lastBuildOutput;
         public void SetProperties(string properties) => File.WriteAllText(
             Path.Combine(directory, $"{ProjectName}.csproj"),
-            $"<Project Sdk=\"Balu.Sdk/0.3.1\"><PropertyGroup><TargetFramework>net10.0</TargetFramework><OutputType>Exe</OutputType>{properties}</PropertyGroup></Project>");
+            $"<Project Sdk=\"{SdkPackageId}/{SdkPackageVersion}\"><PropertyGroup><TargetFramework>net10.0</TargetFramework><OutputType>Exe</OutputType>{properties}</PropertyGroup></Project>");
         public void SetSource(string source) => File.WriteAllText(Path.Combine(directory, "main.b"), source);
 
         public void Build(string configuration, bool noRestore = false) => Run("build", configuration, noRestore);
@@ -248,4 +252,9 @@ public sealed class SdkBuildTests
 
         public void Dispose() => Directory.Delete(directory, recursive: true);
     }
+
+    static string GetAssemblyMetadata(string key) => Assembly.GetExecutingAssembly()
+                                                            .GetCustomAttributes<AssemblyMetadataAttribute>()
+                                                            .Single(attribute => attribute.Key == key)
+                                                            .Value!;
 }

--- a/src/Balu.Sdk/Balu.Sdk.csproj
+++ b/src/Balu.Sdk/Balu.Sdk.csproj
@@ -7,6 +7,7 @@
 	</PropertyGroup>
 	<PropertyGroup>
 		<IsPackable>true</IsPackable>
+		<PackageId>Balu.Sdk</PackageId>
 		<Version>0.3.1</Version>
 		<Title>Balu.Sdk</Title>
 		<Authors>René Vogt</Authors>
@@ -44,6 +45,18 @@
 		<Content Include="Sdk.props" PackagePath="sdk/" />
 		<Content Include="Sdk.targets" PackagePath="sdk/" />
 	</ItemGroup>
+	<Target Name="GetBaluSdkPackageIdentity" Returns="@(_BaluSdkPackageIdentity)">
+		<PropertyGroup>
+			<_BaluSdkPackageVersion Condition="'$(PackageVersion)' != ''">$(PackageVersion)</_BaluSdkPackageVersion>
+			<_BaluSdkPackageVersion Condition="'$(_BaluSdkPackageVersion)' == ''">$(Version)</_BaluSdkPackageVersion>
+			<_BaluSdkPackageOutputPath Condition="'$(PackageOutputPath)' != ''">$(PackageOutputPath)</_BaluSdkPackageOutputPath>
+			<_BaluSdkPackageOutputPath Condition="'$(_BaluSdkPackageOutputPath)' == ''">$(OutputPath)</_BaluSdkPackageOutputPath>
+			<_BaluSdkPackagePath>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), '$(_BaluSdkPackageOutputPath)', '$(PackageId).$(_BaluSdkPackageVersion).nupkg'))</_BaluSdkPackagePath>
+		</PropertyGroup>
+		<ItemGroup>
+			<_BaluSdkPackageIdentity Include="$(PackageId)" Version="$(_BaluSdkPackageVersion)" PackagePath="$(_BaluSdkPackagePath)" />
+		</ItemGroup>
+	</Target>
 
 	<Target Name="CollectPackageBuildOutput" DependsOnTargets="ResolveReferences">
 		<MSBuild Projects="$(BaluCompilerProject)"

--- a/src/Balu.Sdk/Balu.Sdk.csproj
+++ b/src/Balu.Sdk/Balu.Sdk.csproj
@@ -8,7 +8,8 @@
 	<PropertyGroup>
 		<IsPackable>true</IsPackable>
 		<PackageId>Balu.Sdk</PackageId>
-		<Version>0.3.1</Version>
+		<Version>0.4.0</Version>
+		<AssemblyVersion>0.4.0</AssemblyVersion>
 		<Title>Balu.Sdk</Title>
 		<Authors>René Vogt</Authors>
 		<Description>The Balu language SDK.</Description>

--- a/src/Balu.Sdk/BaluCompiler.cs
+++ b/src/Balu.Sdk/BaluCompiler.cs
@@ -38,6 +38,7 @@ public sealed class BaluCompiler : ToolTask
 
         if (!string.IsNullOrWhiteSpace(SymbolPath))
             builder.AppendSwitchIfNotNull("/s ", SymbolPath);
+        builder.AppendSwitchIfNotNull("/debug ", Debug.ToString());
 
         foreach (var reference in ReferencedAssemblies)
             builder.AppendSwitchIfNotNull("/r ", reference.GetMetadata("FullPath"));

--- a/src/Balu.Sdk/Sdk.targets
+++ b/src/Balu.Sdk/Sdk.targets
@@ -1,22 +1,52 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<Import Project="sdk.targets" Sdk="Microsoft.NET.Sdk"/>
+	<PropertyGroup>
+		<_BaluSymbolsProduced>false</_BaluSymbolsProduced>
+		<_BaluSymbolsProduced Condition="'$(DebugSymbols)' == 'true'">true</_BaluSymbolsProduced>
+		<_BaluSymbolsProduced Condition="'$(DebugType)' == 'none'">false</_BaluSymbolsProduced>
+		<_BaluSymbolsProduced Condition="'$(DebugType)' == 'pdbonly' OR '$(DebugType)' == 'full' OR '$(DebugType)' == 'portable'">true</_BaluSymbolsProduced>
+		<_BaluSymbolsProduced Condition="'$(DebugType)' == 'embedded'">false</_BaluSymbolsProduced>
+		<_DebugSymbolsProduced>$(_BaluSymbolsProduced)</_DebugSymbolsProduced>
+		<BaluSymbolPath Condition="'$(_BaluSymbolsProduced)' == 'true' AND '$(BaluSymbolPath)' == ''">$(IntermediateOutputPath)$(TargetName).pdb</BaluSymbolPath>
+		<_BaluDebug Condition="'$(Optimize)' != 'true'">true</_BaluDebug>
+		<_BaluDebug Condition="'$(_BaluDebug)' == ''">false</_BaluDebug>
+		<_BaluCompilerOptionsFile>$(IntermediateOutputPath)BaluCompilerOptions.txt</_BaluCompilerOptionsFile>
+		<_BaluSymbolPathStateFile>$(IntermediateOutputPath)BaluSymbolPath.txt</_BaluSymbolPathStateFile>
+	</PropertyGroup>
+	<ItemGroup Condition="'$(_BaluSymbolsProduced)' == 'true'">
+		<_DebugSymbolsIntermediatePath Remove="@(_DebugSymbolsIntermediatePath)" />
+		<_DebugSymbolsIntermediatePath Include="$(BaluSymbolPath)" />
+		<_DebugSymbolsOutputPath Remove="@(_DebugSymbolsOutputPath)" />
+		<_DebugSymbolsOutputPath Include="@(_DebugSymbolsIntermediatePath -> '$(OutDir)%(Filename)%(Extension)')" />
+		<_BaluSymbolOutput Include="$(BaluSymbolPath)" />
+	</ItemGroup>
 	<Target Name="BaluCollectFiles" BeforeTargets="CoreCompile">
 		<ItemGroup>
 			<BaluFiles Include="**/*.b"/>
 			<UpToDateCheckInput Include="@(BaluFiles)"/>
 		</ItemGroup>
 	</Target>
-	<Target Name="CoreCompile" DependsOnTargets="$(CoreCompileDependsOn);BaluCollectFiles" Inputs="@(BaluFiles -> '%(FullPath)')" Outputs="@(IntermediateAssembly -> '%(FullPath)')">
+	<Target Name="BaluPrepareCompilerOptions">
+		<Error Condition="'$(DebugType)' == 'embedded'" Text="Balu does not support embedded PDBs. Use DebugType 'portable' or 'none'." />
+		<ReadLinesFromFile File="$(_BaluSymbolPathStateFile)" Condition="Exists('$(_BaluSymbolPathStateFile)')">
+			<Output TaskParameter="Lines" ItemName="_PreviousBaluSymbolPath" />
+		</ReadLinesFromFile>
+		<WriteLinesToFile File="$(_BaluCompilerOptionsFile)" Lines="DebugSymbols=$(DebugSymbols);DebugType=$(DebugType);Optimize=$(Optimize);SymbolPath=$(BaluSymbolPath)" Overwrite="true" WriteOnlyWhenDifferent="true" />
+		<WriteLinesToFile File="$(_BaluSymbolPathStateFile)" Lines="$(BaluSymbolPath)" Overwrite="true" WriteOnlyWhenDifferent="true" />
+		<ItemGroup>
+			<FileWrites Include="$(_BaluCompilerOptionsFile);$(_BaluSymbolPathStateFile)" />
+		</ItemGroup>
+	</Target>
+	<Target Name="CoreCompile" DependsOnTargets="$(CoreCompileDependsOn);BaluCollectFiles;BaluPrepareCompilerOptions" Inputs="@(BaluFiles -> '%(FullPath)');$(_BaluCompilerOptionsFile)" Outputs="@(IntermediateAssembly -> '%(FullPath)');@(_BaluSymbolOutput -> '%(FullPath)')">
 		<ItemGroup>
 			<ReferencePath Remove="@(ReferencePath)" Condition="
 						   '%(Filename)' != 'System.Runtime' AND 
 						   '%(Filename)' != 'System.Runtime.Extensions' AND 						   
 						   '%(Filename)' != 'System.Console'"/>
 		</ItemGroup>
-		<PropertyGroup>
-			<BaluSymbolPath Condition="'$(Configuration)' == 'Debug' AND '$(BaluSymbolPath)' == ''">@(IntermediateAssembly -> '%(RootDir)%(Directory)%(filename).pdb')</BaluSymbolPath>
-		</PropertyGroup>
-		<BaluCompiler DotNetPath="$(DOTNET_HOST_PATH)" CompilerPath="$(BaluCompilerPath)/bc.dll" SourceFiles="@(BaluFiles)" OutputPath="@(IntermediateAssembly)" ReferencedAssemblies="@(ReferencePath)" SymbolPath="$(BaluSymbolPath)"/>
+		<BaluCompiler DotNetPath="$(DOTNET_HOST_PATH)" CompilerPath="$(BaluCompilerPath)/bc.dll" SourceFiles="@(BaluFiles)" OutputPath="@(IntermediateAssembly)" ReferencedAssemblies="@(ReferencePath)" SymbolPath="$(BaluSymbolPath)" Debug="$(_BaluDebug)"/>
+		<Delete Files="@(_PreviousBaluSymbolPath);@(_PreviousBaluSymbolPath -> '$(OutDir)%(Filename)%(Extension)')" Condition="'$(_BaluSymbolsProduced)' != 'true' OR '@(_PreviousBaluSymbolPath)' != '$(BaluSymbolPath)'" />
+		<Delete Files="$(IntermediateOutputPath)$(TargetName).pdb;$(OutDir)$(TargetName).pdb" Condition="'$(_BaluSymbolsProduced)' != 'true'" />
 	</Target>
 </Project>

--- a/src/Balu.Tests/EmitterTests/ConstantFoldingTests.cs
+++ b/src/Balu.Tests/EmitterTests/ConstantFoldingTests.cs
@@ -13,7 +13,7 @@ public partial class EmitterTests
             function test() [{]
                 [let x = 4]
                 [let y = 5]
-                if (x < y)
+                [if (x < y)]
                     [call()]
             [}]
             test()
@@ -24,11 +24,12 @@ public partial class EmitterTests
             IL0002: stloc.0
             IL0003: ldc.i4.5
             IL0004: stloc.1
-            IL0005: call System.Void Program::call()
-            IL000A: nop
-            IL000B: ret
+            IL0005: nop
+            IL0006: call System.Void Program::call()
+            IL000B: nop
+            IL000C: ret
 ";
-        var offsets = new[] { 0, 1, 3, 5, 0xA };
+        var offsets = new[] { 0, 1, 3, 5, 6, 0xB };
         code.AssertIlAndSymbols("test", il, offsets, output: output);
     }
     [Fact]
@@ -55,6 +56,30 @@ public partial class EmitterTests
         code.AssertIl("test", il, output: output);
     }
     [Fact]
+    public void Emitter_ConstantFolding_IfTrueOptimizedWithSymbols()
+    {
+        const string code = @"
+            function call() {}
+            function test() {
+                [let x = 4]
+                [let y = 5]
+                if (x < y)
+                    [call()]
+            }
+            test()
+";
+        const string il = @"
+            IL0000: ldc.i4.4
+            IL0001: stloc.0
+            IL0002: ldc.i4.5
+            IL0003: stloc.1
+            IL0004: call System.Void Program::call()
+            IL0009: ret
+";
+        var offsets = new[] { 0, 2, 4 };
+        code.AssertIlAndSymbols("test", il, offsets, debugFriendly: false, output: output);
+    }
+    [Fact]
     public void Emitter_ConstantFolding_IfFalseDebug()
     {
         const string code = @"
@@ -62,7 +87,7 @@ public partial class EmitterTests
             function test() [{]
                 [let x = 4]
                 [let y = 5]
-                if (x > y)
+                [if (x > y)]
                 {
                     call()
                 }
@@ -76,9 +101,10 @@ public partial class EmitterTests
             IL0003: ldc.i4.5
             IL0004: stloc.1
             IL0005: nop
-            IL0006: ret
+            IL0006: nop
+            IL0007: ret
 ";
-        var offsets = new[] { 0, 1, 3, 5 };
+        var offsets = new[] { 0, 1, 3, 5, 6 };
         code.AssertIlAndSymbols("test", il, offsets, output: output);
     }
     [Fact]
@@ -113,7 +139,7 @@ public partial class EmitterTests
             function test() [{]
                 [let x = 4]
                 [let y = 5]
-                if (x < y)
+                [if (x < y)]
                 [{]
                     [call()]
                 [}]
@@ -128,12 +154,13 @@ public partial class EmitterTests
             IL0003: ldc.i4.5
             IL0004: stloc.1
             IL0005: nop
-            IL0006: call System.Void Program::call()
-            IL000B: nop
+            IL0006: nop
+            IL0007: call System.Void Program::call()
             IL000C: nop
-            IL000D: ret
+            IL000D: nop
+            IL000E: ret
 ";
-        var offsets = new[] { 0, 1, 3, 5, 6, 0xB, 0xC };
+        var offsets = new[] { 0, 1, 3, 5, 6, 7, 0xC, 0xD };
         code.AssertIlAndSymbols("test", il, offsets, output: output);
     }
     [Fact]
@@ -170,7 +197,7 @@ public partial class EmitterTests
             function test() [{]
                 [let x = 4]
                 [let y = 5]
-                if (x > y)
+                [if (x > y)]
                 {
                     call()
                 }
@@ -187,9 +214,10 @@ public partial class EmitterTests
             IL0005: nop
             IL0006: nop
             IL0007: nop
-            IL0008: ret
+            IL0008: nop
+            IL0009: ret
 ";
-        var offsets = new[] { 0, 1, 3, 5, 6, 7 };
+        var offsets = new[] { 0, 1, 3, 5, 6, 7, 8 };
         code.AssertIlAndSymbols("test", il, offsets, output: output);
     }
     [Fact]
@@ -227,7 +255,7 @@ public partial class EmitterTests
             function test() [{]
                 [let x = true]
                 [let y = false]
-                while x || y
+                [while x || y]
                 [{]
                     [call()]
                 [}]
@@ -242,13 +270,14 @@ public partial class EmitterTests
             IL0003: ldc.i4.0
             IL0004: stloc.1
             IL0005: nop
-            IL0006: call System.Void Program::call()
-            IL000B: nop
-            IL000C: br.s IL_0005: nop
-            IL000E: nop
-            IL000F: ret
+            IL0006: nop
+            IL0007: call System.Void Program::call()
+            IL000C: nop
+            IL000D: br.s IL_0005: nop
+            IL000F: nop
+            IL0010: ret
 ";
-        var offsets = new[] { 0, 1, 3, 5, 6, 0xB, 0xE };
+        var offsets = new[] { 0, 1, 3, 5, 6, 7, 0xC, 0xF };
         code.AssertIlAndSymbols("test", il, offsets, output: output);
     }
     [Fact]
@@ -289,7 +318,7 @@ public partial class EmitterTests
             function test() [{]
                 [let x = false]
                 [let y = true]
-                while x && y
+                [while x && y]
                 {
                     call()
                 }
@@ -303,11 +332,12 @@ public partial class EmitterTests
             IL0002: stloc.0
             IL0003: ldc.i4.1
             IL0004: stloc.1
-            IL0005: call System.Void Program::call2()
-            IL000A: nop
-            IL000B: ret
+            IL0005: nop
+            IL0006: call System.Void Program::call2()
+            IL000B: nop
+            IL000C: ret
 ";
-        var offsets = new[] { 0, 1, 3, 5, 0xA };
+        var offsets = new[] { 0, 1, 3, 5, 6, 0xB };
         code.AssertIlAndSymbols("test", il, offsets, output: output);
     }
     [Fact]

--- a/src/Balu.sln
+++ b/src/Balu.sln
@@ -41,6 +41,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "bc.Tests", "bc.Tests\bc.Tes
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Balu.Interpretation.Tests", "Balu.Interpretation.Tests\Balu.Interpretation.Tests.csproj", "{7C47C45E-FBEE-4F65-AB4A-B6BFEC4EF605}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Balu.Sdk.Tests", "Balu.Sdk.Tests\Balu.Sdk.Tests.csproj", "{D8B6A94F-0B65-471C-AA9B-880448B3AC1D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -195,6 +197,18 @@ Global
 		{7C47C45E-FBEE-4F65-AB4A-B6BFEC4EF605}.Release|arm64.Build.0 = Release|Any CPU
 		{7C47C45E-FBEE-4F65-AB4A-B6BFEC4EF605}.Release|x86.ActiveCfg = Release|Any CPU
 		{7C47C45E-FBEE-4F65-AB4A-B6BFEC4EF605}.Release|x86.Build.0 = Release|Any CPU
+		{D8B6A94F-0B65-471C-AA9B-880448B3AC1D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D8B6A94F-0B65-471C-AA9B-880448B3AC1D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D8B6A94F-0B65-471C-AA9B-880448B3AC1D}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{D8B6A94F-0B65-471C-AA9B-880448B3AC1D}.Debug|arm64.Build.0 = Debug|Any CPU
+		{D8B6A94F-0B65-471C-AA9B-880448B3AC1D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D8B6A94F-0B65-471C-AA9B-880448B3AC1D}.Debug|x86.Build.0 = Debug|Any CPU
+		{D8B6A94F-0B65-471C-AA9B-880448B3AC1D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D8B6A94F-0B65-471C-AA9B-880448B3AC1D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D8B6A94F-0B65-471C-AA9B-880448B3AC1D}.Release|arm64.ActiveCfg = Release|Any CPU
+		{D8B6A94F-0B65-471C-AA9B-880448B3AC1D}.Release|arm64.Build.0 = Release|Any CPU
+		{D8B6A94F-0B65-471C-AA9B-880448B3AC1D}.Release|x86.ActiveCfg = Release|Any CPU
+		{D8B6A94F-0B65-471C-AA9B-880448B3AC1D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Balu/Balu.csproj
+++ b/src/Balu/Balu.csproj
@@ -11,8 +11,8 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<Version>0.1.0</Version>
-		<AssemblyVersion>0.1.0</AssemblyVersion>
+		<Version>0.4.0</Version>
+		<AssemblyVersion>0.4.0</AssemblyVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Balu/Compilation.cs
+++ b/src/Balu/Compilation.cs
@@ -71,7 +71,11 @@ public sealed class Compilation
 
     public ImmutableArray<Diagnostic> Emit(string moduleName, string[] references, string outputPath, string? symbolPath) =>
         Emit(moduleName, references, outputPath, symbolPath, ImmutableDictionary<GlobalVariableSymbol, object>.Empty);
+    public ImmutableArray<Diagnostic> Emit(string moduleName, string[] references, string outputPath, string? symbolPath, bool debug) =>
+        Emit(moduleName, references, outputPath, symbolPath, debug, ImmutableDictionary<GlobalVariableSymbol, object>.Empty);
     public ImmutableArray<Diagnostic> Emit(string moduleName, string[] references, string outputPath, string? symbolPath, ImmutableDictionary<GlobalVariableSymbol, object> initializedGlobalVariables)
+        => Emit(moduleName, references, outputPath, symbolPath, symbolPath is not null, initializedGlobalVariables);
+    public ImmutableArray<Diagnostic> Emit(string moduleName, string[] references, string outputPath, string? symbolPath, bool debug, ImmutableDictionary<GlobalVariableSymbol, object> initializedGlobalVariables)
     {
         _ = moduleName ?? throw new ArgumentNullException(nameof(moduleName));
         _ = references ?? throw new ArgumentNullException(nameof(references));
@@ -82,11 +86,15 @@ public sealed class Compilation
         if (Program.Diagnostics.HasErrors()) return Program.Diagnostics;
 
         using var referenceSet = new EmitReferenceSet(references);
-        return EmitToFiles(moduleName, referenceSet, canonicalOutputPath, canonicalSymbolPath, initializedGlobalVariables);
+        return EmitToFiles(moduleName, referenceSet, canonicalOutputPath, canonicalSymbolPath, debug, initializedGlobalVariables);
     }
     public ImmutableArray<Diagnostic> EmitWithReferenceSet(string moduleName, EmitReferenceSet references, string outputPath, string? symbolPath) =>
         EmitWithReferenceSet(moduleName, references, outputPath, symbolPath, ImmutableDictionary<GlobalVariableSymbol, object>.Empty);
+    public ImmutableArray<Diagnostic> EmitWithReferenceSet(string moduleName, EmitReferenceSet references, string outputPath, string? symbolPath, bool debug) =>
+        EmitWithReferenceSet(moduleName, references, outputPath, symbolPath, debug, ImmutableDictionary<GlobalVariableSymbol, object>.Empty);
     public ImmutableArray<Diagnostic> EmitWithReferenceSet(string moduleName, EmitReferenceSet references, string outputPath, string? symbolPath, ImmutableDictionary<GlobalVariableSymbol, object> initializedGlobalVariables)
+        => EmitWithReferenceSet(moduleName, references, outputPath, symbolPath, symbolPath is not null, initializedGlobalVariables);
+    public ImmutableArray<Diagnostic> EmitWithReferenceSet(string moduleName, EmitReferenceSet references, string outputPath, string? symbolPath, bool debug, ImmutableDictionary<GlobalVariableSymbol, object> initializedGlobalVariables)
     {
         _ = moduleName ?? throw new ArgumentNullException(nameof(moduleName));
         _ = references ?? throw new ArgumentNullException(nameof(references));
@@ -95,7 +103,7 @@ public sealed class Compilation
         var pathDiagnostics = ValidateEmitPaths(outputPath, symbolPath, out var canonicalOutputPath, out var canonicalSymbolPath);
         if (pathDiagnostics.HasErrors()) return pathDiagnostics;
         if (Program.Diagnostics.HasErrors()) return Program.Diagnostics;
-        return EmitToFiles(moduleName, references, canonicalOutputPath, canonicalSymbolPath, initializedGlobalVariables);
+        return EmitToFiles(moduleName, references, canonicalOutputPath, canonicalSymbolPath, debug, initializedGlobalVariables);
     }
     public ImmutableArray<Diagnostic> Emit(string moduleName, string[] references, Stream outputStream, Stream? symbolStream)
     {
@@ -118,12 +126,29 @@ public sealed class Compilation
         _ = outputStream ?? throw new ArgumentNullException(nameof(outputStream));
         return Emitter.Emit(Program, moduleName, references, outputStream, symbolStream, ImmutableDictionary<GlobalVariableSymbol, object>.Empty).Diagnostics;
     }
-    public EmitterResult EmitWithReferenceSet(string moduleName, EmitReferenceSet references, Stream outputStream, Stream? symbolStream, ImmutableDictionary<GlobalVariableSymbol, object> initializedGlobalVariables)
+    public ImmutableArray<Diagnostic> EmitWithReferenceSet(string moduleName, EmitReferenceSet references, Stream outputStream, Stream? symbolStream, bool debug)
     {
         _ = moduleName ?? throw new ArgumentNullException(nameof(moduleName));
         _ = references ?? throw new ArgumentNullException(nameof(references));
         _ = outputStream ?? throw new ArgumentNullException(nameof(outputStream));
-        return Emitter.Emit(Program, moduleName, references, outputStream, symbolStream, initializedGlobalVariables);
+        return Emitter.Emit(Program, moduleName, references, outputStream, symbolStream, debug, ImmutableDictionary<GlobalVariableSymbol, object>.Empty).Diagnostics;
+    }
+    public ImmutableArray<Diagnostic> Emit(string moduleName, string[] references, Stream outputStream, Stream? symbolStream, bool debug)
+    {
+        _ = moduleName ?? throw new ArgumentNullException(nameof(moduleName));
+        _ = references ?? throw new ArgumentNullException(nameof(references));
+        _ = outputStream ?? throw new ArgumentNullException(nameof(outputStream));
+        using var referenceSet = new EmitReferenceSet(references);
+        return Emitter.Emit(Program, moduleName, referenceSet, outputStream, symbolStream, debug, ImmutableDictionary<GlobalVariableSymbol, object>.Empty).Diagnostics;
+    }
+    public EmitterResult EmitWithReferenceSet(string moduleName, EmitReferenceSet references, Stream outputStream, Stream? symbolStream, ImmutableDictionary<GlobalVariableSymbol, object> initializedGlobalVariables)
+        => EmitWithReferenceSet(moduleName, references, outputStream, symbolStream, symbolStream is not null, initializedGlobalVariables);
+    public EmitterResult EmitWithReferenceSet(string moduleName, EmitReferenceSet references, Stream outputStream, Stream? symbolStream, bool debug, ImmutableDictionary<GlobalVariableSymbol, object> initializedGlobalVariables)
+    {
+        _ = moduleName ?? throw new ArgumentNullException(nameof(moduleName));
+        _ = references ?? throw new ArgumentNullException(nameof(references));
+        _ = outputStream ?? throw new ArgumentNullException(nameof(outputStream));
+        return Emitter.Emit(Program, moduleName, references, outputStream, symbolStream, debug, initializedGlobalVariables);
     }
 
     ImmutableArray<Diagnostic> EmitToFiles(
@@ -131,6 +156,7 @@ public sealed class Compilation
         EmitReferenceSet references,
         string outputPath,
         string? symbolPath,
+        bool debug,
         ImmutableDictionary<GlobalVariableSymbol, object> initializedGlobalVariables)
     {
         var referenceDiagnostics = references.GetDiagnostics();
@@ -148,7 +174,7 @@ public sealed class Compilation
                     result = EmitWithReferenceSet(moduleName, references, outputStream, null, initializedGlobalVariables);
                 else
                     using (var symbolStream = CreateTemporaryFile(symbolPath, out temporarySymbolPath))
-                        result = Emitter.Emit(Program, moduleName, references, outputStream, symbolStream, initializedGlobalVariables, symbolPath);
+                        result = Emitter.Emit(Program, moduleName, references, outputStream, symbolStream, debug, initializedGlobalVariables, symbolPath);
             }
 
             if (result.Diagnostics.HasErrors()) return result.Diagnostics;

--- a/src/Balu/Emit/Emitter.cs
+++ b/src/Balu/Emit/Emitter.cs
@@ -33,6 +33,7 @@ sealed class Emitter : IDisposable
 
 
     LocalVariableScope? locals;
+    bool emitSymbols;
     bool debug;
 
     Emitter(BoundProgram program, string moduleName, EmitReferenceSet references)
@@ -151,7 +152,7 @@ sealed class Emitter : IDisposable
         
         method.Body.OptimizeMacros();
 
-        if (debug)
+        if (emitSymbols)
             method.DebugInformation.Scope = EndScope(processor);
     }
     void EmitStatement(ILProcessor processor, BoundStatement statement)
@@ -617,7 +618,7 @@ sealed class Emitter : IDisposable
     }
     void EmitSequencePointStatement(ILProcessor processor, BoundSequencePointStatement statement)
     {
-        if (!debug)
+        if (!emitSymbols || !debug && statement.Statement.Kind == BoundNodeKind.NopStatement)
         {
             if (statement.Statement.Kind != BoundNodeKind.NopStatement)
                 EmitStatement(processor, statement.Statement);
@@ -744,11 +745,12 @@ sealed class Emitter : IDisposable
         referencedMembers.Assembly.MainModule.CustomAttributes.Add(attribute);
     }
 
-    void Emit(Stream outputStream, Stream? symbolStream, ImmutableDictionary<GlobalVariableSymbol, object> initializedGlobalVariables, string? pdbPath = null)
+    void Emit(Stream outputStream, Stream? symbolStream, bool debug, ImmutableDictionary<GlobalVariableSymbol, object> initializedGlobalVariables, string? pdbPath = null)
     {
         if (diagnostics.HasErrors()) return;
 
-        debug = symbolStream is not null;
+        emitSymbols = symbolStream is not null;
+        this.debug = debug && emitSymbols;
         EmitDebuggableAttribute();
 
         EmitFields(initializedGlobalVariables);
@@ -782,16 +784,19 @@ sealed class Emitter : IDisposable
     {
         if (program.Diagnostics.HasErrors()) return new(program.Diagnostics, ImmutableDictionary<Symbol, string>.Empty);
         using var referenceSet = new EmitReferenceSet(references);
-        return Emit(program, moduleName, referenceSet, outputStream, symbolStream, initializedGlobalVariables);
+        return Emit(program, moduleName, referenceSet, outputStream, symbolStream, symbolStream is not null, initializedGlobalVariables);
     }
 
     public static EmitterResult Emit(BoundProgram program, string moduleName, EmitReferenceSet references, Stream outputStream, Stream? symbolStream, ImmutableDictionary<GlobalVariableSymbol, object> initializedGlobalVariables, string? pdbPath = null)
+        => Emit(program, moduleName, references, outputStream, symbolStream, symbolStream is not null, initializedGlobalVariables, pdbPath);
+
+    public static EmitterResult Emit(BoundProgram program, string moduleName, EmitReferenceSet references, Stream outputStream, Stream? symbolStream, bool debug, ImmutableDictionary<GlobalVariableSymbol, object> initializedGlobalVariables, string? pdbPath = null)
     {
         try
         {
             if (program.Diagnostics.HasErrors()) return new(program.Diagnostics, ImmutableDictionary<Symbol, string>.Empty);
             using var emitter = new Emitter(program, moduleName, references);
-            emitter.Emit(outputStream, symbolStream, initializedGlobalVariables, pdbPath);
+            emitter.Emit(outputStream, symbolStream, debug, initializedGlobalVariables, pdbPath);
             return new(emitter.diagnostics.ToImmutableArray(), emitter.globalSymbolNames.ToImmutableDictionary());
         }
         catch (MissingReferencesException exception)

--- a/src/Balu/Lowering/Lowerer.cs
+++ b/src/Balu/Lowering/Lowerer.cs
@@ -200,7 +200,7 @@ sealed class Lowerer : BoundTreeRewriter
         var seq = currentSequencePointStatement; currentSequencePointStatement = node;
         var result = (BoundSequencePointStatement)base.VisitBoundSequencePointStatement(node);
         currentSequencePointStatement = seq;
-        return result.Statement.Kind == BoundNodeKind.NopStatement ? result.Statement : result;
+        return result;
     }
 
     static void InsertBlockStatement(ImmutableArray<BoundStatement>.Builder builder, BoundStatement body)
@@ -319,8 +319,13 @@ sealed class Lowerer : BoundTreeRewriter
                 var next = builder[labelIndex].UnwrapSequencePoint();
                 if (next.Kind == BoundNodeKind.LabelStatement && ((BoundLabelStatement)next).Label == label)
                 {
-                    builder.RemoveAt(gotoIndex);
-                    gotoIndex--;
+                    if (builder[gotoIndex] is BoundSequencePointStatement sequencePoint)
+                        builder[gotoIndex] = SequencePoint(Nop(current.Syntax), sequencePoint.Location);
+                    else
+                    {
+                        builder.RemoveAt(gotoIndex);
+                        gotoIndex--;
+                    }
                     break;
                 }
 

--- a/src/HelloWorld/helloworld.csproj
+++ b/src/HelloWorld/helloworld.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.3.1">
+﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.4.0">
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
 		<OutputType>Exe</OutputType>

--- a/src/TestHelpers/IlAsserter.cs
+++ b/src/TestHelpers/IlAsserter.cs
@@ -19,7 +19,7 @@ public static class IlAsserter
     public static void AssertIl(this string code, string methodToAssert, string expectedIL, bool script = false, bool debug = false, ITestOutputHelper? output = null)
     {
         var expected = string.Join(Environment.NewLine,
-                                   expectedIL.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Select(line => line.Trim()));
+                                   expectedIL.ReplaceLineEndings().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Select(line => line.Trim()));
         var tree = SyntaxTree.Parse(SourceText.From(code, "IlAsserter.b"));
         var (il, _, _) = ExecuteEmitter(tree, methodToAssert, script, debug, output);
         Assert.Equal(expected, il);
@@ -38,10 +38,10 @@ public static class IlAsserter
         Assert.Equal(expectedSymbols, symbols);
         if (scopes is not null) Assert.Equal(AnnotatedText.Parse(scopes).Text, actualScopes);
     }
-    public static void AssertIlAndSymbols(this string code, string methodToAssert, string expectedIL, IEnumerable<int> sequencePointOffsets, string? scopes = null, bool script = false, ITestOutputHelper? output = null)
+    public static void AssertIlAndSymbols(this string code, string methodToAssert, string expectedIL, IEnumerable<int> sequencePointOffsets, string? scopes = null, bool script = false, bool debugFriendly = true, ITestOutputHelper? output = null)
     {
         var expected = string.Join(Environment.NewLine,
-                                   expectedIL.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Select(line => line.Trim()));
+                                   expectedIL.ReplaceLineEndings().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Select(line => line.Trim()));
         var annotated = AnnotatedText.Parse(code);
         var tree = SyntaxTree.Parse(SourceText.From(annotated.Text, "IlAsserter.b"));
         var expectedSymbols = string.Join(Environment.NewLine,
@@ -50,12 +50,12 @@ public static class IlAsserter
                                                    .Zip(sequencePointOffsets,
                                                     (span, offset) => ToSymbolString(offset, new (tree.Text, span))));
 
-        var (il, symbols, actualScopes) = ExecuteEmitter(tree, methodToAssert, script, true, output);
+        var (il, symbols, actualScopes) = ExecuteEmitter(tree, methodToAssert, script, true, output, debugFriendly);
         Assert.Equal(expected, il);
         Assert.Equal(expectedSymbols, symbols);
         if (scopes is not null) Assert.Equal(AnnotatedText.Parse(scopes).Text.TrimEnd(), actualScopes);
     }
-    static (string il, string symbols, string locals) ExecuteEmitter(SyntaxTree syntaxTree, string methodToAssert, bool script, bool debug, ITestOutputHelper? output)
+    static (string il, string symbols, string locals) ExecuteEmitter(SyntaxTree syntaxTree, string methodToAssert, bool script, bool debug, ITestOutputHelper? output, bool debugFriendly = true)
     {
         var compilation = script
                               ? Compilation.CreateScript(null, syntaxTree)
@@ -65,7 +65,7 @@ public static class IlAsserter
         var outputStream = new MemoryStream();
         try
         {
-            var diagnostics = compilation.Emit("Balu", ReferenceProvider.References, outputStream, symbolStream);
+            var diagnostics = compilation.Emit("Balu", ReferenceProvider.References, outputStream, symbolStream, debug && debugFriendly);
             Assert.Empty(diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
 
             outputStream.Seek(0, SeekOrigin.Begin);

--- a/src/bc/Program.cs
+++ b/src/bc/Program.cs
@@ -37,6 +37,7 @@ sealed class Program
         string moduleName = string.Empty;
         List<string> sourcePaths = [];
         bool helpRequested = false;
+        bool? debug = null;
 
         var options = new OptionSet
         {
@@ -44,6 +45,7 @@ sealed class Program
             { "r=", "The {path} of an assembly to reference.", v => references.Add(v) },
             { "o=", "The output {path} of the assembly to create.", v => outputPath = v },
             { "s=", "The optional symbol {path} of the pdb to create.", v => symbolPath = v },
+            { "debug=", "Whether to emit debugger-friendly IL.", (bool v) => debug = v },
             { "m=", "The module {name} of the assembly to create.", v => moduleName = v },
             { "q", _ => quiet = true },
             { "?|h|help", "Shows help.", _ => helpRequested = true }
@@ -95,7 +97,7 @@ sealed class Program
             var compilation = Compilation.Create(syntaxTrees);
             LogInfo(
                 $"Emitting assembly '{outputPath}'{(string.IsNullOrWhiteSpace(symbolPath) ? string.Empty : $" and symbol file '{symbolPath}'")}.");
-            var diagnostics = compilation.Emit(moduleName, [.. references], outputPath, symbolPath);
+            var diagnostics = compilation.Emit(moduleName, [.. references], outputPath, symbolPath, debug ?? !string.IsNullOrWhiteSpace(symbolPath));
             LogDiagnostics(diagnostics);
             LogInfo("Done.");
             return diagnostics.HasErrors() ? CompilationError : Success;

--- a/src/bc/bc.csproj
+++ b/src/bc/bc.csproj
@@ -8,8 +8,8 @@
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
 		<AnalysisLevel>latest</AnalysisLevel>
 		<AnalysisMode>AllEnabledByDefault</AnalysisMode>
-		<Version>0.1.0</Version>
-		<AssemblyVersion>0.1.0</AssemblyVersion>
+		<Version>0.4.0</Version>
+		<AssemblyVersion>0.4.0</AssemblyVersion>
 	</PropertyGroup>
 	<ItemGroup>
 	  <PackageReference Include="Mono.Options" Version="6.12.0.148" />

--- a/src/bi/bi.csproj
+++ b/src/bi/bi.csproj
@@ -9,6 +9,7 @@
 	  <EnableNETAnalyzers>true</EnableNETAnalyzers>
 	  <AnalysisLevel>latest</AnalysisLevel>
 	  <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+	  <AssemblyVersion>0.4.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #82.

Summary:
- preserve optimized condition sequence points with debug NOPs
- align SDK symbol output with DebugSymbols, DebugType, Optimize, and incremental outputs
- add Balu.Sdk.Tests integration coverage and document /debug

Verification:
- `dotnet test src/Balu.Tests/Balu.Tests.csproj --no-restore`
- `dotnet test src/bc.Tests/bc.Tests.csproj --no-restore`
- `dotnet test src/Balu.Interpretation.Tests/Balu.Interpretation.Tests.csproj --no-restore`
- `dotnet test src/Balu.Sdk.Tests/Balu.Sdk.Tests.csproj --no-restore`
- Full Visual Studio MSBuild Release build of `src/Balu.sln`