### PR TITLE
Stabilize source generator node ordering

### DIFF
--- a/src/Balu.SourceGenerator.Tests/Balu.SourceGenerator.Tests.csproj
+++ b/src/Balu.SourceGenerator.Tests/Balu.SourceGenerator.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+		<PackageReference Include="xunit" Version="2.4.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.2.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Balu.SourceGenerator\Balu.SourceGenerator.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/Balu.SourceGenerator.Tests/GeneratorOrderingTests.cs
+++ b/src/Balu.SourceGenerator.Tests/GeneratorOrderingTests.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Balu.SourceGenerator;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Balu.SourceGenerator.Tests;
+
+public sealed class GeneratorOrderingTests
+{
+    [Fact]
+    public void Generator_UsesConstructorOrderForChildrenAndRewriterArguments()
+    {
+        var (result, compilationDiagnostics) = RunGenerator(ValidSource);
+
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        Assert.DoesNotContain(compilationDiagnostics, diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        var syntaxChildren = GetGeneratedSource(result, "SyntaxNodeChildren.g.cs");
+        Assert.True(syntaxChildren.IndexOf("case 0: return First;", StringComparison.Ordinal) <
+                    syntaxChildren.IndexOf("case 1: return Second;", StringComparison.Ordinal));
+
+        var boundChildren = GetGeneratedSource(result, "BoundNodeChildren.g.cs");
+        Assert.True(boundChildren.IndexOf("case 0: return Left;", StringComparison.Ordinal) <
+                    boundChildren.IndexOf("case 1: return Right;", StringComparison.Ordinal));
+
+        var rewriter = GetGeneratedSource(result, "BoundTreeRewriter.g.cs");
+        Assert.Contains("new BoundPair(node.Syntax, rewrittenLeft, rewrittenRight)", rewriter);
+    }
+
+    [Fact]
+    public void Generator_ReportsParameterWithoutMatchingProperty()
+    {
+        var (result, _) = RunGenerator(ValidSource.Replace("public SyntaxNode First { get; }", "public SyntaxNode Other { get; }", StringComparison.Ordinal));
+
+        var diagnostic = Assert.Single(result.Diagnostics.Where(candidate => candidate.Id == "BLS0001"));
+        Assert.Contains("parameter 'first' has no property with the same name and type", diagnostic.GetMessage());
+        Assert.True(diagnostic.Location.IsInSource);
+    }
+
+    static (GeneratorDriverRunResult Result, ImmutableArray<Diagnostic> CompilationDiagnostics) RunGenerator(string source)
+    {
+        var parseOptions = new CSharpParseOptions(LanguageVersion.CSharp10);
+        var syntaxTree = CSharpSyntaxTree.ParseText(source, parseOptions);
+        var compilation = CSharpCompilation.Create("GeneratorTests",
+                                                   new[] { syntaxTree },
+                                                   GetReferences(),
+                                                   new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { new BaluSourceGenerator() }, parseOptions: parseOptions);
+        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out _);
+        return (driver.GetRunResult(), outputCompilation.GetDiagnostics());
+    }
+
+    static string GetGeneratedSource(GeneratorDriverRunResult result, string hintName) =>
+        result.Results.Single().GeneratedSources.Single(source => source.HintName == hintName).SourceText.ToString();
+
+    static IEnumerable<MetadataReference> GetReferences()
+    {
+        var trustedAssemblies = (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") ??
+                                throw new InvalidOperationException("Trusted platform assemblies are unavailable.");
+        return trustedAssemblies.Split(Path.PathSeparator).Select(path => MetadataReference.CreateFromFile(path));
+    }
+
+    const string ValidSource = """
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Balu.Syntax
+{
+    public enum SyntaxKind { Ordered }
+
+    public abstract class SyntaxNode
+    {
+        public abstract SyntaxKind Kind { get; }
+        public abstract int ChildrenCount { get; }
+        public abstract SyntaxNode GetChild(int index);
+    }
+
+    public sealed class SyntaxToken : SyntaxNode
+    {
+        public override SyntaxKind Kind => default;
+        public override int ChildrenCount => 0;
+        public override SyntaxNode GetChild(int index) => throw new ArgumentOutOfRangeException(nameof(index));
+    }
+
+    sealed class SeparatedSyntaxList<T> where T : SyntaxNode
+    {
+        public ImmutableArray<SyntaxNode> ElementsWithSeparators { get; } = ImmutableArray<SyntaxNode>.Empty;
+        public SyntaxNode this[int index] => ElementsWithSeparators[index];
+    }
+
+    public sealed partial class OrderedSyntax : SyntaxNode
+    {
+        public SyntaxNode Second { get; }
+        public SyntaxNode First { get; }
+        public override SyntaxKind Kind => SyntaxKind.Ordered;
+
+        public OrderedSyntax(SyntaxNode first, SyntaxNode second)
+        {
+            First = first;
+            Second = second;
+        }
+
+        public OrderedSyntax(SyntaxNode first) : this(first, first) { }
+
+        public OrderedSyntax(string value, int count) : this(new SyntaxToken(), new SyntaxToken()) { }
+    }
+}
+
+namespace Balu.Binding
+{
+    using Balu.Syntax;
+
+    enum BoundNodeKind { Pair }
+
+    abstract class BoundNode
+    {
+        protected BoundNode(SyntaxNode syntax) => Syntax = syntax;
+        public SyntaxNode Syntax { get; }
+        public abstract BoundNodeKind Kind { get; }
+        public abstract int ChildrenCount { get; }
+        public abstract BoundNode GetChild(int index);
+    }
+
+    abstract class BoundLoopStatement : BoundNode
+    {
+        protected BoundLoopStatement(SyntaxNode syntax) : base(syntax) { }
+    }
+
+    sealed partial class BoundPair : BoundNode
+    {
+        public BoundNode Right { get; }
+        public BoundNode Left { get; }
+        public override BoundNodeKind Kind => BoundNodeKind.Pair;
+
+        public BoundPair(SyntaxNode syntax, BoundNode left, BoundNode right) : base(syntax)
+        {
+            Left = left;
+            Right = right;
+        }
+    }
+}
+""";
+}

--- a/src/Balu.SourceGenerator/BaluSourceGenerator.cs
+++ b/src/Balu.SourceGenerator/BaluSourceGenerator.cs
@@ -9,7 +9,6 @@ public sealed class BaluSourceGenerator : ISourceGenerator
 {
     public const string BoundNodeTypeName = "Balu.Binding.BoundNode";
     public const string BoundNodeKindTypeName = "Balu.Binding.BoundNodeKind";
-    public const string BoundLoopStatementTypeName = "Balu.Binding.BoundLoopStatement";
     public const string SyntaxNodeTypeName = "Balu.Syntax.SyntaxNode";
     public const string SyntaxKindTypeName = "Balu.Syntax.SyntaxKind";
     public const string SeparatedSyntaxListTypeName = "Balu.Syntax.SeparatedSyntaxList`1";
@@ -30,13 +29,12 @@ public sealed class BaluSourceGenerator : ISourceGenerator
         var compilation = (CSharpCompilation)context.Compilation;
         var boundNodeType = FindType(context, BoundNodeTypeName);
         var boundNodeKindType = FindType(context, BoundNodeKindTypeName);
-        var boundLoopStatementType = FindType(context, BoundLoopStatementTypeName);
         var immutableArrayType = FindType(context, ImmutableArrayTypeName);
         var syntaxNodeType = FindType(context, SyntaxNodeTypeName);
         var syntaxNodeKindType = FindType(context, SyntaxKindTypeName);
         var separatedListType = FindType(context, SeparatedSyntaxListTypeName);
 
-        if (boundNodeType is null || boundNodeKindType is null || boundLoopStatementType is null || immutableArrayType is null || syntaxNodeType is null ||
+        if (boundNodeType is null || boundNodeKindType is null || immutableArrayType is null || syntaxNodeType is null ||
             syntaxNodeKindType is null || separatedListType is null) return;
 
         var generators = new BaseGenerator[]
@@ -45,7 +43,7 @@ public sealed class BaluSourceGenerator : ISourceGenerator
             new SyntaxTreeVisitorGenerator(compilation, syntaxNodeType, syntaxNodeKindType), 
             new BoundNodeChildrenGenerator(compilation, boundNodeType, immutableArrayType), 
             new BoundTreeVisitorGenerator(compilation, boundNodeType, boundNodeKindType),
-            new BoundTreeRewriterGenerator(compilation, boundNodeType, boundNodeKindType, boundLoopStatementType, immutableArrayType)
+            new BoundTreeRewriterGenerator(compilation, boundNodeType, boundNodeKindType, immutableArrayType)
         };
 
         foreach (var generator in generators.TakeWhile(_ => !context.CancellationToken.IsCancellationRequested))

--- a/src/Balu.SourceGenerator/BoundNodeChildrenGenerator.cs
+++ b/src/Balu.SourceGenerator/BoundNodeChildrenGenerator.cs
@@ -32,33 +32,35 @@ sealed class BoundNodeChildrenGenerator : BaseGenerator
         var boundNodeTypes = types.Where(t => !t.IsAbstract && t.IsPartial() && t.IsDerivedFrom(boundNodeType) && SymbolEqualityComparer.Default.Equals(boundNodeType.ContainingNamespace, t.ContainingNamespace));
 
         foreach (var type in boundNodeTypes.TakeWhile(_ => !context.CancellationToken.IsCancellationRequested))
-                WriteType(type);
+                WriteType(type, context);
 
         context.AddSource(
             "BoundNodeChildren.g.cs",
             SourceText.From(Writer.InnerWriter.ToString(), Encoding.UTF8));
     }
-    void WriteType(INamedTypeSymbol type)
+    void WriteType(INamedTypeSymbol type, GeneratorExecutionContext context)
     {
+        var model = NodeModel.Create(type, context);
+        if (model is null) return;
+
+        var properties = model.Parameters
+                              .Select(parameter => parameter.Property)
+                              .Where(property => property.Type is INamedTypeSymbol propertyType &&
+                                                 (propertyType.IsDerivedFrom(boundNodeType) ||
+                                                  propertyType.IsGenericListOf(immutableArrayType, boundNodeType)))
+                              .ToImmutableArray();
         using(new CurlyIndenter(Writer, $"partial class {type.Name}"))
         {
-            WriteChildrenCount(type);
-            WriteGetChild(type);
+            WriteChildrenCount(properties);
+            WriteGetChild(properties);
         }
     }
-    void WriteChildrenCount(INamedTypeSymbol type)
+    void WriteChildrenCount(ImmutableArray<IPropertySymbol> properties)
     {
-        var properties = type.GetMembers()
-                             .OfType<IPropertySymbol>()
-                             .Where(property => property.Type is INamedTypeSymbol propertyType &&
-                                                propertyType.IsDerivedFrom(boundNodeType))
-                             .ToImmutableArray();
-        var nonNullableProperties = properties.Where(property => property.NullableAnnotation != NullableAnnotation.Annotated).ToImmutableArray();
-        var nullableProperties = properties.Where(property => property.NullableAnnotation == NullableAnnotation.Annotated).ToImmutableArray();
-        var collections = type.GetMembers()
-                              .OfType<IPropertySymbol>()
-                              .Where(property => property.Type is INamedTypeSymbol propertyType && propertyType.IsGenericListOf(immutableArrayType, boundNodeType))
-                              .ToImmutableArray();
+        var nodeProperties = properties.Where(property => ((INamedTypeSymbol)property.Type).IsDerivedFrom(boundNodeType)).ToImmutableArray();
+        var nonNullableProperties = nodeProperties.Where(property => property.NullableAnnotation != NullableAnnotation.Annotated).ToImmutableArray();
+        var nullableProperties = nodeProperties.Where(property => property.NullableAnnotation == NullableAnnotation.Annotated).ToImmutableArray();
+        var collections = properties.Where(property => ((INamedTypeSymbol)property.Type).IsGenericListOf(immutableArrayType, boundNodeType)).ToImmutableArray();
 
         if (nullableProperties.Length == 0)
         {
@@ -98,16 +100,10 @@ sealed class BoundNodeChildrenGenerator : BaseGenerator
             Writer.Write(string.Join(" + ", collections.Select(collection => $"{collection.Name}.Length")));
         }
     }
-    void WriteGetChild(INamedTypeSymbol type)
+    void WriteGetChild(ImmutableArray<IPropertySymbol> properties)
     {
         const string signature = "public override Balu.Binding.BoundNode GetChild(int index)";
         const string exception = "throw new ArgumentOutOfRangeException(\"index\")";
-
-        var properties = type.GetMembers()
-                             .OfType<IPropertySymbol>()
-                             .Where(property => property.Type is INamedTypeSymbol propertyType &&
-                                                (propertyType.IsDerivedFrom(boundNodeType) ||
-                                                 propertyType.IsGenericListOf(immutableArrayType, boundNodeType))).ToImmutableArray();
 
         if (properties.Length == 0)
         {

--- a/src/Balu.SourceGenerator/BoundTreeRewriterGenerator.cs
+++ b/src/Balu.SourceGenerator/BoundTreeRewriterGenerator.cs
@@ -10,22 +10,14 @@ namespace Balu.SourceGenerator;
 sealed class BoundTreeRewriterGenerator : BaseGenerator
 {
 
-    static readonly DiagnosticDescriptor UnableToConstructBoundNode = new(id: "BLS0001",
-                                                                     title: "BoundNode construction failure",
-                                                                     messageFormat: "Cannot generate rewrite method for '{0}', constructor arguments do not match.",
-                                                                     category: "Balu source generation",
-                                                                     DiagnosticSeverity.Error,
-                                                                     isEnabledByDefault: true);
-
     readonly CSharpCompilation compilation;
-    readonly INamedTypeSymbol boundNodeType, boundNodeKindType, boundLoopStatementType, immutableArrayType;
+    readonly INamedTypeSymbol boundNodeType, boundNodeKindType, immutableArrayType;
 
-    internal BoundTreeRewriterGenerator(CSharpCompilation compilation, INamedTypeSymbol boundNodeType, INamedTypeSymbol boundNodeKindType, INamedTypeSymbol boundLoopStatementType, INamedTypeSymbol immutableArrayType)
+    internal BoundTreeRewriterGenerator(CSharpCompilation compilation, INamedTypeSymbol boundNodeType, INamedTypeSymbol boundNodeKindType, INamedTypeSymbol immutableArrayType)
     {
         this.compilation = compilation;
         this.boundNodeType = boundNodeType;
         this.boundNodeKindType = boundNodeKindType;
-        this.boundLoopStatementType = boundLoopStatementType;
         this.immutableArrayType = immutableArrayType;
     }
 
@@ -78,12 +70,15 @@ sealed class BoundTreeRewriterGenerator : BaseGenerator
 
             foreach (var (kind, type) in kindsToVisit)
             {
-                var propertiesToRewrite = type!.GetMembers()
-                                      .OfType<IPropertySymbol>()
-                                      .Where(property => property.Type is INamedTypeSymbol propertyType &&
-                                                         (propertyType.IsDerivedFrom(boundNodeType) ||
-                                                          propertyType.IsGenericListOf(immutableArrayType, boundNodeType)))
-                                      .ToImmutableArray();
+                var model = NodeModel.Create(type!, context);
+                if (model is null) continue;
+
+                var propertiesToRewrite = model.Parameters
+                                               .Select(parameter => parameter.Property)
+                                               .Where(property => property.Type is INamedTypeSymbol propertyType &&
+                                                                  (propertyType.IsDerivedFrom(boundNodeType) ||
+                                                                   propertyType.IsGenericListOf(immutableArrayType, boundNodeType)))
+                                               .ToImmutableArray();
 
                 if (propertiesToRewrite.Length == 0)
                 {
@@ -110,37 +105,16 @@ sealed class BoundTreeRewriterGenerator : BaseGenerator
                     Writer.WriteLine();
                     Writer.Write("return ");
                     Writer.Write(string.Join(" && ", propertiesToRewrite.Select(property => $"node.{property.Name} == rewritten{property.Name}")));
-                    Writer.Write($" ? node : new {type.Name}(node.Syntax");
-
-                    var allProperties = type.GetMembers()
-                                            .OfType<IPropertySymbol>()
-                                            .Where(property => property.Type is INamedTypeSymbol)
-                                            .ToImmutableArray();
-                    var constructorParameters = type.InstanceConstructors.First(ctor => !ctor.IsOverride).Parameters;
-                    int propertyIndex, argumentIndex;
-                    for (propertyIndex = 0, argumentIndex = 1;
-                         propertyIndex < allProperties.Length && argumentIndex < constructorParameters.Length; propertyIndex++)
+                    Writer.Write($" ? node : new {type.Name}(");
+                    for (int i = 0; i < model.Parameters.Length; i++)
                     {
-                        var property = allProperties[propertyIndex];
-                        if (!SymbolEqualityComparer.Default.Equals(property.Type, constructorParameters[argumentIndex].Type))
-                            continue;
-                        Writer.Write(", ");
+                        if (i > 0) Writer.Write(", ");
+                        var property = model.Parameters[i].Property;
                         if (propertiesToRewrite.Contains(property))
                             Writer.Write($"rewritten{property.Name}");
                         else
                             Writer.Write($"node.{property.Name}");
-                        argumentIndex++;
                     }
-
-                    if (type.IsDerivedFrom(boundLoopStatementType))
-                    {
-                        Writer.Write(", node.BreakLabel, node.ContinueLabel");
-                        argumentIndex += 2;
-                    }
-
-                    if (argumentIndex != constructorParameters.Length || allProperties.Skip(propertyIndex).Any(propertiesToRewrite.Contains))
-                        context.ReportDiagnostic(Diagnostic.Create(UnableToConstructBoundNode, null, DiagnosticSeverity.Error, null, null, type.Name));
-
                     Writer.WriteLine(");");
                 }
             }

--- a/src/Balu.SourceGenerator/NodeModel.cs
+++ b/src/Balu.SourceGenerator/NodeModel.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace Balu.SourceGenerator;
+
+sealed class NodeModel
+{
+    internal static readonly DiagnosticDescriptor InvalidNodeModel = new(id: "BLS0001",
+                                                                          title: "Node construction failure",
+                                                                          messageFormat: "Cannot determine the constructor model for '{0}': {1}",
+                                                                          category: "Balu source generation",
+                                                                          DiagnosticSeverity.Error,
+                                                                          isEnabledByDefault: true);
+
+    internal ImmutableArray<(IParameterSymbol Parameter, IPropertySymbol Property)> Parameters { get; }
+
+    NodeModel(ImmutableArray<(IParameterSymbol Parameter, IPropertySymbol Property)> parameters)
+    {
+        Parameters = parameters;
+    }
+
+    internal static NodeModel? Create(INamedTypeSymbol type, GeneratorExecutionContext context)
+    {
+        var constructors = type.InstanceConstructors
+                               .Where(constructor => !constructor.IsImplicitlyDeclared)
+                               .ToImmutableArray();
+        if (constructors.Length == 0)
+            constructors = type.InstanceConstructors;
+
+        var properties = GetProperties(type);
+        var candidates = constructors.Select(constructor => (Constructor: constructor, Parameters: MapParameters(constructor)))
+                                     .Where(candidate => candidate.Parameters is not null)
+                                     .ToImmutableArray();
+        if (candidates.Length == 0)
+        {
+            var constructor = constructors.OrderByDescending(candidate => candidate.Parameters.Length).First();
+            _ = TryMapParameters(constructor, out var reason);
+            return ReportError(reason!);
+        }
+
+        var maximumParameterCount = candidates.Max(candidate => candidate.Constructor.Parameters.Length);
+        var longestCandidates = candidates.Where(candidate => candidate.Constructor.Parameters.Length == maximumParameterCount).ToImmutableArray();
+        if (longestCandidates.Length != 1)
+            return ReportError($"{longestCandidates.Length} constructors with {maximumParameterCount} parameters match the node properties");
+
+        return new NodeModel(longestCandidates[0].Parameters!.Value);
+
+        ImmutableArray<(IParameterSymbol, IPropertySymbol)>? MapParameters(IMethodSymbol constructor) =>
+            TryMapParameters(constructor, out _);
+
+        ImmutableArray<(IParameterSymbol, IPropertySymbol)>? TryMapParameters(IMethodSymbol constructor, out string? reason)
+        {
+            var parameters = ImmutableArray.CreateBuilder<(IParameterSymbol, IPropertySymbol)>(constructor.Parameters.Length);
+            foreach (var parameter in constructor.Parameters)
+            {
+                var matchingProperties = properties.Where(property =>
+                                                              string.Equals(property.Name, parameter.Name, StringComparison.OrdinalIgnoreCase) &&
+                                                              SymbolEqualityComparer.Default.Equals(property.Type, parameter.Type))
+                                                   .ToImmutableArray();
+                if (matchingProperties.Length != 1)
+                {
+                    reason = matchingProperties.Length == 0
+                                 ? $"parameter '{parameter.Name}' has no property with the same name and type"
+                                 : $"parameter '{parameter.Name}' matches multiple properties";
+                    return null;
+                }
+
+                parameters.Add((parameter, matchingProperties[0]));
+            }
+
+            reason = null;
+            return parameters.ToImmutable();
+        }
+
+        NodeModel? ReportError(string reason)
+        {
+            var location = type.Locations.FirstOrDefault(candidate => candidate.IsInSource);
+            context.ReportDiagnostic(Diagnostic.Create(InvalidNodeModel, location, type.Name, reason));
+            return null;
+        }
+    }
+
+    static ImmutableArray<IPropertySymbol> GetProperties(INamedTypeSymbol type)
+    {
+        var properties = ImmutableArray.CreateBuilder<IPropertySymbol>();
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (var current = type; current is not null; current = current.BaseType)
+            foreach (var property in current.GetMembers().OfType<IPropertySymbol>())
+                if (names.Add(property.Name))
+                    properties.Add(property);
+        return properties.ToImmutable();
+    }
+}

--- a/src/Balu.SourceGenerator/SyntaxNodeChildrenGenerator.cs
+++ b/src/Balu.SourceGenerator/SyntaxNodeChildrenGenerator.cs
@@ -21,7 +21,7 @@ sealed class SyntaxNodeChildrenGenerator : BaseGenerator
         this.immutableArrayType = immutableArrayType;
     }
 
-    public override void Generate(GeneratorExecutionContext context) 
+    public override void Generate(GeneratorExecutionContext context)
     {
         Writer.WriteLine("using System;");
         Writer.WriteLine("using System.Collections.Generic;");
@@ -34,37 +34,37 @@ sealed class SyntaxNodeChildrenGenerator : BaseGenerator
                                                SymbolEqualityComparer.Default.Equals(syntaxNodeType.ContainingNamespace, t.ContainingNamespace));
 
         foreach (var type in syntaxNodeTypes.TakeWhile(_ => !context.CancellationToken.IsCancellationRequested))
-            WriteType(type);
+            WriteType(type, context);
 
         context.AddSource(
             "SyntaxNodeChildren.g.cs",
             SourceText.From(Writer.InnerWriter.ToString(), Encoding.UTF8));
     }
-    void WriteType(INamedTypeSymbol type)
+    void WriteType(INamedTypeSymbol type, GeneratorExecutionContext context)
     {
+        var model = NodeModel.Create(type, context);
+        if (model is null) return;
+
+        var properties = model.Parameters
+                              .Select(parameter => parameter.Property)
+                              .Where(property => property.Type is INamedTypeSymbol propertyType &&
+                                                 (propertyType.IsDerivedFrom(syntaxNodeType) ||
+                                                  propertyType.IsGenericListOf(separatedListType, syntaxNodeType) ||
+                                                  propertyType.IsGenericListOf(immutableArrayType, syntaxNodeType)))
+                              .ToImmutableArray();
         using(new CurlyIndenter(Writer, $"partial class {type.Name}"))
         {
-            WriteChildrenCount(type);
-            WriteGetChild(type);
+            WriteChildrenCount(properties);
+            WriteGetChild(properties);
         }
     }
-    void WriteChildrenCount(INamedTypeSymbol type)
+    void WriteChildrenCount(ImmutableArray<IPropertySymbol> properties)
     {
-        var properties = type.GetMembers()
-                             .OfType<IPropertySymbol>()
-                             .Where(property => property.Type is INamedTypeSymbol propertyType &&
-                                                propertyType.IsDerivedFrom(syntaxNodeType))
-                             .ToImmutableArray();
-        var nonNullableProperties = properties.Where(property => property.NullableAnnotation != NullableAnnotation.Annotated).ToImmutableArray();
-        var nullableProperties = properties.Where(property => property.NullableAnnotation == NullableAnnotation.Annotated).ToImmutableArray();
-        var separatedLists = type.GetMembers()
-                                 .OfType<IPropertySymbol>()
-                                 .Where(property => property.Type is INamedTypeSymbol propertyType && propertyType.IsGenericListOf(separatedListType, syntaxNodeType))
-                                 .ToImmutableArray();
-        var immutableArrays = type.GetMembers()
-                                 .OfType<IPropertySymbol>()
-                                 .Where(property => property.Type is INamedTypeSymbol propertyType && propertyType.IsGenericListOf(immutableArrayType, syntaxNodeType))
-                                 .ToImmutableArray();
+        var nodeProperties = properties.Where(property => ((INamedTypeSymbol)property.Type).IsDerivedFrom(syntaxNodeType)).ToImmutableArray();
+        var nonNullableProperties = nodeProperties.Where(property => property.NullableAnnotation != NullableAnnotation.Annotated).ToImmutableArray();
+        var nullableProperties = nodeProperties.Where(property => property.NullableAnnotation == NullableAnnotation.Annotated).ToImmutableArray();
+        var separatedLists = properties.Where(property => ((INamedTypeSymbol)property.Type).IsGenericListOf(separatedListType, syntaxNodeType)).ToImmutableArray();
+        var immutableArrays = properties.Where(property => ((INamedTypeSymbol)property.Type).IsGenericListOf(immutableArrayType, syntaxNodeType)).ToImmutableArray();
 
         if (nullableProperties.Length == 0)
         {
@@ -113,17 +113,10 @@ sealed class SyntaxNodeChildrenGenerator : BaseGenerator
             Writer.Write(builder.ToString());
         }
     }
-    void WriteGetChild(INamedTypeSymbol type)
+    void WriteGetChild(ImmutableArray<IPropertySymbol> properties)
     {
         const string signature = "public override Balu.Syntax.SyntaxNode GetChild(int index)";
         const string exception = "throw new ArgumentOutOfRangeException(\"index\")";
-
-        var properties = type.GetMembers()
-                             .OfType<IPropertySymbol>()
-                             .Where(property => property.Type is INamedTypeSymbol propertyType &&
-                                                (propertyType.IsDerivedFrom(syntaxNodeType) ||
-                                                 propertyType.IsGenericListOf(separatedListType, syntaxNodeType) ||
-                                                 propertyType.IsGenericListOf(immutableArrayType, syntaxNodeType))).ToImmutableArray();
 
         if (properties.Length == 0)
         {

--- a/src/Balu.Tests/ParserTests/VariableDeclarationStatementTests.cs
+++ b/src/Balu.Tests/ParserTests/VariableDeclarationStatementTests.cs
@@ -1,0 +1,33 @@
+using System.Linq;
+using Balu.Authoring;
+using Balu.Syntax;
+using Balu.Text;
+using Xunit;
+
+namespace Balu.Tests.ParserTests;
+
+public sealed class VariableDeclarationStatementTests
+{
+    [Fact]
+    public void Parser_TypedVariableDeclaration_PreservesSourceOrder()
+    {
+        const string text = "var i : any = 12";
+        var tree = SyntaxTree.Parse(text);
+        var globalStatement = Assert.IsType<GlobalStatementSyntax>(Assert.Single(tree.Root.Members));
+        var declaration = Assert.IsType<VariableDeclarationStatementSyntax>(globalStatement.Statement);
+
+        Assert.Equal(5, declaration.ChildrenCount);
+        Assert.Same(declaration.KeywordToken, declaration.GetChild(0));
+        Assert.Same(declaration.IdentifierToken, declaration.GetChild(1));
+        Assert.Same(declaration.TypeClause, declaration.GetChild(2));
+        Assert.Same(declaration.EqualsToken, declaration.GetChild(3));
+        Assert.Same(declaration.Expression, declaration.GetChild(4));
+        Assert.Equal(new TextSpan(0, text.Length), declaration.Span);
+        Assert.Equal(new TextSpan(0, text.Length), declaration.FullSpan);
+        Assert.Same(declaration.Expression.LastToken, declaration.LastToken);
+
+        var classifiedSpans = Classifier.Classify(tree, new TextSpan(0, text.Length));
+        Assert.Equal(classifiedSpans.Select(span => span.Span.Start).OrderBy(start => start),
+                     classifiedSpans.Select(span => span.Span.Start));
+    }
+}

--- a/src/Balu.sln
+++ b/src/Balu.sln
@@ -44,6 +44,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Balu.Interpretation.Tests",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Balu.Sdk.Tests", "Balu.Sdk.Tests\Balu.Sdk.Tests.csproj", "{D8B6A94F-0B65-471C-AA9B-880448B3AC1D}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Balu.SourceGenerator.Tests", "Balu.SourceGenerator.Tests\Balu.SourceGenerator.Tests.csproj", "{BFD94C17-20E7-462E-95A1-C5F4D36E7CA4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -210,6 +212,18 @@ Global
 		{D8B6A94F-0B65-471C-AA9B-880448B3AC1D}.Release|arm64.Build.0 = Release|Any CPU
 		{D8B6A94F-0B65-471C-AA9B-880448B3AC1D}.Release|x86.ActiveCfg = Release|Any CPU
 		{D8B6A94F-0B65-471C-AA9B-880448B3AC1D}.Release|x86.Build.0 = Release|Any CPU
+		{BFD94C17-20E7-462E-95A1-C5F4D36E7CA4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BFD94C17-20E7-462E-95A1-C5F4D36E7CA4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BFD94C17-20E7-462E-95A1-C5F4D36E7CA4}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{BFD94C17-20E7-462E-95A1-C5F4D36E7CA4}.Debug|arm64.Build.0 = Debug|Any CPU
+		{BFD94C17-20E7-462E-95A1-C5F4D36E7CA4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BFD94C17-20E7-462E-95A1-C5F4D36E7CA4}.Debug|x86.Build.0 = Debug|Any CPU
+		{BFD94C17-20E7-462E-95A1-C5F4D36E7CA4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BFD94C17-20E7-462E-95A1-C5F4D36E7CA4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BFD94C17-20E7-462E-95A1-C5F4D36E7CA4}.Release|arm64.ActiveCfg = Release|Any CPU
+		{BFD94C17-20E7-462E-95A1-C5F4D36E7CA4}.Release|arm64.Build.0 = Release|Any CPU
+		{BFD94C17-20E7-462E-95A1-C5F4D36E7CA4}.Release|x86.ActiveCfg = Release|Any CPU
+		{BFD94C17-20E7-462E-95A1-C5F4D36E7CA4}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Balu/Binding/BoundBinaryExpression.cs
+++ b/src/Balu/Binding/BoundBinaryExpression.cs
@@ -14,12 +14,12 @@ sealed partial class BoundBinaryExpression : BoundExpression
     public BoundBinaryOperator Operator { get; }
     public BoundExpression Right { get; }
     
-    public BoundBinaryExpression(SyntaxNode syntax, BoundExpression left, BoundBinaryOperator op, BoundExpression right) : base(syntax)
+    public BoundBinaryExpression(SyntaxNode syntax, BoundExpression left, BoundBinaryOperator @operator, BoundExpression right) : base(syntax)
     {
         Left = left;
-        Operator = op;
+        Operator = @operator;
         Right = right;
-        Constant = ConstantFolder.ComputeConstant(left, op, right);
+        Constant = ConstantFolder.ComputeConstant(left, @operator, right);
         HasSideEffects = Left.HasSideEffects || Right.HasSideEffects;
     }
 

--- a/src/Balu/Binding/BoundPostfixExpression.cs
+++ b/src/Balu/Binding/BoundPostfixExpression.cs
@@ -3,14 +3,14 @@ using Balu.Syntax;
 
 namespace Balu.Binding;
 
-sealed partial class BoundPostfixExpression(SyntaxNode syntax, VariableSymbol variable, BoundBinaryOperator op) : BoundExpression(syntax)
+sealed partial class BoundPostfixExpression(SyntaxNode syntax, VariableSymbol variable, BoundBinaryOperator @operator) : BoundExpression(syntax)
 {
     public override BoundNodeKind Kind => BoundNodeKind.PostfixExpression;
     public override TypeSymbol Type => Operator.Type;
     public override bool HasSideEffects => true;
 
     public VariableSymbol Variable { get; } = variable;
-    public BoundBinaryOperator Operator { get; } = op;
+    public BoundBinaryOperator Operator { get; } = @operator;
 
     public override string ToString() => $"{Variable.Name}{Operator.SyntaxKind.GetText()}";
 }

--- a/src/Balu/Binding/BoundPrefixExpression.cs
+++ b/src/Balu/Binding/BoundPrefixExpression.cs
@@ -3,13 +3,13 @@ using Balu.Syntax;
 
 namespace Balu.Binding;
 
-sealed partial class BoundPrefixExpression(SyntaxNode syntax, BoundBinaryOperator op, VariableSymbol variable) : BoundExpression(syntax)
+sealed partial class BoundPrefixExpression(SyntaxNode syntax, BoundBinaryOperator @operator, VariableSymbol variable) : BoundExpression(syntax)
 {
     public override BoundNodeKind Kind => BoundNodeKind.PrefixExpression;
     public override TypeSymbol Type => Operator.Type;
     public override bool HasSideEffects => true;
 
-    public BoundBinaryOperator Operator { get; } = op;
+    public BoundBinaryOperator Operator { get; } = @operator;
     public VariableSymbol Variable { get; } = variable;
 
     public override string ToString() => $"{Operator.SyntaxKind.GetText()}{Variable.Name}";

--- a/src/Balu/Binding/BoundUnaryExpression.cs
+++ b/src/Balu/Binding/BoundUnaryExpression.cs
@@ -3,14 +3,14 @@ using Balu.Syntax;
 
 namespace Balu.Binding;
 
-sealed partial class BoundUnaryExpression(SyntaxNode syntax, BoundUnaryOperator op, BoundExpression operand) : BoundExpression(syntax)
+sealed partial class BoundUnaryExpression(SyntaxNode syntax, BoundUnaryOperator @operator, BoundExpression operand) : BoundExpression(syntax)
 {
     public override BoundNodeKind Kind => BoundNodeKind.UnaryExpression;
     public override TypeSymbol Type => Operator.Type;
-    public override BoundConstant? Constant { get; } = ConstantFolder.ComputeConstant(op, operand);
+    public override BoundConstant? Constant { get; } = ConstantFolder.ComputeConstant(@operator, operand);
     public override bool HasSideEffects { get; } = operand.HasSideEffects;
 
-    public BoundUnaryOperator Operator { get; } = op;
+    public BoundUnaryOperator Operator { get; } = @operator;
     public BoundExpression Operand { get; } = operand;
 
     public override string ToString() => $"{Operator.SyntaxKind.GetText()} {Operand}";

--- a/src/Balu/Syntax/AssignmentExpressionSyntax.cs
+++ b/src/Balu/Syntax/AssignmentExpressionSyntax.cs
@@ -9,10 +9,10 @@ public sealed partial class AssignmentExpressionSyntax : ExpressionSyntax
     public ExpressionSyntax Expression { get; }
     public override SyntaxKind Kind => SyntaxKind.AssignmentExpression;
 
-    internal AssignmentExpressionSyntax(SyntaxTree syntaxTree, SyntaxToken identifierrToken, SyntaxToken assignmentToken, ExpressionSyntax expression)
+    internal AssignmentExpressionSyntax(SyntaxTree syntaxTree, SyntaxToken identifierToken, SyntaxToken assignmentToken, ExpressionSyntax expression)
         : base(syntaxTree ?? throw new ArgumentNullException(nameof(syntaxTree)))
     {
-        IdentifierToken = identifierrToken;
+        IdentifierToken = identifierToken;
         AssignmentToken = assignmentToken;
         Expression = expression;
     }

--- a/src/Balu/Syntax/ForStatementSyntax.cs
+++ b/src/Balu/Syntax/ForStatementSyntax.cs
@@ -13,15 +13,15 @@ public sealed partial class ForStatementSyntax : StatementSyntax
     public ExpressionSyntax UpperBound { get; }
     public StatementSyntax Body { get; }
 
-    internal ForStatementSyntax(SyntaxTree syntaxTree, SyntaxToken forKeyword, SyntaxToken identifierToken, SyntaxToken equals,
-                                ExpressionSyntax lowerBound, SyntaxToken toKeyWord, ExpressionSyntax upperBound, StatementSyntax body)
+    internal ForStatementSyntax(SyntaxTree syntaxTree, SyntaxToken forKeyword, SyntaxToken identifierToken, SyntaxToken equalsToken,
+                                ExpressionSyntax lowerBound, SyntaxToken toKeyword, ExpressionSyntax upperBound, StatementSyntax body)
         : base(syntaxTree ?? throw new ArgumentNullException(nameof(syntaxTree)))
     {
         ForKeyword = forKeyword ?? throw new ArgumentNullException(nameof(forKeyword));
         IdentifierToken = identifierToken ?? throw new ArgumentNullException(nameof(identifierToken));
-        EqualsToken = equals ?? throw new ArgumentNullException(nameof(equals));
+        EqualsToken = equalsToken ?? throw new ArgumentNullException(nameof(equalsToken));
         LowerBound = lowerBound ?? throw new ArgumentNullException(nameof(lowerBound));
-        ToKeyword = toKeyWord ?? throw new ArgumentNullException(nameof(toKeyWord));
+        ToKeyword = toKeyword ?? throw new ArgumentNullException(nameof(toKeyword));
         UpperBound = upperBound ?? throw new ArgumentNullException(nameof(upperBound));
         Body = body ?? throw new ArgumentNullException(nameof(body));
     }

--- a/src/Balu/Syntax/FunctionDeclarationSyntax.cs
+++ b/src/Balu/Syntax/FunctionDeclarationSyntax.cs
@@ -14,7 +14,7 @@ public sealed partial class FunctionDeclarationSyntax : MemberSyntax
     public BlockStatementSyntax Body { get; }
 
     internal FunctionDeclarationSyntax(SyntaxTree syntaxTree, SyntaxToken functionKeyword, SyntaxToken identifier, SyntaxToken openParenthesis,
-                                       SeparatedSyntaxList<ParameterSyntax> parameters, SyntaxToken closedParenthesis, TypeClauseSyntax? type,
+                                        SeparatedSyntaxList<ParameterSyntax> parameters, SyntaxToken closedParenthesis, TypeClauseSyntax? typeClause,
                                        BlockStatementSyntax body)
         : base(syntaxTree ?? throw new ArgumentNullException(nameof(syntaxTree)))
     {
@@ -23,7 +23,7 @@ public sealed partial class FunctionDeclarationSyntax : MemberSyntax
         OpenParenthesis = openParenthesis ?? throw new ArgumentNullException(nameof(openParenthesis));
         Parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
         ClosedParenthesis = closedParenthesis ?? throw new ArgumentNullException(nameof(closedParenthesis));
-        TypeClause = type;
+        TypeClause = typeClause;
         Body = body ?? throw new ArgumentNullException(nameof(body));
     }
 

--- a/src/Balu/Syntax/ParameterSyntax.cs
+++ b/src/Balu/Syntax/ParameterSyntax.cs
@@ -8,9 +8,9 @@ public sealed partial class ParameterSyntax : SyntaxNode
     public SyntaxToken Identifier { get; }
     public TypeClauseSyntax TypeClause { get; }
 
-    internal ParameterSyntax(SyntaxTree syntaxTree, SyntaxToken identifier, TypeClauseSyntax type) : base(syntaxTree ?? throw new ArgumentNullException(nameof(syntaxTree)))
+    internal ParameterSyntax(SyntaxTree syntaxTree, SyntaxToken identifier, TypeClauseSyntax typeClause) : base(syntaxTree ?? throw new ArgumentNullException(nameof(syntaxTree)))
     {
         Identifier = identifier ?? throw new ArgumentNullException(nameof(identifier)) ;
-        TypeClause = type ?? throw new ArgumentNullException(nameof(type));
+        TypeClause = typeClause ?? throw new ArgumentNullException(nameof(typeClause));
     }
 }

--- a/src/Balu/Syntax/Parser.cs
+++ b/src/Balu/Syntax/Parser.cs
@@ -179,7 +179,7 @@ sealed class Parser
         var typeClause = ParseOptionalTypeClause();
         var equals = MatchToken(SyntaxKind.EqualsToken);
         var expression = ParseExpression();
-        return new(syntaxTree, keyword, identifier, equals, expression, typeClause);
+        return new(syntaxTree, keyword, identifier, typeClause, equals, expression);
     }
     ContinueStatementSyntax ParseContinueStatement()
     {

--- a/src/Balu/Syntax/VariableDeclarationStatementSyntax.cs
+++ b/src/Balu/Syntax/VariableDeclarationStatementSyntax.cs
@@ -7,17 +7,17 @@ public sealed partial class VariableDeclarationStatementSyntax : StatementSyntax
     public override SyntaxKind Kind => SyntaxKind.VariableDeclarationStatement;
     public SyntaxToken KeywordToken { get; }
     public SyntaxToken IdentifierToken { get; }
+    public TypeClauseSyntax? TypeClause { get; }
     public SyntaxToken EqualsToken { get; }
     public ExpressionSyntax Expression { get; }
-    public TypeClauseSyntax? TypeClause { get; }
 
-    internal VariableDeclarationStatementSyntax(SyntaxTree syntaxTree, SyntaxToken keywordToken, SyntaxToken identifierToken, SyntaxToken equalsToken, ExpressionSyntax expression, TypeClauseSyntax? typeClause)
+    internal VariableDeclarationStatementSyntax(SyntaxTree syntaxTree, SyntaxToken keywordToken, SyntaxToken identifierToken, TypeClauseSyntax? typeClause, SyntaxToken equalsToken, ExpressionSyntax expression)
     : base(syntaxTree ?? throw new ArgumentNullException(nameof(syntaxTree)))
     {
         KeywordToken = keywordToken ?? throw new ArgumentNullException(nameof(keywordToken));
         IdentifierToken = identifierToken ?? throw new ArgumentNullException(nameof(identifierToken));
+        TypeClause = typeClause;
         EqualsToken = equalsToken ?? throw new ArgumentNullException(nameof(equalsToken));
         Expression = expression ?? throw new ArgumentNullException(nameof(expression));
-        TypeClause = typeClause;
     }
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<BaluVersion Condition="'$(BaluVersion)' == ''">0.4.1</BaluVersion>
+		<BaluVersion Condition="'$(BaluVersion)' == ''">0.4.2</BaluVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(MSBuildProjectName)' == 'Balu' Or

--- a/src/HelloWorld/helloworld.csproj
+++ b/src/HelloWorld/helloworld.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.4.1">
+﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.4.2">
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
 		<OutputType>Exe</OutputType>

--- a/src/TestHelpers/TestHelpers.csproj
+++ b/src/TestHelpers/TestHelpers.csproj
@@ -5,11 +5,13 @@
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
+		<IsTestProject>false</IsTestProject>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Mono.Cecil" Version="0.11.4" />
 		<PackageReference Include="xunit" Version="2.4.2" />
+		<ProjectCapability Remove="TestContainer" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary

- derive syntax and bound child order from a validated constructor-to-property model instead of `GetMembers()` enumeration order
- reconstruct bound nodes in constructor parameter order, including inherited state, and report `BLS0001` for ambiguous or incomplete models
- preserve source order for typed variable declarations and align constructor parameter names with their properties
- add GeneratorDriver coverage for reordered same-type properties, overloads, diagnostics, and generated-code compilation
- add parser, span, last-token, and classifier regression coverage for typed variable declarations
- keep the shared `TestHelpers` project excluded from test discovery

## Verification

- `dotnet test src/Balu.SourceGenerator.Tests/Balu.SourceGenerator.Tests.csproj`
- `dotnet test src/Balu.Tests/Balu.Tests.csproj --no-restore` (21,704 tests)
- Full `Release` build of `src/Balu.sln` with Visual Studio MSBuild (0 warnings, 0 errors)

Closes #91
Closes #107