### PR TITLE
Diagnose constant integer overflow

### DIFF
--- a/src/Balu.Tests/BinderTests/ConstantDivisionByZeroTests.cs
+++ b/src/Balu.Tests/BinderTests/ConstantDivisionByZeroTests.cs
@@ -19,12 +19,4 @@ public sealed partial class BinderTests
     {
         code.AssertScriptEvaluation(expectedDiagnostics: "BL1032: Constant division by zero.", ignoreWarnings: false);
     }
-
-    [Fact]
-    public void Binder_DoesNotFoldOverflowingConstantDivision()
-    {
-        const string code = "function test(): int { return (-2147483647 - 1) / -1 }";
-
-        code.AssertScriptEvaluation();
-    }
 }

--- a/src/Balu.Tests/BinderTests/ConstantIntegerOverflowTests.cs
+++ b/src/Balu.Tests/BinderTests/ConstantIntegerOverflowTests.cs
@@ -1,0 +1,39 @@
+using TestHelpers;
+using Xunit;
+
+namespace Balu.Tests.BinderTests;
+
+public sealed partial class BinderTests
+{
+    [Theory]
+    [InlineData("[(-2147483647 - 1) / -1]")]
+    [InlineData("let minValue = -2147483647 - 1 [minValue / -1]")]
+    [InlineData("var value = 1 + [(-2147483647 - 1) / -1]")]
+    [InlineData(@"
+        function test()
+        {
+            var value = [(-2147483647 - 1) / -1]
+        }")]
+    public void Binder_ReportsConstantIntegerOverflow(string code)
+    {
+        code.AssertScriptEvaluation(expectedDiagnostics: "BL1033: Constant expression causes an integer overflow.", ignoreWarnings: false);
+    }
+
+    [Fact]
+    public void Binder_FoldsNonOverflowingIntegerDivisionAtBoundary()
+    {
+        const string code = "-2147483647 / -1";
+
+        code.AssertScriptEvaluation(value: int.MaxValue);
+    }
+
+    [Theory]
+    [InlineData("2147483647 + 1", int.MinValue)]
+    [InlineData("-2147483647 - 2", int.MaxValue)]
+    [InlineData("1073741824 * 2", int.MinValue)]
+    [InlineData("-(-2147483647 - 1)", int.MinValue)]
+    public void Binder_FoldsWrappingIntegerOverflow(string code, int expected)
+    {
+        code.AssertScriptEvaluation(value: expected);
+    }
+}

--- a/src/Balu.Tests/UnitTests/Diagnostics/DiagnosticIdTests.cs
+++ b/src/Balu.Tests/UnitTests/Diagnostics/DiagnosticIdTests.cs
@@ -50,6 +50,7 @@ public class DiagnosticIdTests
         (DiagnosticId.NoEntryPointDefined, 1030),
         (DiagnosticId.UnreachableCode, 1031),
         (DiagnosticId.ConstantDivisionByZero, 1032),
+        (DiagnosticId.ConstantIntegerOverflow, 1033),
 
         (DiagnosticId.Emitter, 2000),
         (DiagnosticId.InvalidAssemblyReference, 2001),

--- a/src/Balu/Binding/Binder.cs
+++ b/src/Balu/Binding/Binder.cs
@@ -91,6 +91,11 @@ sealed class Binder : SyntaxTreeVisitor
                 diagnostics.ReportConstantDivisionByZero(node.Location);
                 SetErrorExpression(node);
             }
+            else if (expression.FoldingError == ConstantFoldingError.IntegerOverflow)
+            {
+                diagnostics.ReportConstantIntegerOverflow(node.Location);
+                SetErrorExpression(node);
+            }
             else
                 boundNode = expression;
         }

--- a/src/Balu/Binding/ConstantFolder.cs
+++ b/src/Balu/Binding/ConstantFolder.cs
@@ -29,7 +29,7 @@ static class ConstantFolder
             if (divisor == 0)
                 return new(null, ConstantFoldingError.DivisionByZero);
             if (dividend == int.MinValue && divisor == -1)
-                return new(null, ConstantFoldingError.IntegerDivisionOverflow);
+                return new(null, ConstantFoldingError.IntegerOverflow);
         }
 
         return operation.OperatorKind switch

--- a/src/Balu/Binding/ConstantFoldingResult.cs
+++ b/src/Balu/Binding/ConstantFoldingResult.cs
@@ -4,7 +4,7 @@ enum ConstantFoldingError
 {
     None,
     DivisionByZero,
-    IntegerDivisionOverflow
+    IntegerOverflow
 }
 
 readonly struct ConstantFoldingResult

--- a/src/Balu/Diagnostics/DiagnosticBag.cs
+++ b/src/Balu/Diagnostics/DiagnosticBag.cs
@@ -104,6 +104,8 @@ sealed class DiagnosticBag : List<Diagnostic>
     public void ReportUnreachableCode(TextLocation location) => Add(new(DiagnosticId.UnreachableCode, location, "Unreachable code detected.", DiagnosticSeverity.Warning));
     public void ReportConstantDivisionByZero(TextLocation location) =>
         Add(new(DiagnosticId.ConstantDivisionByZero, location, "Constant division by zero."));
+    public void ReportConstantIntegerOverflow(TextLocation location) =>
+        Add(new(DiagnosticId.ConstantIntegerOverflow, location, "Constant expression causes an integer overflow."));
 
     public void ReportInvalidAssemblyReference(string reference, string exceptionMessage) =>
         Add(new(DiagnosticId.InvalidAssemblyReference, default, $"Could not load referenced assembly '{reference}': {exceptionMessage}"));

--- a/src/Balu/Diagnostics/DiagnosticId.cs
+++ b/src/Balu/Diagnostics/DiagnosticId.cs
@@ -42,6 +42,7 @@ public enum DiagnosticId
     NoEntryPointDefined = 1030,
     UnreachableCode = 1031,
     ConstantDivisionByZero = 1032,
+    ConstantIntegerOverflow = 1033,
 
     Emitter = 2000,
     InvalidAssemblyReference = 2001,


### PR DESCRIPTION
## Summary
- report BL1033 when constant folding detects the throwing `int.MinValue / -1` overflow
- generalize the folding error from division-specific overflow to integer overflow
- preserve and test wrapping semantics for addition, subtraction, multiplication, and unary negation
- cover direct, propagated, nested, function-body, and valid boundary division cases

## Tests
- `dotnet test src/Balu.Tests/Balu.Tests.csproj`
- `dotnet test src/Balu.SourceGenerator.Tests/Balu.SourceGenerator.Tests.csproj`
- `dotnet test src/Balu.Interpretation.Tests/Balu.Interpretation.Tests.csproj`
- `dotnet test src/bc.Tests/bc.Tests.csproj`
- `dotnet test src/Balu.Sdk.Tests/Balu.Sdk.Tests.csproj`