### PR TITLE
Diagnose constant division by zero

### DIFF
--- a/src/Balu.Tests/BinderTests/ConstantDivisionByZeroTests.cs
+++ b/src/Balu.Tests/BinderTests/ConstantDivisionByZeroTests.cs
@@ -1,0 +1,30 @@
+using TestHelpers;
+using Xunit;
+
+namespace Balu.Tests.BinderTests;
+
+public sealed partial class BinderTests
+{
+    [Theory]
+    [InlineData("[1/0]")]
+    [InlineData("[(12 + 1) / (3 - 3)]")]
+    [InlineData("var y = 7 + [3/0]")]
+    [InlineData("let zero = 2 - 2 [10 / zero]")]
+    [InlineData(@"
+        function test()
+        {
+            var x = [1 / 0]
+        }")]
+    public void Binder_ReportsConstantDivisionByZero(string code)
+    {
+        code.AssertScriptEvaluation(expectedDiagnostics: "BL1032: Constant division by zero.", ignoreWarnings: false);
+    }
+
+    [Fact]
+    public void Binder_DoesNotFoldOverflowingConstantDivision()
+    {
+        const string code = "function test(): int { return (-2147483647 - 1) / -1 }";
+
+        code.AssertScriptEvaluation();
+    }
+}

--- a/src/Balu.Tests/UnitTests/Diagnostics/DiagnosticIdTests.cs
+++ b/src/Balu.Tests/UnitTests/Diagnostics/DiagnosticIdTests.cs
@@ -49,6 +49,7 @@ public class DiagnosticIdTests
         (DiagnosticId.OnlyOneFileCanHaveGlobalStatements, 1029),
         (DiagnosticId.NoEntryPointDefined, 1030),
         (DiagnosticId.UnreachableCode, 1031),
+        (DiagnosticId.ConstantDivisionByZero, 1032),
 
         (DiagnosticId.Emitter, 2000),
         (DiagnosticId.InvalidAssemblyReference, 2001),

--- a/src/Balu/Binding/Binder.cs
+++ b/src/Balu/Binding/Binder.cs
@@ -84,7 +84,16 @@ sealed class Binder : SyntaxTreeVisitor
             SetErrorExpression(node);
         }
         else
-            boundNode = Binary(node, left, op, right);
+        {
+            var expression = Binary(node, left, op, right);
+            if (expression.FoldingError == ConstantFoldingError.DivisionByZero)
+            {
+                diagnostics.ReportConstantDivisionByZero(node.Location);
+                SetErrorExpression(node);
+            }
+            else
+                boundNode = expression;
+        }
     }
     protected override void VisitNameExpression(NameExpressionSyntax node)
     {

--- a/src/Balu/Binding/BoundBinaryExpression.cs
+++ b/src/Balu/Binding/BoundBinaryExpression.cs
@@ -9,6 +9,7 @@ sealed partial class BoundBinaryExpression : BoundExpression
     public override TypeSymbol Type => Operator.Type;
     public override BoundConstant? Constant { get; }
     public override bool HasSideEffects { get; }
+    internal ConstantFoldingError FoldingError { get; }
 
     public BoundExpression Left { get; }
     public BoundBinaryOperator Operator { get; }
@@ -19,7 +20,9 @@ sealed partial class BoundBinaryExpression : BoundExpression
         Left = left;
         Operator = @operator;
         Right = right;
-        Constant = ConstantFolder.ComputeConstant(left, @operator, right);
+        var foldingResult = ConstantFolder.Fold(left, @operator, right);
+        Constant = foldingResult.Constant;
+        FoldingError = foldingResult.Error;
         HasSideEffects = Left.HasSideEffects || Right.HasSideEffects;
     }
 

--- a/src/Balu/Binding/BoundUnaryExpression.cs
+++ b/src/Balu/Binding/BoundUnaryExpression.cs
@@ -5,10 +5,13 @@ namespace Balu.Binding;
 
 sealed partial class BoundUnaryExpression(SyntaxNode syntax, BoundUnaryOperator @operator, BoundExpression operand) : BoundExpression(syntax)
 {
+    readonly ConstantFoldingResult foldingResult = ConstantFolder.Fold(@operator, operand);
+
     public override BoundNodeKind Kind => BoundNodeKind.UnaryExpression;
     public override TypeSymbol Type => Operator.Type;
-    public override BoundConstant? Constant { get; } = ConstantFolder.ComputeConstant(@operator, operand);
+    public override BoundConstant? Constant => foldingResult.Constant;
     public override bool HasSideEffects { get; } = operand.HasSideEffects;
+    internal ConstantFoldingError FoldingError => foldingResult.Error;
 
     public BoundUnaryOperator Operator { get; } = @operator;
     public BoundExpression Operand { get; } = operand;

--- a/src/Balu/Binding/ConstantFolder.cs
+++ b/src/Balu/Binding/ConstantFolder.cs
@@ -4,60 +4,74 @@ namespace Balu.Binding;
 
 static class ConstantFolder
 {
-    public static BoundConstant? ComputeConstant(BoundExpression left, BoundBinaryOperator operation, BoundExpression right)
+    public static ConstantFoldingResult Fold(BoundExpression left, BoundBinaryOperator operation, BoundExpression right)
     {
         if (operation.OperatorKind == BoundBinaryOperatorKind.LogicalAnd)
         {
             if (left.Constant != null && !(bool)left.Constant.Value ||
                 right.Constant != null && !(bool)right.Constant.Value)
-                return new(false);
+                return Constant(false);
         }
         if (operation.OperatorKind == BoundBinaryOperatorKind.LogicalOr)
         {
             if (left.Constant != null && (bool)left.Constant.Value ||
                 right.Constant != null && (bool)right.Constant.Value)
-                return new(true);
+                return Constant(true);
         }
 
-        return left.Constant is null || right.Constant is null
-                   ? null
-                   : operation.OperatorKind switch
-                   {
-                       BoundBinaryOperatorKind.Addition => operation.Type == TypeSymbol.String
-                                                               ? new((string)left.Constant.Value + (string)right.Constant.Value)
-                                                               : new((int)left.Constant.Value + (int)right.Constant.Value),
-                       BoundBinaryOperatorKind.Substraction => new((int)left.Constant.Value - (int)right.Constant.Value),
-                       BoundBinaryOperatorKind.Multiplication => new((int)left.Constant.Value * (int)right.Constant.Value),
-                       BoundBinaryOperatorKind.Division => new((int)left.Constant.Value / (int)right.Constant.Value),
-                       BoundBinaryOperatorKind.LogicalOr => new((bool)left.Constant.Value || (bool)right.Constant.Value),
-                       BoundBinaryOperatorKind.LogicalAnd => new((bool)left.Constant.Value && (bool)right.Constant.Value),
-                       BoundBinaryOperatorKind.BitwiseAnd => left.Type == TypeSymbol.Boolean
-                                                                 ? new((bool)left.Constant.Value & (bool)right.Constant.Value)
-                                                                 : new((int)left.Constant.Value & (int)right.Constant.Value),
-                       BoundBinaryOperatorKind.BitwiseOr => left.Type == TypeSymbol.Boolean
-                                                                ? new((bool)left.Constant.Value | (bool)right.Constant.Value)
-                                                                : new((int)left.Constant.Value | (int)right.Constant.Value),
-                       BoundBinaryOperatorKind.BitwiseXor => left.Type == TypeSymbol.Boolean
-                                                                 ? new((bool)left.Constant.Value ^ (bool)right.Constant.Value)
-                                                                 : new((int)left.Constant.Value ^ (int)right.Constant.Value),
-                       BoundBinaryOperatorKind.Equals => new(Equals(left.Constant.Value, right.Constant.Value)),
-                       BoundBinaryOperatorKind.NotEqual => new(!Equals(left.Constant.Value, right.Constant.Value)),
-                       BoundBinaryOperatorKind.Less => new((int)left.Constant.Value < (int)right.Constant.Value),
-                       BoundBinaryOperatorKind.LessOrEquals => new((int)left.Constant.Value <= (int)right.Constant.Value),
-                       BoundBinaryOperatorKind.Greater => new((int)left.Constant.Value > (int)right.Constant.Value),
-                       BoundBinaryOperatorKind.GreaterOrEquals => new((int)left.Constant.Value >= (int)right.Constant.Value),
-                       _ => throw new BindingException($"Unknown binary operator '{operation.OperatorKind}'.")
-                   };
+        if (left.Constant is null || right.Constant is null)
+            return default;
+
+        if (operation.OperatorKind == BoundBinaryOperatorKind.Division)
+        {
+            var dividend = (int)left.Constant.Value;
+            var divisor = (int)right.Constant.Value;
+            if (divisor == 0)
+                return new(null, ConstantFoldingError.DivisionByZero);
+            if (dividend == int.MinValue && divisor == -1)
+                return new(null, ConstantFoldingError.IntegerDivisionOverflow);
+        }
+
+        return operation.OperatorKind switch
+        {
+            BoundBinaryOperatorKind.Addition => operation.Type == TypeSymbol.String
+                                                    ? Constant((string)left.Constant.Value + (string)right.Constant.Value)
+                                                    : Constant((int)left.Constant.Value + (int)right.Constant.Value),
+            BoundBinaryOperatorKind.Substraction => Constant((int)left.Constant.Value - (int)right.Constant.Value),
+            BoundBinaryOperatorKind.Multiplication => Constant((int)left.Constant.Value * (int)right.Constant.Value),
+            BoundBinaryOperatorKind.Division => Constant((int)left.Constant.Value / (int)right.Constant.Value),
+            BoundBinaryOperatorKind.LogicalOr => Constant((bool)left.Constant.Value || (bool)right.Constant.Value),
+            BoundBinaryOperatorKind.LogicalAnd => Constant((bool)left.Constant.Value && (bool)right.Constant.Value),
+            BoundBinaryOperatorKind.BitwiseAnd => left.Type == TypeSymbol.Boolean
+                                                      ? Constant((bool)left.Constant.Value & (bool)right.Constant.Value)
+                                                      : Constant((int)left.Constant.Value & (int)right.Constant.Value),
+            BoundBinaryOperatorKind.BitwiseOr => left.Type == TypeSymbol.Boolean
+                                                     ? Constant((bool)left.Constant.Value | (bool)right.Constant.Value)
+                                                     : Constant((int)left.Constant.Value | (int)right.Constant.Value),
+            BoundBinaryOperatorKind.BitwiseXor => left.Type == TypeSymbol.Boolean
+                                                      ? Constant((bool)left.Constant.Value ^ (bool)right.Constant.Value)
+                                                      : Constant((int)left.Constant.Value ^ (int)right.Constant.Value),
+            BoundBinaryOperatorKind.Equals => Constant(Equals(left.Constant.Value, right.Constant.Value)),
+            BoundBinaryOperatorKind.NotEqual => Constant(!Equals(left.Constant.Value, right.Constant.Value)),
+            BoundBinaryOperatorKind.Less => Constant((int)left.Constant.Value < (int)right.Constant.Value),
+            BoundBinaryOperatorKind.LessOrEquals => Constant((int)left.Constant.Value <= (int)right.Constant.Value),
+            BoundBinaryOperatorKind.Greater => Constant((int)left.Constant.Value > (int)right.Constant.Value),
+            BoundBinaryOperatorKind.GreaterOrEquals => Constant((int)left.Constant.Value >= (int)right.Constant.Value),
+            _ => throw new BindingException($"Unknown binary operator '{operation.OperatorKind}'.")
+        };
     }
-    public static BoundConstant? ComputeConstant(BoundUnaryOperator operation, BoundExpression operand) =>
+
+    public static ConstantFoldingResult Fold(BoundUnaryOperator operation, BoundExpression operand) =>
         operand.Constant is null
-            ? null
+            ? default
             : operation.OperatorKind switch
             {
-                BoundUnaryOperatorKind.Identity => operand.Constant,
-                BoundUnaryOperatorKind.Negation => new (-(int)operand.Constant.Value),
-                BoundUnaryOperatorKind.LogicalNegation => new(!(bool)operand.Constant.Value),
-                BoundUnaryOperatorKind.BitwiseNegation => new(~(int)operand.Constant.Value),
+                BoundUnaryOperatorKind.Identity => new(operand.Constant),
+                BoundUnaryOperatorKind.Negation => Constant(-(int)operand.Constant.Value),
+                BoundUnaryOperatorKind.LogicalNegation => Constant(!(bool)operand.Constant.Value),
+                BoundUnaryOperatorKind.BitwiseNegation => Constant(~(int)operand.Constant.Value),
                 _ => throw new BindingException($"Unknown unary operator '{operation.OperatorKind}'.")
             };
+
+    static ConstantFoldingResult Constant(object value) => new(new BoundConstant(value));
 }

--- a/src/Balu/Binding/ConstantFoldingResult.cs
+++ b/src/Balu/Binding/ConstantFoldingResult.cs
@@ -1,0 +1,20 @@
+namespace Balu.Binding;
+
+enum ConstantFoldingError
+{
+    None,
+    DivisionByZero,
+    IntegerDivisionOverflow
+}
+
+readonly struct ConstantFoldingResult
+{
+    public BoundConstant? Constant { get; }
+    public ConstantFoldingError Error { get; }
+
+    public ConstantFoldingResult(BoundConstant? constant, ConstantFoldingError error = ConstantFoldingError.None)
+    {
+        Constant = constant;
+        Error = error;
+    }
+}

--- a/src/Balu/Diagnostics/DiagnosticBag.cs
+++ b/src/Balu/Diagnostics/DiagnosticBag.cs
@@ -102,6 +102,8 @@ sealed class DiagnosticBag : List<Diagnostic>
     public void ReportNoEntryPointDefined() =>
         Add(new(DiagnosticId.NoEntryPointDefined, default, $"No entry point found (neither a '{GlobalSymbolNames.Main}' function nor global statements)."));
     public void ReportUnreachableCode(TextLocation location) => Add(new(DiagnosticId.UnreachableCode, location, "Unreachable code detected.", DiagnosticSeverity.Warning));
+    public void ReportConstantDivisionByZero(TextLocation location) =>
+        Add(new(DiagnosticId.ConstantDivisionByZero, location, "Constant division by zero."));
 
     public void ReportInvalidAssemblyReference(string reference, string exceptionMessage) =>
         Add(new(DiagnosticId.InvalidAssemblyReference, default, $"Could not load referenced assembly '{reference}': {exceptionMessage}"));

--- a/src/Balu/Diagnostics/DiagnosticId.cs
+++ b/src/Balu/Diagnostics/DiagnosticId.cs
@@ -41,6 +41,7 @@ public enum DiagnosticId
     OnlyOneFileCanHaveGlobalStatements = 1029,
     NoEntryPointDefined = 1030,
     UnreachableCode = 1031,
+    ConstantDivisionByZero = 1032,
 
     Emitter = 2000,
     InvalidAssemblyReference = 2001,

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<BaluVersion Condition="'$(BaluVersion)' == ''">0.4.3</BaluVersion>
+		<BaluVersion Condition="'$(BaluVersion)' == ''">0.4.4</BaluVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(MSBuildProjectName)' == 'Balu' Or

--- a/src/HelloWorld/hello.b
+++ b/src/HelloWorld/hello.b
@@ -1,8 +1,6 @@
 function main()
 {
 	test()
-	continue
-	break
 }
 
 function test()

--- a/src/HelloWorld/helloworld.csproj
+++ b/src/HelloWorld/helloworld.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.4.3">
+﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.4.4">
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
 		<OutputType>Exe</OutputType>


### PR DESCRIPTION
## Summary
- make unary and binary constant folding return a non-throwing result with an optional folding error
- report BL1032 and bind an error expression for constant division by zero
- leave `int.MinValue / -1` unfolded so binding and diagnostic queries cannot throw
- cover direct, nested, propagated, function-body, and overflow cases

## Tests
- `dotnet test src/Balu.Tests/Balu.Tests.csproj`
- `dotnet test src/Balu.SourceGenerator.Tests/Balu.SourceGenerator.Tests.csproj`
- `dotnet test src/Balu.Interpretation.Tests/Balu.Interpretation.Tests.csproj`
- `dotnet test src/bc.Tests/bc.Tests.csproj`
- `dotnet test src/Balu.Sdk.Tests/Balu.Sdk.Tests.csproj`

Closes #80