### PR TITLE
fix missing return to avoid exceptions when there is no loop around a continue or break statement. #76

### DIFF
--- a/src/Balu.Tests/BinderTests/BreakOrContinueOutsideLooopTests.cs
+++ b/src/Balu.Tests/BinderTests/BreakOrContinueOutsideLooopTests.cs
@@ -1,0 +1,36 @@
+﻿using TestHelpers;
+using Xunit;
+
+namespace Balu.Tests.BinderTests;
+
+public sealed partial class BinderTests
+{
+    [Theory]
+    [InlineData("[break]")]
+    [InlineData(@"
+        function test(a : int)
+        {
+            if (a > 0)
+            {
+                [break]
+            }
+        }")]
+    public void Binder_ReportsBreakOutsideLoop(string code)
+    {
+        code.AssertScriptEvaluation(expectedDiagnostics: "BL1021: Invalid 'break' outside any loop.", ignoreWarnings: false);
+    }
+    [Theory]
+    [InlineData("[continue]")]
+    [InlineData(@"
+        function test(a : int)
+        {
+            if (a > 0)
+            {
+                [continue]
+            }
+        }")]
+    public void Binder_ReportsContinueOutsideLoop(string code)
+    {
+        code.AssertScriptEvaluation(expectedDiagnostics: "BL1021: Invalid 'continue' outside any loop.", ignoreWarnings: false);
+    }
+}

--- a/src/Balu/Binding/Binder.cs
+++ b/src/Balu/Binding/Binder.cs
@@ -375,6 +375,7 @@ sealed class Binder : SyntaxTreeVisitor
         {
             diagnostics.ReportInvalidBreakOrContinue(node.ContinueKeyword);
             SetErrorStatement(node);
+            return;
         }
 
         boundNode = Goto(node, loopStack.Peek().continueLabel);
@@ -385,6 +386,7 @@ sealed class Binder : SyntaxTreeVisitor
         {
             diagnostics.ReportInvalidBreakOrContinue(node.BreakKeyword);
             SetErrorStatement(node);
+            return;
         }
 
         boundNode = Goto(node, loopStack.Peek().breakLabel);

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<BaluVersion Condition="'$(BaluVersion)' == ''">0.4.2</BaluVersion>
+		<BaluVersion Condition="'$(BaluVersion)' == ''">0.4.3</BaluVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(MSBuildProjectName)' == 'Balu' Or

--- a/src/HelloWorld/hello.b
+++ b/src/HelloWorld/hello.b
@@ -1,6 +1,8 @@
 function main()
 {
 	test()
+	continue
+	break
 }
 
 function test()

--- a/src/HelloWorld/helloworld.csproj
+++ b/src/HelloWorld/helloworld.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.4.2">
+﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.4.3">
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
 		<OutputType>Exe</OutputType>


### PR DESCRIPTION
fix missing return to avoid exceptions when there is no loop around a continue or break statement. 

Fixes #76