### PR TITLE
Preserve side effects in explicit conversions

### DIFF
--- a/src/Balu.Tests/ExecutionTests/MiscellaneousTests.cs
+++ b/src/Balu.Tests/ExecutionTests/MiscellaneousTests.cs
@@ -109,4 +109,38 @@ public partial class ExecutionTests
             result
         ".AssertScriptEvaluation(value: true);
     }
+
+    [Theory]
+    [InlineData("bool(SideEffect()) && false", 1)]
+    [InlineData("false && bool(SideEffect())", 0)]
+    [InlineData("bool(SideEffect()) || true", 1)]
+    [InlineData("true || bool(SideEffect())", 0)]
+    public void Script_ConstantFolding_DoesNotRemoveExplicitlyConvertedCallSideEffects(string expression, int expectedCalls)
+    {
+        $@"
+            var calls = 0
+            function SideEffect() : any
+            {{
+                calls += 1
+                return true
+            }}
+            var test = {expression}
+            calls
+        ".AssertScriptEvaluation(value: expectedCalls);
+    }
+
+    [Theory]
+    [InlineData("bool(value = (calls += 1)) && false", 1)]
+    [InlineData("false && bool(value = (calls += 1))", 0)]
+    [InlineData("bool(value = (calls += 1)) || true", 1)]
+    [InlineData("true || bool(value = (calls += 1))", 0)]
+    public void Script_ConstantFolding_DoesNotRemoveExplicitlyConvertedAssignmentSideEffects(string expression, int expectedCalls)
+    {
+        $@"
+            var calls = 0
+            var value : any = false
+            var test = {expression}
+            calls
+        ".AssertScriptEvaluation(value: expectedCalls);
+    }
 }

--- a/src/Balu/Binding/BoundConversionExpression.cs
+++ b/src/Balu/Binding/BoundConversionExpression.cs
@@ -9,5 +9,7 @@ sealed partial class BoundConversionExpression(SyntaxNode syntax, TypeSymbol typ
     public BoundExpression Expression { get; } = expression;
     public override BoundNodeKind Kind => BoundNodeKind.ConversionExpression;
 
+    public override bool HasSideEffects => Expression.HasSideEffects;
+
     public override string ToString() => $"{Type}({Expression})";
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<BaluVersion Condition="'$(BaluVersion)' == ''">0.4.7</BaluVersion>
+		<BaluVersion Condition="'$(BaluVersion)' == ''">0.4.8</BaluVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(MSBuildProjectName)' == 'Balu' Or

--- a/src/HelloWorld/hello.b
+++ b/src/HelloWorld/hello.b
@@ -1,10 +1,11 @@
 function main()
 {
-	test()
+	var a = bool(test()) && false
+	println(a)
 }
 
-function test()
+function test() : any
 {
-	var s = input()
-	println("Hallo " + s)
+	println("test called.")
+	return true
 }

--- a/src/HelloWorld/helloworld.csproj
+++ b/src/HelloWorld/helloworld.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.4.7">
+﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.4.8">
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
 		<OutputType>Exe</OutputType>


### PR DESCRIPTION
## Summary
- propagate operand side effects through explicit conversion expressions
- add regression coverage for converted calls and assignments with constant logical operands on both sides
- bump the Balu version to 0.4.8 and update the HelloWorld example

## Testing
- `dotnet test src/Balu.Tests/Balu.Tests.csproj` (21,740 passed)

Closes #134