### PR TITLE
Preserve side effects in constant conditions

### DIFF
--- a/src/Balu.Tests/ExecutionTests/DoWhileStatementTests.cs
+++ b/src/Balu.Tests/ExecutionTests/DoWhileStatementTests.cs
@@ -10,6 +10,11 @@ public partial class ExecutionTests
     [InlineData("var result = 1 var i = 0 do { i = i + 1 result = result * 2} while (i < 5) result", 32)]
     [InlineData("var result = 0 var i = 0 do { i = i + 1 result = result + i} while (i < 10) result", 55)]
     public void Script_DoWhileStatement_BasicallyWorks(string text, object? result) => text.AssertScriptEvaluation(value: result);
+    [Theory]
+    [InlineData("var condition = true do {} while (condition = false) condition", false)]
+    [InlineData("var calls = 0 function condition(): bool { calls += 1 return true } do {} while condition() && false calls", 1)]
+    public void Script_DoWhileStatement_EvaluatesSideEffectsInConditionWithConstantResult(string text, object? result) =>
+        text.AssertScriptEvaluation(value: result);
     [Fact]
     public void Script_DoWhileStatement_Reports_WrongConditionType()
     {

--- a/src/Balu.Tests/ExecutionTests/IfStatementTests.cs
+++ b/src/Balu.Tests/ExecutionTests/IfStatementTests.cs
@@ -15,6 +15,11 @@ public partial class ExecutionTests
     [InlineData("var a = 10 if a == 10 a = 5 else a = 20 a", 5)]
     [InlineData("var a = 10 if a != 10 a = 5 else a = 20 a", 20)]
     public void Script_IfStatement_BasicallyWorks(string text, object? result) => text.AssertScriptEvaluation(value: result);
+    [Theory]
+    [InlineData("var condition = true if (condition = false) {} condition", false)]
+    [InlineData("var calls = 0 function condition(): bool { calls += 1 return true } if condition() && false {} calls", 1)]
+    public void Script_IfStatement_EvaluatesSideEffectsInConditionWithConstantResult(string text, object? result) =>
+        text.AssertScriptEvaluation(value: result);
     [Fact]
     public void Script_IfStatement_Reports_WrongConditionType()
     {

--- a/src/Balu.Tests/ExecutionTests/WhileStatementTests.cs
+++ b/src/Balu.Tests/ExecutionTests/WhileStatementTests.cs
@@ -10,6 +10,11 @@ public partial class ExecutionTests
     [InlineData("var result = 1 var i = 0 while (i < 5) { i = i + 1 result = result * 2} result", 32)]
     [InlineData("var result = 0 var i = 0 while (i < 10) { i = i + 1 result = result + i} result", 55)]
     public void Script_WhileStatement_BasicallyWorks(string text, object? result) => text.AssertScriptEvaluation(value: result);
+    [Theory]
+    [InlineData("var condition = true while (condition = false) {} condition", false)]
+    [InlineData("var calls = 0 function condition(): bool { calls += 1 return true } while condition() && false {} calls", 1)]
+    public void Script_WhileStatement_EvaluatesSideEffectsInConditionWithConstantResult(string text, object? result) =>
+        text.AssertScriptEvaluation(value: result);
     [Fact]
     public void Script_WhileStatement_Reports_WrongConditionType()
     {

--- a/src/Balu/Binding/ConstantFolder.cs
+++ b/src/Balu/Binding/ConstantFolder.cs
@@ -8,14 +8,14 @@ static class ConstantFolder
     {
         if (operation.OperatorKind == BoundBinaryOperatorKind.LogicalAnd)
         {
-            if (left.Constant != null && !(bool)left.Constant.Value ||
-                right.Constant != null && !(bool)right.Constant.Value)
+            if (!right.HasSideEffects && left.Constant != null && !(bool)left.Constant.Value ||
+                !left.HasSideEffects && right.Constant != null && !(bool)right.Constant.Value)
                 return Constant(false);
         }
         if (operation.OperatorKind == BoundBinaryOperatorKind.LogicalOr)
         {
-            if (left.Constant != null && (bool)left.Constant.Value ||
-                right.Constant != null && (bool)right.Constant.Value)
+            if (!right.HasSideEffects && left.Constant != null && (bool)left.Constant.Value ||
+                !left.HasSideEffects && right.Constant != null && (bool)right.Constant.Value)
                 return Constant(true);
         }
 

--- a/src/Balu/Lowering/Lowerer.cs
+++ b/src/Balu/Lowering/Lowerer.cs
@@ -36,7 +36,7 @@ sealed class Lowerer : BoundTreeRewriter
     }
     protected override BoundNode VisitBoundConditionalGotoStatement(BoundConditionalGotoStatement conditionalGotoStatement)
     {
-        if (conditionalGotoStatement.Condition.Constant is null) return conditionalGotoStatement;
+        if (conditionalGotoStatement.Condition.Constant is null || conditionalGotoStatement.Condition.HasSideEffects) return conditionalGotoStatement;
         return (bool)conditionalGotoStatement.Condition.Constant.Value == conditionalGotoStatement.JumpIfTrue
                    ? Visit(new BoundGotoStatement(conditionalGotoStatement.Syntax, conditionalGotoStatement.Label))
                    : Visit(new BoundNopStatement(conditionalGotoStatement.Syntax));

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<BaluVersion Condition="'$(BaluVersion)' == ''">0.4.6</BaluVersion>
+		<BaluVersion Condition="'$(BaluVersion)' == ''">0.4.7</BaluVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(MSBuildProjectName)' == 'Balu' Or

--- a/src/HelloWorld/helloworld.csproj
+++ b/src/HelloWorld/helloworld.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.4.6">
+﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.4.7">
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
 		<OutputType>Exe</OutputType>


### PR DESCRIPTION
## Summary
- preserve conditional evaluation when a constant result still has side effects
- avoid constant-folding logical expressions when doing so would discard evaluated side effects
- add regression coverage for assignments and calls in `if`, `while`, and `do while` conditions
- bump the Balu version to 0.4.7

## Testing
- `dotnet test src/Balu.Tests/Balu.Tests.csproj`

Closes #79