### PR TITLE
Fix bc option classification

### DIFF
--- a/docs/tools/compiler.md
+++ b/docs/tools/compiler.md
@@ -58,6 +58,16 @@ Mono.Options accepts both dash-style and slash-style options. The repository's
 MSBuild task uses slash-style options, while the development launch profile
 uses dash-style options with `=`.
 
+Use `--` to stop option processing when a source path begins with a dash:
+
+```console
+bc -- -program.b
+```
+
+On Windows, an unrecognized slash-prefixed argument is reported as an unknown
+option. On Unix, it remains a source path so that absolute paths continue to
+work.
+
 ### References: `-r`
 
 `bc` does not add default runtime references. Every required reference assembly

--- a/src/bc.Tests/CommandLineTests.cs
+++ b/src/bc.Tests/CommandLineTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using Xunit;
 
@@ -23,6 +24,35 @@ public sealed class CommandLineTests
         Assert.Equal(2, ExitCode);
         Assert.StartsWith("bc: error: ", Error);
         Assert.DoesNotContain("Compiling", Output);
+    }
+
+    [Fact]
+    public void Compiler_UnknownSlashOption_IsPlatformAppropriate()
+    {
+        var (ExitCode, Output, Error)= Run(["/bogus"]);
+
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Equal(2, ExitCode);
+            Assert.StartsWith("bc: error: Unknown option '/bogus'.", Error);
+            Assert.DoesNotContain("Compiling", Output);
+        }
+        else
+        {
+            Assert.Equal(3, ExitCode);
+            Assert.Contains("Compiling '/bogus'", Output);
+            Assert.DoesNotContain("Unknown option", Error);
+        }
+    }
+
+    [Fact]
+    public void Compiler_OptionTerminator_AllowsDashPrefixedSourcePath()
+    {
+        var (ExitCode, Output, Error)= Run(["--", "-program.b"]);
+
+        Assert.Equal(3, ExitCode);
+        Assert.Contains("Compiling '-program.b'", Output);
+        Assert.DoesNotContain("Unknown option", Error);
     }
 
     [Fact]
@@ -54,6 +84,20 @@ public sealed class CommandLineTests
         Assert.Equal(3, ExitCode);
         Assert.Empty(Output);
         Assert.Empty(Error);
+    }
+
+    [Fact]
+    public void Compiler_MultipleMissingSourceFiles_ReportsEachError()
+    {
+        var firstMissingPath = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.b");
+        var secondMissingPath = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.b");
+
+        var (ExitCode, _, Error)= Run([firstMissingPath, secondMissingPath]);
+
+        Assert.Equal(3, ExitCode);
+        Assert.Contains(firstMissingPath, Error);
+        Assert.Contains(secondMissingPath, Error);
+        Assert.DoesNotContain("One or more errors occurred", Error);
     }
 
     [Fact]

--- a/src/bc/Program.cs
+++ b/src/bc/Program.cs
@@ -54,13 +54,18 @@ sealed class Program
         quiet = args.TakeWhile(argument => argument != "--").Any(IsQuietOption);
         try
         {
-            sourcePaths.AddRange(options.Parse(args));
-            var unknownOption = sourcePaths.FirstOrDefault(path => path.StartsWith('-'));
+            var optionTerminatorIndex = Array.IndexOf(args, "--");
+            var argumentsToParse = optionTerminatorIndex < 0 ? args : args[..optionTerminatorIndex];
+            sourcePaths.AddRange(options.Parse(argumentsToParse));
+            var unknownOption = sourcePaths.FirstOrDefault(IsUnknownOption);
             if (unknownOption is not null)
             {
                 LogError($"Unknown option '{unknownOption}'.");
                 return InvocationError;
             }
+
+            if (optionTerminatorIndex >= 0)
+                sourcePaths.AddRange(args[(optionTerminatorIndex + 1)..]);
         }
         catch (OptionException parseError)
         {
@@ -102,6 +107,12 @@ sealed class Program
             LogInfo("Done.");
             return diagnostics.HasErrors() ? CompilationError : Success;
         }
+        catch (AggregateException aggregateError)
+        {
+            foreach (var innerError in aggregateError.Flatten().InnerExceptions)
+                LogError(innerError.Message);
+            return ToolError;
+        }
         catch (Exception error)
         {
             LogError(error.Message);
@@ -110,6 +121,8 @@ sealed class Program
     }
 
     static bool IsQuietOption(string argument) => argument is "-q" or "/q" or "--q";
+    static bool IsUnknownOption(string argument) =>
+        argument.StartsWith('-') || OperatingSystem.IsWindows() && argument.StartsWith('/');
 
     SyntaxTree Parse(string path)
     {


### PR DESCRIPTION
## Summary
- respect `--` when classifying positional source paths
- reject unknown slash-style options on Windows while preserving rooted Unix paths
- report each parallel source-loading failure without the aggregate wrapper
- document the command-line behavior and add CLI regression coverage

## Testing
- `dotnet test src/bc.Tests/bc.Tests.csproj`
- `dotnet test src/Balu.Tests/Balu.Tests.csproj`
- `dotnet test src/Balu.Sdk.Tests/Balu.Sdk.Tests.csproj`
- `dotnet test src/Balu.Interpretation.Tests/Balu.Interpretation.Tests.csproj`
- `dotnet test src/Balu.SourceGenerator.Tests/Balu.SourceGenerator.Tests.csproj`

Closes #142