### PR TITLE
Fix boolean compound assignment evaluation

### DIFF
--- a/src/Balu.Tests/ExecutionTests/AssignmentExpressionTests.cs
+++ b/src/Balu.Tests/ExecutionTests/AssignmentExpressionTests.cs
@@ -34,4 +34,20 @@ public partial class ExecutionTests
     [InlineData("var a = 5 a ^= 7 a", 2)]
     [InlineData("var a = \"eins\" a += \"zwei\" a", "einszwei")]
     public void Script_AssignmentExpression_AssignsCorrectly(string code, object result) => code.AssertScriptEvaluation(value: result);
+
+    [Theory]
+    [InlineData("&=", "false")]
+    [InlineData("|=", "true")]
+    public void Script_BooleanCompoundAssignment_EvaluatesRightHandSide(string operatorToken, string initialValue) =>
+        $@"
+            var calls = 0
+            function SideEffect() : bool
+            {{
+                calls += 1
+                return true
+            }}
+            var value = {initialValue}
+            value {operatorToken} SideEffect()
+            calls
+        ".AssertScriptEvaluation(value: 1);
 }

--- a/src/Balu/Binding/BoundBinaryOperator.cs
+++ b/src/Balu/Binding/BoundBinaryOperator.cs
@@ -40,9 +40,9 @@ sealed class BoundBinaryOperator
         [(SyntaxKind.StarEqualsToken, TypeSymbol.Integer, TypeSymbol.Integer)] = new(SyntaxKind.StarEqualsToken, BoundBinaryOperatorKind.Multiplication, TypeSymbol.Integer),
         [(SyntaxKind.SlashEqualsToken, TypeSymbol.Integer, TypeSymbol.Integer)] = new(SyntaxKind.SlashEqualsToken, BoundBinaryOperatorKind.Division, TypeSymbol.Integer),
         [(SyntaxKind.AmpersandEqualsToken, TypeSymbol.Integer, TypeSymbol.Integer)] = new(SyntaxKind.AmpersandEqualsToken, BoundBinaryOperatorKind.BitwiseAnd, TypeSymbol.Integer),
-        [(SyntaxKind.AmpersandEqualsToken, TypeSymbol.Boolean, TypeSymbol.Boolean)] = new(SyntaxKind.AmpersandEqualsToken, BoundBinaryOperatorKind.LogicalAnd, TypeSymbol.Boolean),
+        [(SyntaxKind.AmpersandEqualsToken, TypeSymbol.Boolean, TypeSymbol.Boolean)] = new(SyntaxKind.AmpersandEqualsToken, BoundBinaryOperatorKind.BitwiseAnd, TypeSymbol.Boolean),
         [(SyntaxKind.PipeEqualsToken, TypeSymbol.Integer, TypeSymbol.Integer)] = new(SyntaxKind.PipeEqualsToken, BoundBinaryOperatorKind.BitwiseOr, TypeSymbol.Integer),
-        [(SyntaxKind.PipeEqualsToken, TypeSymbol.Boolean, TypeSymbol.Boolean)] = new(SyntaxKind.PipeEqualsToken, BoundBinaryOperatorKind.LogicalOr, TypeSymbol.Boolean),
+        [(SyntaxKind.PipeEqualsToken, TypeSymbol.Boolean, TypeSymbol.Boolean)] = new(SyntaxKind.PipeEqualsToken, BoundBinaryOperatorKind.BitwiseOr, TypeSymbol.Boolean),
         [(SyntaxKind.CircumflexEqualsToken, TypeSymbol.Integer, TypeSymbol.Integer)] = new(SyntaxKind.CircumflexEqualsToken, BoundBinaryOperatorKind.BitwiseXor, TypeSymbol.Integer),
         [(SyntaxKind.CircumflexEqualsToken, TypeSymbol.Boolean, TypeSymbol.Boolean)] = new(SyntaxKind.CircumflexEqualsToken, BoundBinaryOperatorKind.BitwiseXor, TypeSymbol.Boolean),
         

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<BaluVersion Condition="'$(BaluVersion)' == ''">0.4.4</BaluVersion>
+		<BaluVersion Condition="'$(BaluVersion)' == ''">0.4.6</BaluVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(MSBuildProjectName)' == 'Balu' Or

--- a/src/HelloWorld/helloworld.csproj
+++ b/src/HelloWorld/helloworld.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.4.4">
+﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.4.6">
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
 		<OutputType>Exe</OutputType>


### PR DESCRIPTION
## Summary
- bind boolean `&=` and `|=` as non-short-circuiting bitwise operators
- add regression tests verifying that their right-hand sides are evaluated
- bump the Balu SDK version to 0.4.6

## Testing
- `dotnet test src/Balu.Tests/Balu.Tests.csproj`

Closes #86