### PR TITLE
Remove duplicate xUnit IDs from lexer theory data

### DIFF
--- a/src/Balu.Tests/LexerTests/DataProvider.cs
+++ b/src/Balu.Tests/LexerTests/DataProvider.cs
@@ -23,8 +23,6 @@ public partial class LexerTests
                     ("_my123", kind: SyntaxKind.IdentifierToken),
                     ("my_123_NameIs", kind: SyntaxKind.IdentifierToken),
                     ("x", kind: SyntaxKind.IdentifierToken),
-                    ("true", kind: SyntaxKind.TrueKeyword),
-                    ("false", kind: SyntaxKind.FalseKeyword),
                     ("\"Escaped\\\"String with even \\r and \\n, \\t and \\v\"", SyntaxKind.StringToken)
                 });
     static IEnumerable<(string text, SyntaxKind kind)> GetSeparators() => new (string text, SyntaxKind kind)[]

--- a/src/Balu.Tests/LexerTests/TokenCombinationTests.cs
+++ b/src/Balu.Tests/LexerTests/TokenCombinationTests.cs
@@ -21,6 +21,16 @@ public partial class LexerTests
         Assert.Empty(untestedTokenKinds);
     }
     [Fact]
+    public void Lexer_TestData_HasNoDuplicateSingleTokens()
+    {
+        var duplicateTokens = GetSingleTokens()
+                              .GroupBy(token => token)
+                              .Where(group => group.Count() > 1)
+                              .Select(group => group.Key);
+
+        Assert.Empty(duplicateTokens);
+    }
+    [Fact]
     public void Lexer_Lexes_EmptyInput()
     {
         Assert.Empty(SyntaxTree.ParseTokens(string.Empty));


### PR DESCRIPTION
## Summary
- remove redundant `true` and `false` lexer token fixtures already supplied by `SyntaxKind.GetText()`
- add a regression test that rejects duplicate `(text, kind)` fixtures
- eliminate duplicate xUnit theory IDs from lexer token combinations

## Tests
- `dotnet test src/Balu.Tests/Balu.Tests.csproj --filter "FullyQualifiedName~Balu.Tests.Syntax.LexerTests" --no-restore`
- `dotnet test src/Balu.Tests/Balu.Tests.csproj --no-restore`

Closes #145