### PR TITLE
Fix SDK source tracking and runtime reference validation

### DIFF
--- a/src/Balu.Sdk.Tests/SdkBuildTests.cs
+++ b/src/Balu.Sdk.Tests/SdkBuildTests.cs
@@ -166,6 +166,40 @@ public sealed class SdkBuildTests
         Assert.False(File.Exists(outputPdb));
     }
 
+    [Fact]
+    public void Sdk_DefaultItems_IgnoreIntermediateSources()
+    {
+        using var project = new TestProject();
+        project.SetSource("obj/generated.b", "missing()");
+
+        project.Build("Debug");
+    }
+
+    [Fact]
+    public void Sdk_DefaultItems_HonorExplicitRemoves()
+    {
+        using var project = new TestProject(items: "<ItemGroup><BaluFiles Remove=\"excluded.b\" /></ItemGroup>");
+        project.SetSource("excluded.b", "missing()");
+
+        project.Build("Debug");
+    }
+
+    [Fact]
+    public void Sdk_DeletingSourceFile_InvalidatesCompilerOutput()
+    {
+        using var project = new TestProject();
+        project.SetSource("removed.b", "function removed(): int { return 42 }");
+        project.Build("Debug");
+        var assemblyPath = project.IntermediateAssembly("Debug");
+        AssertProgramMethod(assemblyPath, "removed", expected: true);
+
+        Thread.Sleep(1100);
+        project.DeleteSource("removed.b");
+        project.Build("Debug", noRestore: true);
+
+        AssertProgramMethod(assemblyPath, "removed", expected: false);
+    }
+
     static void AssertDebuggerFriendly(string assemblyPath, bool expected, string? details = null)
     {
         using var assembly = AssemblyDefinition.ReadAssembly(assemblyPath);
@@ -175,6 +209,13 @@ public sealed class SdkBuildTests
         Assert.True(hasNop == expected, details);
     }
 
+    static void AssertProgramMethod(string assemblyPath, string methodName, bool expected)
+    {
+        using var assembly = AssemblyDefinition.ReadAssembly(assemblyPath);
+        var program = assembly.MainModule.Types.Single(type => type.Name == "Program");
+        Assert.True(program.Methods.Any(method => method.Name == methodName) == expected);
+    }
+
     sealed class TestProject : IDisposable
     {
         const string ProjectName = "TestProject";
@@ -182,7 +223,7 @@ public sealed class SdkBuildTests
         readonly string packageCache;
         string lastBuildOutput = string.Empty;
 
-        public TestProject(string properties = "")
+        public TestProject(string properties = "", string items = "")
         {
             directory = Directory.CreateTempSubdirectory("BaluSdkTests-").FullName;
             packageCache = Path.Combine(directory, "packages-cache");
@@ -190,7 +231,7 @@ public sealed class SdkBuildTests
             File.WriteAllText(
                 Path.Combine(directory, "NuGet.config"),
                 $"<configuration><packageSources><clear/><add key=\"BaluSdk\" value=\"{SecurityElement.Escape(packageSource)}\"/></packageSources></configuration>");
-            SetProperties(properties);
+            SetProperties(properties, items);
             SetSource("println(\"hello\")");
         }
 
@@ -199,10 +240,17 @@ public sealed class SdkBuildTests
         public string OutputPdb(string configuration) => Path.Combine(directory, "bin", configuration, "net10.0", $"{ProjectName}.pdb");
         public string PathFromProject(string relativePath) => Path.GetFullPath(relativePath, directory);
         public string DescribePdbs() => string.Join(Environment.NewLine, Directory.GetFiles(directory, "*.pdb", SearchOption.AllDirectories)) + Environment.NewLine + lastBuildOutput;
-        public void SetProperties(string properties) => File.WriteAllText(
+        public void SetProperties(string properties, string items = "") => File.WriteAllText(
             Path.Combine(directory, $"{ProjectName}.csproj"),
-            $"<Project Sdk=\"{SdkPackageId}/{SdkPackageVersion}\"><PropertyGroup><TargetFramework>net10.0</TargetFramework><OutputType>Exe</OutputType>{properties}</PropertyGroup></Project>");
+            $"<Project Sdk=\"{SdkPackageId}/{SdkPackageVersion}\"><PropertyGroup><TargetFramework>net10.0</TargetFramework><OutputType>Exe</OutputType>{properties}</PropertyGroup>{items}</Project>");
         public void SetSource(string source) => File.WriteAllText(Path.Combine(directory, "main.b"), source);
+        public void SetSource(string relativePath, string source)
+        {
+            var path = PathFromProject(relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, source);
+        }
+        public void DeleteSource(string relativePath) => File.Delete(PathFromProject(relativePath));
 
         public void Build(string configuration, bool noRestore = false) => Run("build", configuration, noRestore);
         public void Clean(string configuration) => Run("clean", configuration, noRestore: false);

--- a/src/Balu.Sdk/Sdk.props
+++ b/src/Balu.Sdk/Sdk.props
@@ -19,4 +19,7 @@
 	<UsingTask TaskName="Balu.Sdk.BaluCompiler" AssemblyFile="$(CustomTasksAssembly)"/>
 
 	<Import Project="sdk.props" Sdk="Microsoft.NET.Sdk"/>
+	<ItemGroup Condition="'$(EnableDefaultItems)' != 'false' AND '$(EnableDefaultCompileItems)' != 'false'">
+		<BaluFiles Include="$(MSBuildProjectDirectory)/**/*.b" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+	</ItemGroup>
 </Project>

--- a/src/Balu.Sdk/Sdk.targets
+++ b/src/Balu.Sdk/Sdk.targets
@@ -13,6 +13,7 @@
 		<_BaluDebug Condition="'$(_BaluDebug)' == ''">false</_BaluDebug>
 		<_BaluCompilerOptionsFile>$(IntermediateOutputPath)BaluCompilerOptions.txt</_BaluCompilerOptionsFile>
 		<_BaluSymbolPathStateFile>$(IntermediateOutputPath)BaluSymbolPath.txt</_BaluSymbolPathStateFile>
+		<_BaluSourceFilesStateFile>$(IntermediateOutputPath)BaluSourceFiles.txt</_BaluSourceFilesStateFile>
 	</PropertyGroup>
 	<ItemGroup Condition="'$(_BaluSymbolsProduced)' == 'true'">
 		<_DebugSymbolsIntermediatePath Remove="@(_DebugSymbolsIntermediatePath)" />
@@ -23,9 +24,10 @@
 	</ItemGroup>
 	<Target Name="BaluCollectFiles" BeforeTargets="CoreCompile">
 		<ItemGroup>
-			<BaluFiles Include="**/*.b"/>
 			<UpToDateCheckInput Include="@(BaluFiles)"/>
+			<FileWrites Include="$(_BaluSourceFilesStateFile)" />
 		</ItemGroup>
+		<WriteLinesToFile File="$(_BaluSourceFilesStateFile)" Lines="@(BaluFiles -> '%(FullPath)')" Overwrite="true" WriteOnlyWhenDifferent="true" />
 	</Target>
 	<Target Name="BaluPrepareCompilerOptions">
 		<Error Condition="'$(DebugType)' == 'embedded'" Text="Balu does not support embedded PDBs. Use DebugType 'portable' or 'none'." />
@@ -38,7 +40,7 @@
 			<FileWrites Include="$(_BaluCompilerOptionsFile);$(_BaluSymbolPathStateFile)" />
 		</ItemGroup>
 	</Target>
-	<Target Name="CoreCompile" DependsOnTargets="$(CoreCompileDependsOn);BaluCollectFiles;BaluPrepareCompilerOptions" Inputs="@(BaluFiles -> '%(FullPath)');$(_BaluCompilerOptionsFile)" Outputs="@(IntermediateAssembly -> '%(FullPath)');@(_BaluSymbolOutput -> '%(FullPath)')">
+	<Target Name="CoreCompile" DependsOnTargets="$(CoreCompileDependsOn);BaluCollectFiles;BaluPrepareCompilerOptions" Inputs="@(BaluFiles -> '%(FullPath)');$(_BaluSourceFilesStateFile);$(_BaluCompilerOptionsFile)" Outputs="@(IntermediateAssembly -> '%(FullPath)');@(_BaluSymbolOutput -> '%(FullPath)')">
 		<ItemGroup>
 			<ReferencePath Remove="@(ReferencePath)" Condition="
 						   '%(Filename)' != 'System.Runtime' AND 

--- a/src/Balu.Tests/EmitterTests/ReferenceValidationTests.cs
+++ b/src/Balu.Tests/EmitterTests/ReferenceValidationTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+using System.Linq;
+using Balu.Diagnostics;
+using Balu.Syntax;
+using Mono.Cecil;
+using TestHelpers;
+using Xunit;
+
+namespace Balu.Tests.EmitterTests;
+
+public partial class EmitterTests
+{
+    [Fact]
+    public void Emitter_RejectsRequiredMethodWithWrongReturnType() =>
+        AssertInvalidConsoleWrite(method => method.ReturnType = method.Module.TypeSystem.String, DiagnosticId.RequiredMethodNotFound);
+
+    [Fact]
+    public void Emitter_RejectsRequiredMethodWithWrongInvocationShape() =>
+        AssertInvalidConsoleWrite(method => method.IsStatic = false, DiagnosticId.RequiredMethodNotFound);
+
+    [Fact]
+    public void Emitter_RejectsStaticRequiredInstanceMethod() =>
+        AssertInvalidRequiredMethod("System.Random", "Next", "System.Int32", method => method.IsStatic = true, DiagnosticId.RequiredMethodNotFound);
+
+    [Fact]
+    public void Emitter_RejectsNonPublicRequiredMethod() =>
+        AssertInvalidConsoleWrite(method => method.IsPublic = false, DiagnosticId.RequiredMethodNotFound);
+
+    [Fact]
+    public void Emitter_RejectsAmbiguousRequiredMethod() =>
+        AssertInvalidConsoleWrite(CloneMethod, DiagnosticId.RequiredMethodAmbiguous);
+
+    static void AssertInvalidConsoleWrite(Action<MethodDefinition> modify, DiagnosticId expectedDiagnostic)
+        => AssertInvalidRequiredMethod("System.Console", "Write", "System.Object", modify, expectedDiagnostic);
+
+    static void AssertInvalidRequiredMethod(string typeName, string methodName, string parameterTypeName, Action<MethodDefinition> modify, DiagnosticId expectedDiagnostic)
+    {
+        var directory = Directory.CreateTempSubdirectory("BaluEmitterValidation-");
+        try
+        {
+            var references = CopyReferences(directory);
+            ModifyRequiredMethod(references, typeName, methodName, parameterTypeName, modify);
+            var compilation = Compilation.Create(SyntaxTree.Parse("function main() {}"));
+            using var output = new MemoryStream();
+
+            var diagnostics = compilation.Emit("InvalidReferences", references, output, null);
+
+            Assert.Contains(diagnostics, diagnostic => diagnostic.Id == expectedDiagnostic);
+            Assert.Equal(0, output.Length);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    static void ModifyRequiredMethod(string[] references, string typeName, string methodName, string parameterTypeName, Action<MethodDefinition> modify)
+    {
+        foreach (var reference in references)
+        {
+            using var assembly = AssemblyDefinition.ReadAssembly(reference, new ReaderParameters { InMemory = true });
+            var type = assembly.MainModule.GetType(typeName);
+            if (type is null) continue;
+            var method = type.Methods.Single(candidate =>
+                candidate.Name == methodName &&
+                candidate.Parameters.Count == 1 &&
+                candidate.Parameters[0].ParameterType.FullName == parameterTypeName);
+            modify(method);
+            assembly.Write(reference);
+            return;
+        }
+        throw new InvalidOperationException($"Could not find required type '{typeName}'.");
+    }
+
+    static void CloneMethod(MethodDefinition method)
+    {
+        var clone = new MethodDefinition(method.Name, method.Attributes, method.ReturnType)
+        {
+            CallingConvention = method.CallingConvention,
+            ExplicitThis = method.ExplicitThis,
+            HasThis = method.HasThis
+        };
+        foreach (var parameter in method.Parameters)
+            clone.Parameters.Add(new(parameter.Name, parameter.Attributes, parameter.ParameterType));
+        method.DeclaringType.Methods.Add(clone);
+    }
+}

--- a/src/Balu.Tests/UnitTests/Diagnostics/DiagnosticIdTests.cs
+++ b/src/Balu.Tests/UnitTests/Diagnostics/DiagnosticIdTests.cs
@@ -59,7 +59,8 @@ public class DiagnosticIdTests
         (DiagnosticId.RequiredMethodNotFound, 2004),
         (DiagnosticId.SourceDocumentNameMissing, 2005),
         (DiagnosticId.SourceDocumentNameCollision, 2006),
-        (DiagnosticId.EmitPathCollision, 2007)
+        (DiagnosticId.EmitPathCollision, 2007),
+        (DiagnosticId.RequiredMethodAmbiguous, 2008)
     };
 
     [Theory]

--- a/src/Balu/Diagnostics/DiagnosticBag.cs
+++ b/src/Balu/Diagnostics/DiagnosticBag.cs
@@ -119,7 +119,9 @@ sealed class DiagnosticBag : List<Diagnostic>
     public void ReportRequiredTypeAmbiguous(string name, TypeDefinition[] typeDefinitions) =>
         Add(new(DiagnosticId.RequiredTypeAmbiguous, default, $"The required type '{name}' is ambiguous among these referenced assemblies: {string.Join(", ", typeDefinitions.Select(t => t.Module.Assembly.Name.Name).OrderBy(n => n))}."));
     public void ReportRequiredMethodNotFound(string type, string name, string[] parameterTypeNames) =>
-        Add(new(DiagnosticId.RequiredMethodNotFound, default, $"The required method'{type}.{name}({string.Join(", ", parameterTypeNames)})' could not be found in the referenced assemblies."));
+        Add(new(DiagnosticId.RequiredMethodNotFound, default, $"The required method '{type}.{name}({string.Join(", ", parameterTypeNames)})' could not be found in the referenced assemblies."));
+    public void ReportRequiredMethodAmbiguous(string type, string name, string[] parameterTypeNames) =>
+        Add(new(DiagnosticId.RequiredMethodAmbiguous, default, $"The required method '{type}.{name}({string.Join(", ", parameterTypeNames)})' is ambiguous in the referenced assemblies."));
     public void ReportSourceDocumentNameMissing(TextLocation location) =>
         Add(new(DiagnosticId.SourceDocumentNameMissing, location, "Cannot emit debug symbols for a source document without a name."));
     public void ReportSourceDocumentNameCollision(TextLocation location, string documentName) =>

--- a/src/Balu/Diagnostics/DiagnosticId.cs
+++ b/src/Balu/Diagnostics/DiagnosticId.cs
@@ -51,5 +51,6 @@ public enum DiagnosticId
     RequiredMethodNotFound = 2004,
     SourceDocumentNameMissing = 2005,
     SourceDocumentNameCollision = 2006,
-    EmitPathCollision = 2007
+    EmitPathCollision = 2007,
+    RequiredMethodAmbiguous = 2008
 }

--- a/src/Balu/Emit/EmitReferenceSet.cs
+++ b/src/Balu/Emit/EmitReferenceSet.cs
@@ -10,25 +10,32 @@ namespace Balu.Emit;
 
 public sealed class EmitReferenceSet : IDisposable
 {
-    static class RequiredMethodParameters
+    readonly record struct RequiredMethod(
+        string Name,
+        string ReturnTypeName,
+        bool IsStatic,
+        bool IsConstructor,
+        string[] ParameterTypeNames);
+
+    static class RequiredMethods
     {
         static readonly string[] SingleObject = ["System.Object"];
         static readonly string[] Empty = [];
 
-        public static readonly string[] ConsoleWrite = SingleObject;
-        public static readonly string[] ConsoleWriteLine = SingleObject;
-        public static readonly string[] ConsoleReadLine = Empty;
-        public static readonly string[] StringConcat2 = ["System.String", "System.String"];
-        public static readonly string[] StringConcat3 = ["System.String", "System.String", "System.String"];
-        public static readonly string[] StringConcat4 = ["System.String", "System.String", "System.String", "System.String"];
-        public static readonly string[] StringConcatArray = ["System.String[]"];
-        public static readonly string[] ConvertToBool = SingleObject;
-        public static readonly string[] ConvertToInt = SingleObject;
-        public static readonly string[] ConvertToString = SingleObject;
-        public static readonly string[] ObjectEquals = ["System.Object", "System.Object"];
-        public static readonly string[] RandomCtor = Empty;
-        public static readonly string[] RandomNext = ["System.Int32"];
-        public static readonly string[] DebuggableCtor = ["System.Boolean", "System.Boolean"];
+        public static readonly RequiredMethod ConsoleWrite = new("Write", "System.Void", true, false, SingleObject);
+        public static readonly RequiredMethod ConsoleWriteLine = new("WriteLine", "System.Void", true, false, SingleObject);
+        public static readonly RequiredMethod ConsoleReadLine = new("ReadLine", "System.String", true, false, Empty);
+        public static readonly RequiredMethod StringConcat2 = new("Concat", "System.String", true, false, ["System.String", "System.String"]);
+        public static readonly RequiredMethod StringConcat3 = new("Concat", "System.String", true, false, ["System.String", "System.String", "System.String"]);
+        public static readonly RequiredMethod StringConcat4 = new("Concat", "System.String", true, false, ["System.String", "System.String", "System.String", "System.String"]);
+        public static readonly RequiredMethod StringConcatArray = new("Concat", "System.String", true, false, ["System.String[]"]);
+        public static readonly RequiredMethod ConvertToBool = new("ToBoolean", "System.Boolean", true, false, SingleObject);
+        public static readonly RequiredMethod ConvertToInt = new("ToInt32", "System.Int32", true, false, SingleObject);
+        public static readonly RequiredMethod ConvertToString = new("ToString", "System.String", true, false, SingleObject);
+        public static readonly RequiredMethod ObjectEquals = new("Equals", "System.Boolean", true, false, ["System.Object", "System.Object"]);
+        public static readonly RequiredMethod RandomCtor = new(".ctor", "System.Void", false, true, Empty);
+        public static readonly RequiredMethod RandomNext = new("Next", "System.Int32", false, false, ["System.Int32"]);
+        public static readonly RequiredMethod DebuggableCtor = new(".ctor", "System.Void", false, true, ["System.Boolean", "System.Boolean"]);
     }
 
     static readonly string[] requiredTypeNames =
@@ -155,20 +162,20 @@ public sealed class EmitReferenceSet : IDisposable
         var randomType = types["System.Random"]!;
         var debuggableAttributeType = types["System.Diagnostics.DebuggableAttribute"]!;
 
-        var consoleWrite = ResolveMethod(consoleType, "Write", RequiredMethodParameters.ConsoleWrite, diagnosticBag);
-        var consoleWriteLine = ResolveMethod(consoleType, "WriteLine", RequiredMethodParameters.ConsoleWriteLine, diagnosticBag);
-        var consoleReadLine = ResolveMethod(consoleType, "ReadLine", RequiredMethodParameters.ConsoleReadLine, diagnosticBag);
-        var stringConcat2 = ResolveMethod(stringType, "Concat", RequiredMethodParameters.StringConcat2, diagnosticBag);
-        var stringConcat3 = ResolveMethod(stringType, "Concat", RequiredMethodParameters.StringConcat3, diagnosticBag);
-        var stringConcat4 = ResolveMethod(stringType, "Concat", RequiredMethodParameters.StringConcat4, diagnosticBag);
-        var stringConcatArray = ResolveMethod(stringType, "Concat", RequiredMethodParameters.StringConcatArray, diagnosticBag);
-        var convertToBool = ResolveMethod(convertType, "ToBoolean", RequiredMethodParameters.ConvertToBool, diagnosticBag);
-        var convertToInt = ResolveMethod(convertType, "ToInt32", RequiredMethodParameters.ConvertToInt, diagnosticBag);
-        var convertToString = ResolveMethod(convertType, "ToString", RequiredMethodParameters.ConvertToString, diagnosticBag);
-        var objectEquals = ResolveMethod(objectType, "Equals", RequiredMethodParameters.ObjectEquals, diagnosticBag);
-        var randomCtor = ResolveMethod(randomType, ".ctor", RequiredMethodParameters.RandomCtor, diagnosticBag);
-        var randomNext = ResolveMethod(randomType, "Next", RequiredMethodParameters.RandomNext, diagnosticBag);
-        var debuggableCtor = ResolveMethod(debuggableAttributeType, ".ctor", RequiredMethodParameters.DebuggableCtor, diagnosticBag);
+        var consoleWrite = ResolveMethod(consoleType, RequiredMethods.ConsoleWrite, diagnosticBag);
+        var consoleWriteLine = ResolveMethod(consoleType, RequiredMethods.ConsoleWriteLine, diagnosticBag);
+        var consoleReadLine = ResolveMethod(consoleType, RequiredMethods.ConsoleReadLine, diagnosticBag);
+        var stringConcat2 = ResolveMethod(stringType, RequiredMethods.StringConcat2, diagnosticBag);
+        var stringConcat3 = ResolveMethod(stringType, RequiredMethods.StringConcat3, diagnosticBag);
+        var stringConcat4 = ResolveMethod(stringType, RequiredMethods.StringConcat4, diagnosticBag);
+        var stringConcatArray = ResolveMethod(stringType, RequiredMethods.StringConcatArray, diagnosticBag);
+        var convertToBool = ResolveMethod(convertType, RequiredMethods.ConvertToBool, diagnosticBag);
+        var convertToInt = ResolveMethod(convertType, RequiredMethods.ConvertToInt, diagnosticBag);
+        var convertToString = ResolveMethod(convertType, RequiredMethods.ConvertToString, diagnosticBag);
+        var objectEquals = ResolveMethod(objectType, RequiredMethods.ObjectEquals, diagnosticBag);
+        var randomCtor = ResolveMethod(randomType, RequiredMethods.RandomCtor, diagnosticBag);
+        var randomNext = ResolveMethod(randomType, RequiredMethods.RandomNext, diagnosticBag);
+        var debuggableCtor = ResolveMethod(debuggableAttributeType, RequiredMethods.DebuggableCtor, diagnosticBag);
         if (diagnosticBag.HasErrors()) return null;
 
         return new(
@@ -194,13 +201,24 @@ public sealed class EmitReferenceSet : IDisposable
             debuggableCtor!);
     }
 
-    static MethodDefinition? ResolveMethod(TypeDefinition type, string name, string[] parameterTypeNames, DiagnosticBag diagnosticBag)
+    static MethodDefinition? ResolveMethod(TypeDefinition type, RequiredMethod requiredMethod, DiagnosticBag diagnosticBag)
     {
-        var method = type.Methods.FirstOrDefault(candidate =>
-            candidate.Name == name && candidate.Parameters.Select(parameter => parameter.ParameterType.FullName).SequenceEqual(parameterTypeNames));
-        if (method is null)
-            diagnosticBag.ReportRequiredMethodNotFound(type.FullName, name, parameterTypeNames);
-        return method;
+        var methods = type.Methods.Where(candidate =>
+            candidate.Name == requiredMethod.Name &&
+            candidate.ReturnType.FullName == requiredMethod.ReturnTypeName &&
+            candidate.IsPublic &&
+            candidate.IsStatic == requiredMethod.IsStatic &&
+            candidate.HasThis == !requiredMethod.IsStatic &&
+            !candidate.ExplicitThis &&
+            candidate.IsConstructor == requiredMethod.IsConstructor &&
+            !candidate.HasGenericParameters &&
+            candidate.CallingConvention == MethodCallingConvention.Default &&
+            candidate.Parameters.Select(parameter => parameter.ParameterType.FullName).SequenceEqual(requiredMethod.ParameterTypeNames)).ToArray();
+        if (methods.Length == 0)
+            diagnosticBag.ReportRequiredMethodNotFound(type.FullName, requiredMethod.Name, requiredMethod.ParameterTypeNames);
+        else if (methods.Length > 1)
+            diagnosticBag.ReportRequiredMethodAmbiguous(type.FullName, requiredMethod.Name, requiredMethod.ParameterTypeNames);
+        return methods.Length == 1 ? methods[0] : null;
     }
 
     void DisposeAssemblies()

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<BaluVersion Condition="'$(BaluVersion)' == ''">0.4.8</BaluVersion>
+		<BaluVersion Condition="'$(BaluVersion)' == ''">0.5.0</BaluVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(MSBuildProjectName)' == 'Balu' Or

--- a/src/HelloWorld/helloworld.csproj
+++ b/src/HelloWorld/helloworld.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.4.8">
+﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.5.0">
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
 		<OutputType>Exe</OutputType>


### PR DESCRIPTION
## Summary
- evaluate default Balu source items with standard MSBuild exclusions and project-level item semantics
- track the evaluated source-file set so deletions invalidate incremental compilation
- validate complete runtime method signatures and diagnose ambiguous matches
- add SDK integration tests and Cecil-generated malformed-reference tests

## Tests
- `dotnet test src/Balu.Tests/Balu.Tests.csproj --no-restore`
- `dotnet test src/Balu.Sdk.Tests/Balu.Sdk.Tests.csproj --no-restore`
- `dotnet test src/Balu.Interpretation.Tests/Balu.Interpretation.Tests.csproj --no-restore`
- `dotnet test src/bc.Tests/bc.Tests.csproj --no-restore`
- `dotnet test src/Balu.SourceGenerator.Tests/Balu.SourceGenerator.Tests.csproj --no-restore`

Closes #139
Closes #140
Closes #141