### PR TITLE
Reserve built-in names for functions

### DIFF
--- a/src/Balu.Tests/BinderTests/ShadowedSymbolDiagnosticTests.cs
+++ b/src/Balu.Tests/BinderTests/ShadowedSymbolDiagnosticTests.cs
@@ -37,11 +37,6 @@ public sealed partial class BinderTests
         };
         yield return new object[]
         {
-            @"function [println](a:int){}",
-            "BL1009: Function 'println' hides existing function 'println'."
-        };
-        yield return new object[]
-        {
             @"function test(a:int){ var [println] = 12}",
             "BL1009: Local variable 'println' hides existing function 'println'."
         };

--- a/src/Balu.Tests/ExecutionTests/FunctionDeclarationTests.cs
+++ b/src/Balu.Tests/ExecutionTests/FunctionDeclarationTests.cs
@@ -1,4 +1,5 @@
-﻿using TestHelpers;
+﻿using System.Collections.Generic;
+using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.CompilationTests.ExecutionTests;
@@ -11,4 +12,65 @@ public partial class ExecutionTests
         "function [(]) : int { var i = 0 return i }".AssertScriptEvaluation(" BL0001: Unexpected OpenParenthesisToken ('('), expected IdentifierToken.");
     }
 
+    [Theory]
+    [MemberData(nameof(ProvideBuiltInTypeFunctionDeclarations))]
+    public void Script_FunctionDeclaration_ReportsBuiltInTypeName(string name, string code)
+    {
+        code.AssertScriptEvaluation($"BL1020: Function '{name}' is already declared.");
+    }
+
+    [Theory]
+    [InlineData("int")]
+    [InlineData("bool")]
+    [InlineData("string")]
+    [InlineData("any")]
+    public void Program_FunctionDeclaration_ReportsBuiltInTypeName(string name)
+    {
+        new[] { ("test", $"function [{name}]() {{}} function main() {{}}") }
+            .AssertProgramDiagnostics($"BL1020: Function '{name}' is already declared.");
+    }
+
+    public static IEnumerable<object[]> ProvideBuiltInTypeFunctionDeclarations()
+    {
+        foreach (var (name, argument) in new[]
+                 {
+                     ("int", "1"),
+                     ("bool", "true"),
+                     ("string", "\"value\""),
+                     ("any", "1")
+                 })
+        {
+            yield return new object[] { name, $"function [{name}]() {{}} {name}()" };
+            yield return new object[] { name, $"function [{name}](value:any) {{}} {name}({argument})" };
+            yield return new object[] { name, $"function [{name}](first:any, second:any) {{}} {name}(1, 2)" };
+        }
+    }
+
+    [Theory]
+    [InlineData("print")]
+    [InlineData("println")]
+    [InlineData("input")]
+    [InlineData("random")]
+    public void Script_FunctionDeclaration_ReportsBuiltInFunctionName(string name)
+    {
+        $"function [{name}]() {{}}".AssertScriptEvaluation($"BL1020: Function '{name}' is already declared.");
+    }
+
+    [Theory]
+    [InlineData("print")]
+    [InlineData("println")]
+    [InlineData("input")]
+    [InlineData("random")]
+    public void Program_FunctionDeclaration_ReportsBuiltInFunctionName(string name)
+    {
+        new[] { ("test", $"function [{name}]() {{}} function main() {{}}") }
+            .AssertProgramDiagnostics($"BL1020: Function '{name}' is already declared.");
+    }
+
+    [Fact]
+    public void Script_VariablesAndParametersMayUseBuiltInTypeNames()
+    {
+        "function test(int:int):int { var bool = true var string = \"\" var any = 1 return int } test(42)"
+            .AssertScriptEvaluation(value: 42);
+    }
 }

--- a/src/Balu.Tests/ExecutionTests/RedeclaringSymbolsTests.cs
+++ b/src/Balu.Tests/ExecutionTests/RedeclaringSymbolsTests.cs
@@ -14,4 +14,27 @@ public partial class ExecutionTests
         asserter.AssertScriptEvaluation("var a = 23");
         asserter.AssertScriptEvaluation("b()", value: 42);
     }
+
+    [Fact]
+    public void Script_RedeclaringFunctionFromPreviousSubmission_ReportsWarningAndUsesNewFunction()
+    {
+        using var asserter = new CompilationAsserter();
+        asserter.AssertScriptEvaluation("function value():int { return 1 }");
+        asserter.AssertScriptEvaluation(
+            "function [value]():int { return 2 }",
+            "BL1009: Function 'value' hides existing function 'value'.",
+            ignoreWarnings: false);
+        asserter.AssertScriptEvaluation("function value():int { return 2 }");
+        asserter.AssertScriptEvaluation("value()", value: 2);
+    }
+
+    [Fact]
+    public void Script_DeclaringBuiltInFunctionAfterHidingItWithVariable_ReportsError()
+    {
+        using var asserter = new CompilationAsserter();
+        asserter.AssertScriptEvaluation("var print = 1");
+        asserter.AssertScriptEvaluation(
+            "function [print]() {}",
+            "BL1020: Function 'print' is already declared.");
+    }
 }

--- a/src/Balu/Binding/Binder.cs
+++ b/src/Balu/Binding/Binder.cs
@@ -423,7 +423,7 @@ sealed class Binder : SyntaxTreeVisitor
 
         var returnType = containingFunction?.ReturnType ?? (isScript ? TypeSymbol.Any : TypeSymbol.Void);
         var functionName = containingFunction?.Name ?? (isScript ? GlobalSymbolNames.Eval : GlobalSymbolNames.Main);
-        
+
         if (expression is null)
         {
             if (returnType != TypeSymbol.Void)
@@ -438,7 +438,7 @@ sealed class Binder : SyntaxTreeVisitor
             if (expression.Type == TypeSymbol.Error)
                 diagnostics.ReportReturnTypeMismatch(node.Expression!.Location, returnType, functionName, ((BoundExpression)boundNode!).Type);
         }
-        
+
         boundNode = Return(node, expression);
     }
 
@@ -556,6 +556,8 @@ sealed class Binder : SyntaxTreeVisitor
         var returnType = declaration.TypeClause is null ? TypeSymbol.Void : BindTypeClause(declaration.TypeClause) ?? TypeSymbol.Error;
         var function = new FunctionSymbol(declaration.Identifier.Text, parameters.ToImmutable(), returnType, declaration);
         if (!scope.TryDeclareSymbol(function))
+            diagnostics.ReportFunctionAlreadyDeclared(declaration.Identifier);
+        else if (LookupType(function.Name) is not null || BuiltInFunctions.IsBuiltInName(function.Name))
             diagnostics.ReportFunctionAlreadyDeclared(declaration.Identifier);
         else if (scope.Parent?.TryLookupSymbol(function.Name, out var hidden) == true)
             diagnostics.ReportSymbolHidesSymbol(function, hidden, declaration.Identifier.Location);
@@ -700,7 +702,7 @@ sealed class Binder : SyntaxTreeVisitor
 
         var functionBodyBuilder = ImmutableDictionary.CreateBuilder<FunctionSymbol, BoundBlockStatement>();
         if (previous is not null) functionBodyBuilder.AddRange(previous.Functions.Where(x => x.Key != previous.EntryPoint));
-        
+
         foreach (var function in globalScope.VisibleSymbols.OfType<FunctionSymbol>().Where(function => function.Declaration is not null && !functionBodyBuilder.ContainsKey(function) && function != previous?.EntryPoint))
         {
             cancellationToken.ThrowIfCancellationRequested();

--- a/src/Balu/Symbols/BuiltInFunctions.cs
+++ b/src/Balu/Symbols/BuiltInFunctions.cs
@@ -29,4 +29,6 @@ static class BuiltInFunctions
         builtInFunctions = builder.ToImmutable();
         return builder;
     }
+
+    public static bool IsBuiltInName(string name) => GetBuiltInFunctions().Any(function => function.Name == name);
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<BaluVersion Condition="'$(BaluVersion)' == ''">0.5.1</BaluVersion>
+		<BaluVersion Condition="'$(BaluVersion)' == ''">0.5.2</BaluVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(MSBuildProjectName)' == 'Balu' Or

--- a/src/HelloWorld/helloworld.csproj
+++ b/src/HelloWorld/helloworld.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.5.1">
+﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.5.2">
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
 		<OutputType>Exe</OutputType>


### PR DESCRIPTION
## Summary
- reject function declarations named after built-in types with BL1020
- reject redeclarations of built-in functions in programs and scripts
- preserve BL1009 and replacement behavior for user-defined functions from earlier script submissions
- keep built-in type names available for variables and parameters

## Tests
- `dotnet test src/Balu.Tests/Balu.Tests.csproj --no-restore`
- 21,774 tests passed

Closes #143