### PR TITLE
Centralize release version

### DIFF
--- a/src/Balu.Interpretation/Balu.Interpretation.csproj
+++ b/src/Balu.Interpretation/Balu.Interpretation.csproj
@@ -11,12 +11,6 @@
 		<AnalysisMode>AllEnabledByDefault</AnalysisMode>
 	</PropertyGroup>
 
-	<PropertyGroup>
-		<Version>0.4.1</Version>
-		<AssemblyVersion>0.4.1</AssemblyVersion>
-	</PropertyGroup>
-
-
 	<ItemGroup>
 		<ProjectReference Include="..\Balu\Balu.csproj" />
 	</ItemGroup>

--- a/src/Balu.Sdk.Tests/Balu.Sdk.Tests.csproj
+++ b/src/Balu.Sdk.Tests/Balu.Sdk.Tests.csproj
@@ -5,6 +5,8 @@
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
+		<BaluSdkPackageId>Balu.Sdk</BaluSdkPackageId>
+		<BaluSdkPackagePath>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..\Balu.Sdk\bin\$(Configuration)', '$(BaluSdkPackageId).$(BaluVersion).nupkg'))</BaluSdkPackagePath>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -24,38 +26,16 @@
 	<ItemGroup>
 		<ProjectReference Include="..\Balu.Sdk\Balu.Sdk.csproj" ReferenceOutputAssembly="false" />
 		<_BaluSdkPackageInput Include="..\Balu\**\*;..\Balu.SourceGenerator\**\*;..\Balu.Sdk\**\*;..\bc\**\*" Exclude="..\**\bin\**;..\**\obj\**" />
+		<AssemblyMetadata Include="BaluSdkPackageId" Value="$(BaluSdkPackageId)" />
+		<AssemblyMetadata Include="BaluSdkPackageVersion" Value="$(BaluVersion)" />
 	</ItemGroup>
 
-	<Target Name="ResolveBaluSdkPackageIdentity">
-		<MSBuild Projects="..\Balu.Sdk\Balu.Sdk.csproj" Targets="GetBaluSdkPackageIdentity" Properties="Configuration=$(Configuration)">
-			<Output TaskParameter="TargetOutputs" ItemName="_BaluSdkPackageIdentity" />
-		</MSBuild>
-		<PropertyGroup>
-			<BaluSdkPackageId>@(_BaluSdkPackageIdentity)</BaluSdkPackageId>
-			<BaluSdkPackageVersion>%(_BaluSdkPackageIdentity.Version)</BaluSdkPackageVersion>
-			<BaluSdkPackagePath>%(_BaluSdkPackageIdentity.PackagePath)</BaluSdkPackagePath>
-		</PropertyGroup>
-	</Target>
-
-	<Target Name="AddBaluSdkPackageMetadata" BeforeTargets="GetAssemblyAttributes" DependsOnTargets="ResolveBaluSdkPackageIdentity">
-		<ItemGroup>
-			<AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
-				<_Parameter1>BaluSdkPackageId</_Parameter1>
-				<_Parameter2>$(BaluSdkPackageId)</_Parameter2>
-			</AssemblyAttribute>
-			<AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
-				<_Parameter1>BaluSdkPackageVersion</_Parameter1>
-				<_Parameter2>$(BaluSdkPackageVersion)</_Parameter2>
-			</AssemblyAttribute>
-		</ItemGroup>
-	</Target>
-
-	<Target Name="EnsureCurrentBaluSdkPackage" BeforeTargets="CopyBaluSdkPackage" DependsOnTargets="ResolveBaluSdkPackageIdentity" Inputs="@(_BaluSdkPackageInput)" Outputs="$(BaluSdkPackagePath)">
+	<Target Name="EnsureCurrentBaluSdkPackage" BeforeTargets="CopyBaluSdkPackage" Inputs="@(_BaluSdkPackageInput)" Outputs="$(BaluSdkPackagePath)">
 		<Delete Files="$(BaluSdkPackagePath)" />
 		<MSBuild Projects="..\Balu.Sdk\Balu.Sdk.csproj" Targets="Build" Properties="Configuration=$(Configuration)" />
 	</Target>
 
-	<Target Name="CopyBaluSdkPackage" AfterTargets="Build" DependsOnTargets="ResolveBaluSdkPackageIdentity">
+	<Target Name="CopyBaluSdkPackage" AfterTargets="Build">
 		<ItemGroup>
 			<_BaluSdkPackage Include="$(BaluSdkPackagePath)" />
 		</ItemGroup>

--- a/src/Balu.Sdk/Balu.Sdk.csproj
+++ b/src/Balu.Sdk/Balu.Sdk.csproj
@@ -44,19 +44,6 @@
 		<Content Include="Sdk.props" PackagePath="sdk/" />
 		<Content Include="Sdk.targets" PackagePath="sdk/" />
 	</ItemGroup>
-	<Target Name="GetBaluSdkPackageIdentity" Returns="@(_BaluSdkPackageIdentity)">
-		<PropertyGroup>
-			<_BaluSdkPackageVersion Condition="'$(PackageVersion)' != ''">$(PackageVersion)</_BaluSdkPackageVersion>
-			<_BaluSdkPackageVersion Condition="'$(_BaluSdkPackageVersion)' == ''">$(Version)</_BaluSdkPackageVersion>
-			<_BaluSdkPackageOutputPath Condition="'$(PackageOutputPath)' != ''">$(PackageOutputPath)</_BaluSdkPackageOutputPath>
-			<_BaluSdkPackageOutputPath Condition="'$(_BaluSdkPackageOutputPath)' == ''">$(OutputPath)</_BaluSdkPackageOutputPath>
-			<_BaluSdkPackagePath>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), '$(_BaluSdkPackageOutputPath)', '$(PackageId).$(_BaluSdkPackageVersion).nupkg'))</_BaluSdkPackagePath>
-		</PropertyGroup>
-		<ItemGroup>
-			<_BaluSdkPackageIdentity Include="$(PackageId)" Version="$(_BaluSdkPackageVersion)" PackagePath="$(_BaluSdkPackagePath)" />
-		</ItemGroup>
-	</Target>
-
 	<Target Name="CollectPackageBuildOutput" DependsOnTargets="ResolveReferences">
 		<MSBuild Projects="$(BaluCompilerProject)"
 				 Targets="GetBaluCompilerPackageFiles"

--- a/src/Balu.Sdk/Balu.Sdk.csproj
+++ b/src/Balu.Sdk/Balu.Sdk.csproj
@@ -8,8 +8,6 @@
 	<PropertyGroup>
 		<IsPackable>true</IsPackable>
 		<PackageId>Balu.Sdk</PackageId>
-		<Version>0.4.1</Version>
-		<AssemblyVersion>0.4.1</AssemblyVersion>
 		<Title>Balu.Sdk</Title>
 		<Authors>René Vogt</Authors>
 		<Description>The Balu language SDK.</Description>

--- a/src/Balu.sln
+++ b/src/Balu.sln
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Projektmappenelemente", "Pr
 	ProjectSection(SolutionItems) = preProject
 		..\.gitignore = ..\.gitignore
 		..\AGENTS.md = ..\AGENTS.md
+		Directory.Build.props = Directory.Build.props
 		..\LICENSE = ..\LICENSE
 		..\README.md = ..\README.md
 	EndProjectSection

--- a/src/Balu/Balu.csproj
+++ b/src/Balu/Balu.csproj
@@ -10,11 +10,6 @@
 		<AnalysisMode>AllEnabledByDefault</AnalysisMode>
 	</PropertyGroup>
 
-	<PropertyGroup>
-		<Version>0.4.1</Version>
-		<AssemblyVersion>0.4.1</AssemblyVersion>
-	</PropertyGroup>
-
 	<ItemGroup>
 	  <PackageReference Include="Mono.Cecil" Version="0.11.4" />
 	  <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,14 @@
+<Project>
+	<PropertyGroup>
+		<BaluVersion Condition="'$(BaluVersion)' == ''">0.4.1</BaluVersion>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(MSBuildProjectName)' == 'Balu' Or
+						  '$(MSBuildProjectName)' == 'bc' Or
+						  '$(MSBuildProjectName)' == 'bi' Or
+						  '$(MSBuildProjectName)' == 'Balu.Interpretation' Or
+						  '$(MSBuildProjectName)' == 'Balu.Sdk'">
+		<Version>$(BaluVersion)</Version>
+		<AssemblyVersion>$(Version)</AssemblyVersion>
+	</PropertyGroup>
+</Project>

--- a/src/bc/bc.csproj
+++ b/src/bc/bc.csproj
@@ -8,8 +8,6 @@
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
 		<AnalysisLevel>latest</AnalysisLevel>
 		<AnalysisMode>AllEnabledByDefault</AnalysisMode>
-		<Version>0.4.1</Version>
-		<AssemblyVersion>0.4.1</AssemblyVersion>
 	</PropertyGroup>
 	<ItemGroup>
 	  <PackageReference Include="Mono.Options" Version="6.12.0.148" />

--- a/src/bi/bi.csproj
+++ b/src/bi/bi.csproj
@@ -9,7 +9,6 @@
 	  <EnableNETAnalyzers>true</EnableNETAnalyzers>
 	  <AnalysisLevel>latest</AnalysisLevel>
 	  <AnalysisMode>AllEnabledByDefault</AnalysisMode>
-	  <AssemblyVersion>0.4.1</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- add `src/Directory.Build.props` as the single source for the Balu release version
- apply `Version` and `AssemblyVersion` to Balu, bc, bi, Balu.Interpretation, and Balu.Sdk
- let Balu.Sdk.Tests use `BaluVersion` directly and remove the package identity helper targets
- expose the props file as a solution item while leaving the HelloWorld SDK reference unchanged

## Verification
- evaluated all five release projects with the current version and with `BaluVersion=9.8.7`
- verified that the SDK test package path follows `BaluVersion`
- `dotnet test src/Balu.Tests/Balu.Tests.csproj --no-restore` (21,703 passed)
- `dotnet test src/Balu.Interpretation.Tests/Balu.Interpretation.Tests.csproj --no-restore` (14 passed)
- `dotnet test src/bc.Tests/bc.Tests.csproj --no-restore` (7 passed)
- `dotnet test src/Balu.Sdk.Tests/Balu.Sdk.Tests.csproj --no-restore` (9 passed)
- `dotnet build src/bi/bi.csproj --no-restore`