### PR TITLE
Fix scopes for unbraced control-flow bodies

### DIFF
--- a/src/Balu.Interpretation/Balu.Interpretation.csproj
+++ b/src/Balu.Interpretation/Balu.Interpretation.csproj
@@ -12,8 +12,8 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<Version>0.4.0</Version>
-		<AssemblyVersion>0.4.0</AssemblyVersion>
+		<Version>0.4.1</Version>
+		<AssemblyVersion>0.4.1</AssemblyVersion>
 	</PropertyGroup>
 
 

--- a/src/Balu.Sdk/Balu.Sdk.csproj
+++ b/src/Balu.Sdk/Balu.Sdk.csproj
@@ -8,8 +8,8 @@
 	<PropertyGroup>
 		<IsPackable>true</IsPackable>
 		<PackageId>Balu.Sdk</PackageId>
-		<Version>0.4.0</Version>
-		<AssemblyVersion>0.4.0</AssemblyVersion>
+		<Version>0.4.1</Version>
+		<AssemblyVersion>0.4.1</AssemblyVersion>
 		<Title>Balu.Sdk</Title>
 		<Authors>René Vogt</Authors>
 		<Description>The Balu language SDK.</Description>

--- a/src/Balu.Tests/BinderTests/EmbeddedStatementScopeTests.cs
+++ b/src/Balu.Tests/BinderTests/EmbeddedStatementScopeTests.cs
@@ -1,0 +1,25 @@
+using TestHelpers;
+using Xunit;
+
+namespace Balu.Tests.BinderTests;
+
+public sealed partial class BinderTests
+{
+    [Theory]
+    [InlineData("function test() { if true var x = 1 var y = [x] }")]
+    [InlineData("function test() { if true {} else var x = 1 var y = [x] }")]
+    [InlineData("function test() { while false var x = 1 var y = [x] }")]
+    [InlineData("function test() { do var x = 1 while false var y = [x] }")]
+    [InlineData("function test() { for i = 1 to 1 var x = 1 var y = [x] }")]
+    public void Binder_EmbeddedStatementVariable_IsNotVisibleAfterBody(string code) =>
+        code.AssertScriptEvaluation(expectedDiagnostics: "BL1005: Undefined name 'x'.");
+
+    [Fact]
+    public void Binder_DoWhileBodyVariable_IsNotVisibleInCondition() =>
+        "function test() { do var x = 1 while [x] == 1 }".AssertScriptEvaluation(
+            expectedDiagnostics: "BL1005: Undefined name 'x'.");
+
+    [Fact]
+    public void Binder_IfBranches_HaveIndependentScopes() =>
+        "function test(value: bool) { if value var x = 1 else var x = 2 } test(true)".AssertScriptEvaluation();
+}

--- a/src/Balu.Tests/ExecutionTests/EmbeddedStatementScopeTests.cs
+++ b/src/Balu.Tests/ExecutionTests/EmbeddedStatementScopeTests.cs
@@ -1,0 +1,16 @@
+using TestHelpers;
+using Xunit;
+
+namespace Balu.Tests.CompilationTests.ExecutionTests;
+
+public partial class ExecutionTests
+{
+    [Theory]
+    [InlineData("function test(): int { if true var x = 1 var x = 2 return x } test()")]
+    [InlineData("function test(): int { if true {} else var x = 1 var x = 2 return x } test()")]
+    [InlineData("function test(): int { var run = true while run var x = run = false var x = 2 return x } test()")]
+    [InlineData("function test(): int { do var x = 1 while false var x = 2 return x } test()")]
+    [InlineData("function test(): int { for i = 1 to 1 var x = 1 var x = 2 return x } test()")]
+    public void Script_EmbeddedStatementVariable_CanBeRedeclaredAfterBody(string code) =>
+        code.AssertScriptEvaluation(value: 2);
+}

--- a/src/Balu/Balu.csproj
+++ b/src/Balu/Balu.csproj
@@ -11,8 +11,8 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<Version>0.4.0</Version>
-		<AssemblyVersion>0.4.0</AssemblyVersion>
+		<Version>0.4.1</Version>
+		<AssemblyVersion>0.4.1</AssemblyVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Balu/Binding/Binder.cs
+++ b/src/Balu/Binding/Binder.cs
@@ -326,15 +326,11 @@ sealed class Binder : SyntaxTreeVisitor
         var condition = (BoundExpression)boundNode!;
         condition = BindConversion(node.Condition, condition, TypeSymbol.Boolean);
 
-        Visit(node.ThenStatement);
-        var thenStatement = (BoundStatement)boundNode!;
+        var thenStatement = BindEmbeddedStatement(node.ThenStatement);
 
         BoundStatement? elseStatement = null;
         if (node.ElseClause is { Statement: var elseNode })
-        {
-            Visit(elseNode);
-            elseStatement = (BoundStatement)boundNode!;
-        }
+            elseStatement = BindEmbeddedStatement(elseNode);
 
         boundNode = If(node, condition, thenStatement, elseStatement);
     }
@@ -457,9 +453,23 @@ sealed class Binder : SyntaxTreeVisitor
         continueLabel = new ($"continue{labelCounter}");
         labelCounter++;
         loopStack.Push((breakLabel, continueLabel));
-        Visit(statement);
+        var result = BindEmbeddedStatement(statement);
         loopStack.Pop();
-        return (BoundStatement)boundNode!;
+        return result;
+    }
+    BoundStatement BindEmbeddedStatement(StatementSyntax statement)
+    {
+        if (statement.Kind == SyntaxKind.BlockStatement)
+        {
+            Visit(statement);
+            return (BoundStatement)boundNode!;
+        }
+
+        scope = new(scope);
+        Visit(statement);
+        var result = (BoundStatement)boundNode!;
+        scope = scope.Parent!;
+        return result;
     }
 
     static TypeSymbol? LookupType(string name) => name == TypeSymbol.Integer.Name

--- a/src/HelloWorld/helloworld.csproj
+++ b/src/HelloWorld/helloworld.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.4.0">
+﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.4.1">
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
 		<OutputType>Exe</OutputType>

--- a/src/bc/bc.csproj
+++ b/src/bc/bc.csproj
@@ -8,8 +8,8 @@
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
 		<AnalysisLevel>latest</AnalysisLevel>
 		<AnalysisMode>AllEnabledByDefault</AnalysisMode>
-		<Version>0.4.0</Version>
-		<AssemblyVersion>0.4.0</AssemblyVersion>
+		<Version>0.4.1</Version>
+		<AssemblyVersion>0.4.1</AssemblyVersion>
 	</PropertyGroup>
 	<ItemGroup>
 	  <PackageReference Include="Mono.Options" Version="6.12.0.148" />

--- a/src/bi/bi.csproj
+++ b/src/bi/bi.csproj
@@ -9,7 +9,7 @@
 	  <EnableNETAnalyzers>true</EnableNETAnalyzers>
 	  <AnalysisLevel>latest</AnalysisLevel>
 	  <AnalysisMode>AllEnabledByDefault</AnalysisMode>
-	  <AssemblyVersion>0.4.0</AssemblyVersion>
+	  <AssemblyVersion>0.4.1</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- bind unbraced `if`, `else`, and loop bodies in child scopes that match lowering and emission
- preserve the existing scope behavior for explicit block statements
- cover visibility, independent branch declarations, redeclaration, emission, and execution for every control-flow form

## Tests
- `dotnet test src/Balu.Tests/Balu.Tests.csproj --no-restore`
- `dotnet test src/Balu.Interpretation.Tests/Balu.Interpretation.Tests.csproj --no-restore`
- `dotnet test src/bc.Tests/bc.Tests.csproj --no-restore`
- `dotnet test src/Balu.Sdk.Tests/Balu.Sdk.Tests.csproj --no-restore`

Closes #78