### PR TITLE
Prevent inclusive for-loop overflow

### DIFF
--- a/src/Balu.Tests/EmitterTests/ForTests.cs
+++ b/src/Balu.Tests/EmitterTests/ForTests.cs
@@ -22,24 +22,30 @@ public partial class EmitterTests
             IL0002: stloc.0
             IL0003: ldc.i4.s 10
             IL0005: stloc.1
-            IL0006: br.s IL_000c: ldloc.0
-            IL0008: ldloc.0
-            IL0009: ldc.i4.1
-            IL000A: add
-            IL000B: stloc.0
-            IL000C: ldloc.0
-            IL000D: ldc.i4.s 10
-            IL000F: cgt
-            IL0011: ldc.i4.0
-            IL0012: ceq
-            IL0014: brfalse.s IL_001a: nop
-            IL0016: nop
-            IL0017: nop
-            IL0018: br.s IL_0008: ldloc.0
-            IL001A: nop
-            IL001B: ret
+            IL0006: br.s IL_0016: ldloc.0
+            IL0008: ldc.i4.s 10
+            IL000A: ldloc.0
+            IL000B: cgt
+            IL000D: ldc.i4.0
+            IL000E: ceq
+            IL0010: brtrue.s IL_0024: nop
+            IL0012: ldloc.0
+            IL0013: ldc.i4.1
+            IL0014: add
+            IL0015: stloc.0
+            IL0016: ldloc.0
+            IL0017: ldc.i4.s 10
+            IL0019: cgt
+            IL001B: ldc.i4.0
+            IL001C: ceq
+            IL001E: brfalse.s IL_0024: nop
+            IL0020: nop
+            IL0021: nop
+            IL0022: br.s IL_0008: ldc.i4.s 10
+            IL0024: nop
+            IL0025: ret
 ";
-        var offsets = new[] { 0, 1, 3, 8, 0xC, 0x16, 0x17, 0x1A };
+        var offsets = new[] { 0, 1, 3, 0x12, 0x16, 0x20, 0x21, 0x24 };
         code.AssertIlAndSymbols("test", il, offsets, output: output);
     }
     [Fact]
@@ -58,19 +64,25 @@ public partial class EmitterTests
             IL0001: stloc.0
             IL0002: ldc.i4.s 10
             IL0004: stloc.1
-            IL0005: br.s IL_000b: ldloc.0
-            IL0007: ldloc.0
-            IL0008: ldc.i4.1
-            IL0009: add
-            IL000A: stloc.0
-            IL000B: ldloc.0
-            IL000C: ldc.i4.s 10
-            IL000E: cgt
-            IL0010: ldc.i4.0
-            IL0011: ceq
-            IL0013: brfalse.s IL_0017: ret
-            IL0015: br.s IL_0007: ldloc.0
-            IL0017: ret
+            IL0005: br.s IL_0015: ldloc.0
+            IL0007: ldc.i4.s 10
+            IL0009: ldloc.0
+            IL000A: cgt
+            IL000C: ldc.i4.0
+            IL000D: ceq
+            IL000F: brtrue.s IL_0021: ret
+            IL0011: ldloc.0
+            IL0012: ldc.i4.1
+            IL0013: add
+            IL0014: stloc.0
+            IL0015: ldloc.0
+            IL0016: ldc.i4.s 10
+            IL0018: cgt
+            IL001A: ldc.i4.0
+            IL001B: ceq
+            IL001D: brfalse.s IL_0021: ret
+            IL001F: br.s IL_0007: ldc.i4.s 10
+            IL0021: ret
 ";
         code.AssertIl("test", il, output: output);
     }
@@ -97,36 +109,42 @@ public partial class EmitterTests
             IL0002: stloc.0
             IL0003: ldc.i4.s 10
             IL0005: stloc.1
-            IL0006: br.s IL_000c: ldloc.0
-            IL0008: ldloc.0
-            IL0009: ldc.i4.1
-            IL000A: add
-            IL000B: stloc.0
-            IL000C: ldloc.0
-            IL000D: ldc.i4.s 10
-            IL000F: cgt
-            IL0011: ldc.i4.0
-            IL0012: ceq
-            IL0014: brfalse.s IL_002c: nop
-            IL0016: nop
-            IL0017: ldloc.0
-            IL0018: ldc.i4.3
+            IL0006: br.s IL_0016: ldloc.0
+            IL0008: ldc.i4.s 10
+            IL000A: ldloc.0
+            IL000B: cgt
+            IL000D: ldc.i4.0
+            IL000E: ceq
+            IL0010: brtrue.s IL_0036: nop
+            IL0012: ldloc.0
+            IL0013: ldc.i4.1
+            IL0014: add
+            IL0015: stloc.0
+            IL0016: ldloc.0
+            IL0017: ldc.i4.s 10
             IL0019: cgt
-            IL001B: brfalse.s IL_001f: ldloc.0
-            IL001D: br.s IL_002c: nop
-            IL001F: ldloc.0
-            IL0020: ldc.i4.5
-            IL0021: cgt
-            IL0023: brfalse.s IL_0027: ldc.i4.1
-            IL0025: br.s IL_0008: ldloc.0
-            IL0027: ldc.i4.1
-            IL0028: stloc.0
-            IL0029: nop
-            IL002A: br.s IL_0008: ldloc.0
-            IL002C: nop
-            IL002D: ret
+            IL001B: ldc.i4.0
+            IL001C: ceq
+            IL001E: brfalse.s IL_0036: nop
+            IL0020: nop
+            IL0021: ldloc.0
+            IL0022: ldc.i4.3
+            IL0023: cgt
+            IL0025: brfalse.s IL_0029: ldloc.0
+            IL0027: br.s IL_0036: nop
+            IL0029: ldloc.0
+            IL002A: ldc.i4.5
+            IL002B: cgt
+            IL002D: brfalse.s IL_0031: ldc.i4.1
+            IL002F: br.s IL_0008: ldc.i4.s 10
+            IL0031: ldc.i4.1
+            IL0032: stloc.0
+            IL0033: nop
+            IL0034: br.s IL_0008: ldc.i4.s 10
+            IL0036: nop
+            IL0037: ret
 ";
-        var offsets = new[] { 0,1,3,8,0xC, 0x16, 0x17, 0x1D, 0x1F, 0x25, 0x27, 0x29, 0x2C };
+        var offsets = new[] { 0, 1, 3, 0x12, 0x16, 0x20, 0x21, 0x27, 0x29, 0x2F, 0x31, 0x33, 0x36 };
         code.AssertIlAndSymbols("test", il, offsets, output: output);
     }
     [Fact]
@@ -150,31 +168,37 @@ public partial class EmitterTests
             IL0001: stloc.0
             IL0002: ldc.i4.s 10
             IL0004: stloc.1
-            IL0005: br.s IL_000b: ldloc.0
-            IL0007: ldloc.0
-            IL0008: ldc.i4.1
-            IL0009: add
-            IL000A: stloc.0
-            IL000B: ldloc.0
-            IL000C: ldc.i4.s 10
-            IL000E: cgt
-            IL0010: ldc.i4.0
-            IL0011: ceq
-            IL0013: brfalse.s IL_0029: ret
+            IL0005: br.s IL_0015: ldloc.0
+            IL0007: ldc.i4.s 10
+            IL0009: ldloc.0
+            IL000A: cgt
+            IL000C: ldc.i4.0
+            IL000D: ceq
+            IL000F: brtrue.s IL_0033: ret
+            IL0011: ldloc.0
+            IL0012: ldc.i4.1
+            IL0013: add
+            IL0014: stloc.0
             IL0015: ldloc.0
-            IL0016: ldc.i4.3
-            IL0017: cgt
-            IL0019: brfalse.s IL_001d: ldloc.0
-            IL001B: br.s IL_0029: ret
-            IL001D: ldloc.0
-            IL001E: ldc.i4.5
-            IL001F: cgt
-            IL0021: brfalse.s IL_0025: ldc.i4.1
-            IL0023: br.s IL_0007: ldloc.0
-            IL0025: ldc.i4.1
-            IL0026: stloc.0
-            IL0027: br.s IL_0007: ldloc.0
-            IL0029: ret
+            IL0016: ldc.i4.s 10
+            IL0018: cgt
+            IL001A: ldc.i4.0
+            IL001B: ceq
+            IL001D: brfalse.s IL_0033: ret
+            IL001F: ldloc.0
+            IL0020: ldc.i4.3
+            IL0021: cgt
+            IL0023: brfalse.s IL_0027: ldloc.0
+            IL0025: br.s IL_0033: ret
+            IL0027: ldloc.0
+            IL0028: ldc.i4.5
+            IL0029: cgt
+            IL002B: brfalse.s IL_002f: ldc.i4.1
+            IL002D: br.s IL_0007: ldc.i4.s 10
+            IL002F: ldc.i4.1
+            IL0030: stloc.0
+            IL0031: br.s IL_0007: ldc.i4.s 10
+            IL0033: ret
 ";
         code.AssertIl("test", il, output: output);
     }
@@ -195,24 +219,30 @@ public partial class EmitterTests
             IL0002: stloc.0
             IL0003: ldc.i4.s 10
             IL0005: stloc.1
-            IL0006: br.s IL_000c: ldloc.0
-            IL0008: ldloc.0
-            IL0009: ldc.i4.1
-            IL000A: add
-            IL000B: stloc.0
-            IL000C: ldloc.0
-            IL000D: ldc.i4.s 10
-            IL000F: cgt
-            IL0011: ldc.i4.0
-            IL0012: ceq
-            IL0014: brfalse.s IL_0022: nop
-            IL0016: ldstr
-            IL001B: call System.Void System.Console::WriteLine(System.Object)
-            IL0020: br.s IL_0008: ldloc.0
-            IL0022: nop
-            IL0023: ret
+            IL0006: br.s IL_0016: ldloc.0
+            IL0008: ldc.i4.s 10
+            IL000A: ldloc.0
+            IL000B: cgt
+            IL000D: ldc.i4.0
+            IL000E: ceq
+            IL0010: brtrue.s IL_002c: nop
+            IL0012: ldloc.0
+            IL0013: ldc.i4.1
+            IL0014: add
+            IL0015: stloc.0
+            IL0016: ldloc.0
+            IL0017: ldc.i4.s 10
+            IL0019: cgt
+            IL001B: ldc.i4.0
+            IL001C: ceq
+            IL001E: brfalse.s IL_002c: nop
+            IL0020: ldstr
+            IL0025: call System.Void System.Console::WriteLine(System.Object)
+            IL002A: br.s IL_0008: ldc.i4.s 10
+            IL002C: nop
+            IL002D: ret
 ";
-        var offsets = new[] { 0, 1, 3, 8, 0xC, 0x16, 0x22 };
+        var offsets = new[] { 0, 1, 3, 0x12, 0x16, 0x20, 0x2C };
         code.AssertIlAndSymbols("test", il, offsets, output: output);
     }
     [Fact]
@@ -230,21 +260,27 @@ public partial class EmitterTests
             IL0001: stloc.0
             IL0002: ldc.i4.s 10
             IL0004: stloc.1
-            IL0005: br.s IL_000b: ldloc.0
-            IL0007: ldloc.0
-            IL0008: ldc.i4.1
-            IL0009: add
-            IL000A: stloc.0
-            IL000B: ldloc.0
-            IL000C: ldc.i4.s 10
-            IL000E: cgt
-            IL0010: ldc.i4.0
-            IL0011: ceq
-            IL0013: brfalse.s IL_0021: ret
-            IL0015: ldstr
-            IL001A: call System.Void System.Console::WriteLine(System.Object)
-            IL001F: br.s IL_0007: ldloc.0
-            IL0021: ret
+            IL0005: br.s IL_0015: ldloc.0
+            IL0007: ldc.i4.s 10
+            IL0009: ldloc.0
+            IL000A: cgt
+            IL000C: ldc.i4.0
+            IL000D: ceq
+            IL000F: brtrue.s IL_002b: ret
+            IL0011: ldloc.0
+            IL0012: ldc.i4.1
+            IL0013: add
+            IL0014: stloc.0
+            IL0015: ldloc.0
+            IL0016: ldc.i4.s 10
+            IL0018: cgt
+            IL001A: ldc.i4.0
+            IL001B: ceq
+            IL001D: brfalse.s IL_002b: ret
+            IL001F: ldstr
+            IL0024: call System.Void System.Console::WriteLine(System.Object)
+            IL0029: br.s IL_0007: ldc.i4.s 10
+            IL002B: ret
 ";
         code.AssertIl("test", il, output: output);
     }

--- a/src/Balu.Tests/EmitterTests/LocalVariableScopeTests.cs
+++ b/src/Balu.Tests/EmitterTests/LocalVariableScopeTests.cs
@@ -32,7 +32,7 @@ public partial class EmitterTests
              <END 0006>
             <END 0006>
 ";
-        var offsets = new[] { 0, 1, 3, 5};
+        var offsets = new[] { 0, 1, 3, 5 };
 
         code.AssertIlAndSymbols("test", il, offsets, scopes, output: output);
     }
@@ -63,42 +63,48 @@ public partial class EmitterTests
             IL0002: stloc.0
             IL0003: ldc.i4.s 10
             IL0005: stloc.1
-            IL0006: br.s IL_000c: ldloc.0
-            IL0008: ldloc.0
-            IL0009: ldc.i4.1
-            IL000A: add
-            IL000B: stloc.0
-            IL000C: ldloc.0
-            IL000D: ldc.i4.s 10
-            IL000F: cgt
-            IL0011: ldc.i4.0
-            IL0012: ceq
-            IL0014: brfalse.s IL_002b: ldc.i4.1
-            IL0016: nop
-            IL0017: ldc.i4.1
-            IL0018: stloc.2
-            IL0019: ldloc.2
-            IL001A: ldloc.0
-            IL001B: cgt
-            IL001D: brfalse.s IL_0023: ldc.i4.2
-            IL001F: nop
-            IL0020: ldloc.2
-            IL0021: stloc.3
-            IL0022: nop
-            IL0023: ldc.i4.2
-            IL0024: ldloc.2
-            IL0025: mul
-            IL0026: stloc.s V_4
-            IL0028: nop
-            IL0029: br.s IL_0008: ldloc.0
-            IL002B: ldc.i4.1
-            IL002C: stloc.s V_5
-            IL002E: ldloc.s V_5
-            IL0030: brfalse.s IL_0035: nop
-            IL0032: ldc.i4.0
-            IL0033: stloc.s V_6
-            IL0035: nop
-            IL0036: ret
+            IL0006: br.s IL_0016: ldloc.0
+            IL0008: ldc.i4.s 10
+            IL000A: ldloc.0
+            IL000B: cgt
+            IL000D: ldc.i4.0
+            IL000E: ceq
+            IL0010: brtrue.s IL_0035: ldc.i4.1
+            IL0012: ldloc.0
+            IL0013: ldc.i4.1
+            IL0014: add
+            IL0015: stloc.0
+            IL0016: ldloc.0
+            IL0017: ldc.i4.s 10
+            IL0019: cgt
+            IL001B: ldc.i4.0
+            IL001C: ceq
+            IL001E: brfalse.s IL_0035: ldc.i4.1
+            IL0020: nop
+            IL0021: ldc.i4.1
+            IL0022: stloc.2
+            IL0023: ldloc.2
+            IL0024: ldloc.0
+            IL0025: cgt
+            IL0027: brfalse.s IL_002d: ldc.i4.2
+            IL0029: nop
+            IL002A: ldloc.2
+            IL002B: stloc.3
+            IL002C: nop
+            IL002D: ldc.i4.2
+            IL002E: ldloc.2
+            IL002F: mul
+            IL0030: stloc.s V_4
+            IL0032: nop
+            IL0033: br.s IL_0008: ldc.i4.s 10
+            IL0035: ldc.i4.1
+            IL0036: stloc.s V_5
+            IL0038: ldloc.s V_5
+            IL003A: brfalse.s IL_003f: nop
+            IL003C: ldc.i4.0
+            IL003D: stloc.s V_6
+            IL003F: nop
+            IL0040: ret
 ";
         const string scopes = @"
             <BEGIN 0000>
@@ -106,33 +112,33 @@ public partial class EmitterTests
               <BEGIN 0002>
               loopVariable
                <BEGIN 0005>
-                <BEGIN 0016>
-                 <BEGIN 0018>
+                <BEGIN 0020>
+                 <BEGIN 0022>
                  x
-                  <BEGIN 001F>
-                   <BEGIN 0021>
+                  <BEGIN 0029>
+                   <BEGIN 002B>
                    y
-                   <END 0023>
-                  <END 0023>
-                  <BEGIN 0026>
+                   <END 002D>
+                  <END 002D>
+                  <BEGIN 0030>
                   z
-                  <END 0029>
-                 <END 0029>
-                <END 0029>
-               <END 002B>
-              <END 002B>
-             <END 002B>
-             <BEGIN 002C>
-             ende
-              <BEGIN 0032>
-               <BEGIN 0033>
-               schluss
+                  <END 0033>
+                 <END 0033>
+                <END 0033>
                <END 0035>
               <END 0035>
-             <END 0036>
-            <END 0036>
+             <END 0035>
+             <BEGIN 0036>
+             ende
+              <BEGIN 003C>
+               <BEGIN 003D>
+               schluss
+               <END 003F>
+              <END 003F>
+             <END 0040>
+            <END 0040>
 ";
-        var offsets = new[] { 0, 1, 3, 8, 0xC, 0x16, 0x17, 0x19, 0x1F, 0x20, 0x22, 0x23, 0x28, 0x2B, 0x2E, 0x32, 0x35 };
+        var offsets = new[] { 0, 1, 3, 0x12, 0x16, 0x20, 0x21, 0x23, 0x29, 0x2A, 0x2C, 0x2D, 0x32, 0x35, 0x38, 0x3C, 0x3F };
 
         code.AssertIlAndSymbols("test", il, offsets, scopes, output: output);
 

--- a/src/Balu.Tests/ExecutionTests/ForStatementTests.cs
+++ b/src/Balu.Tests/ExecutionTests/ForStatementTests.cs
@@ -9,6 +9,21 @@ public partial class ExecutionTests
     [InlineData("var result = 0 for i=0 to 10 result=result+i result", 55)]
     public void Script_ForStatement_BasicallyWorks(string text, object? result) => text.AssertScriptEvaluation(value: result);
     [Fact]
+    public void Script_ForStatement_DoesNotOverflowAtIntegerMaximum()
+    {
+        const string text = @"
+            var count = 0
+            for i = 2147483647 to 2147483647 {
+                count++
+                if count > 1
+                    break
+            }
+            count
+        ";
+
+        text.AssertScriptEvaluation(value: 1);
+    }
+    [Fact]
     public void Script_ForStatement_Reports_WrongBoundaryTypes()
     {
         const string text = "for i= [1>2] to [2>1] {}";

--- a/src/Balu/Lowering/Lowerer.cs
+++ b/src/Balu/Lowering/Lowerer.cs
@@ -85,6 +85,7 @@ sealed class Lowerer : BoundTreeRewriter
          *  gotofalse <var> <= <tmp> -> <break>
          *  <body>
          *  <continue>:
+         *  gototrue <tmp> <= <var> -> <break>
          *  <var>++
          *  goto <start>
          *  <break>:
@@ -95,10 +96,14 @@ sealed class Lowerer : BoundTreeRewriter
         var startLabel = new BoundLabel("<start>");
         var lowerVariableDeclaration =VariableDeclaration(syntax.LowerBound, forStatement.Variable, forStatement.LowerBound);
         var upperVariableDeclaration = ConstantDeclaration(syntax.UpperBound, "<upperBound>", forStatement.UpperBound);
-        var checkStatement = GotoFalse(syntax.ToKeyword, forStatement.BreakLabel, 
-                                       LessOrEqual(syntax.ToKeyword, 
+        var checkStatement = GotoFalse(syntax.ToKeyword, forStatement.BreakLabel,
+                                       LessOrEqual(syntax.ToKeyword,
                                                    Variable(syntax.IdentifierToken, forStatement.Variable),
                                                    Variable(syntax.UpperBound, upperVariableDeclaration.Variable)));
+        var exitBeforeIncrement = GotoTrue(syntax.ToKeyword, forStatement.BreakLabel,
+                                           LessOrEqual(syntax.ToKeyword,
+                                                       Variable(syntax.UpperBound, upperVariableDeclaration.Variable),
+                                                       Variable(syntax.IdentifierToken, forStatement.Variable)));
         var increment = Increment(syntax.ToKeyword, Variable(syntax.IdentifierToken, forStatement.Variable));
 
         var builder = ImmutableArray.CreateBuilder<BoundStatement>();
@@ -107,6 +112,7 @@ sealed class Lowerer : BoundTreeRewriter
         builder.Add(SequencePoint(upperVariableDeclaration, syntax.ToKeyword.Location + syntax.UpperBound.Location));
         builder.Add(Goto(syntax.ToKeyword, startLabel));
         builder.Add(Label(syntax.ToKeyword, forStatement.ContinueLabel));
+        builder.Add(exitBeforeIncrement);
         builder.Add(SequencePoint(increment, syntax.ToKeyword.Location));
         builder.Add(Label(syntax.ToKeyword, startLabel));
         builder.Add(SequencePoint(checkStatement, syntax.UpperBound.Location));

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<BaluVersion Condition="'$(BaluVersion)' == ''">0.5.0</BaluVersion>
+		<BaluVersion Condition="'$(BaluVersion)' == ''">0.5.1</BaluVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(MSBuildProjectName)' == 'Balu' Or

--- a/src/HelloWorld/hello.b
+++ b/src/HelloWorld/hello.b
@@ -1,11 +1,15 @@
 function main()
 {
-	var a = bool(test()) && false
-	println(a)
-}
+	var count = 0
+	for i = 2147483647 to 2147483647
+	{
+		count++
+		if (count > 1)
+		{
+			println("Count greater 1!")
+			break
+		}
+	}
 
-function test() : any
-{
-	println("test called.")
-	return true
+	println("Final count: " + string(count))
 }

--- a/src/HelloWorld/helloworld.csproj
+++ b/src/HelloWorld/helloworld.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.5.0">
+﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.5.1">
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
 		<OutputType>Exe</OutputType>


### PR DESCRIPTION
## Summary
- stop inclusive `for` loops before incrementing once the upper bound has been reached
- keep `continue` on the shared loop epilogue so the final iteration terminates without overflow
- add a non-hanging regression test for `int.MaxValue` and update affected IL/debug-symbol expectations

## Tests
- `dotnet test src/Balu.Tests/Balu.Tests.csproj --no-restore`
- 21,748 passed

Closes #135