### PR TITLE
Validate initialized global values

### DIFF
--- a/src/Balu.Tests/EmitterTests/InitializedGlobalVariableTests.cs
+++ b/src/Balu.Tests/EmitterTests/InitializedGlobalVariableTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Balu.Diagnostics;
+using Balu.Symbols;
+using Balu.Syntax;
+using TestHelpers;
+using Xunit;
+
+namespace Balu.Tests.EmitterTests;
+
+public partial class EmitterTests
+{
+    [Theory]
+    [InlineData("bool", "true", true)]
+    [InlineData("int", "42", 42)]
+    [InlineData("string", "\"text\"", "text")]
+    [InlineData("any", "true", true)]
+    [InlineData("any", "42", 42)]
+    [InlineData("any", "\"text\"", "text")]
+    public void Emitter_AcceptsValidInitializedGlobalVariable(string type, string literal, object value)
+    {
+        var compilation = CreateScriptWithGlobal(type, literal);
+        var global = GetGlobal(compilation);
+        var initializedGlobals = ImmutableDictionary<GlobalVariableSymbol, object>.Empty.Add(global, value);
+        using var output = new MemoryStream();
+
+        var result = compilation.Emit("ValidGlobals", ReferenceProvider.References, output, null, initializedGlobals);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.NotEqual(0, output.Length);
+    }
+
+    [Theory]
+    [InlineData("bool", "true", 1)]
+    [InlineData("int", "42", false)]
+    [InlineData("string", "\"text\"", 42)]
+    [InlineData("any", "42", 1L)]
+    public void Emitter_RejectsInvalidInitializedGlobalVariableType(string type, string literal, object value)
+    {
+        var compilation = CreateScriptWithGlobal(type, literal);
+        var global = GetGlobal(compilation);
+        var initializedGlobals = ImmutableDictionary<GlobalVariableSymbol, object>.Empty.Add(global, value);
+
+        AssertInvalidInitializedGlobals(compilation, initializedGlobals);
+    }
+
+    [Fact]
+    public void Emitter_RejectsNullInitializedGlobalVariable()
+    {
+        var compilation = CreateScriptWithGlobal("string", "\"text\"");
+        var global = GetGlobal(compilation);
+        var initializedGlobals = ImmutableDictionary<GlobalVariableSymbol, object>.Empty.Add(global, null!);
+
+        AssertInvalidInitializedGlobals(compilation, initializedGlobals);
+    }
+
+    [Fact]
+    public void Emitter_RejectsGlobalVariableFromUnrelatedCompilation()
+    {
+        var compilation = CreateScriptWithGlobal("int", "42");
+        var unrelatedCompilation = CreateScriptWithGlobal("int", "42");
+        var unrelatedGlobal = GetGlobal(unrelatedCompilation);
+        var initializedGlobals = ImmutableDictionary<GlobalVariableSymbol, object>.Empty.Add(unrelatedGlobal, 42);
+
+        AssertInvalidInitializedGlobals(compilation, initializedGlobals);
+    }
+
+    [Fact]
+    public void Emitter_AcceptsShadowedGlobalVariableFromPreviousScriptCompilation()
+    {
+        var previous = CreateScriptWithGlobal("int", "42");
+        var global = GetGlobal(previous);
+        var compilation = Compilation.CreateScript(previous, SyntaxTree.Parse("var value: int = 0"));
+        var initializedGlobals = ImmutableDictionary<GlobalVariableSymbol, object>.Empty.Add(global, 42);
+        using var output = new MemoryStream();
+
+        var result = compilation.Emit("InheritedGlobals", ReferenceProvider.References, output, null, initializedGlobals);
+
+        Assert.False(result.Diagnostics.HasErrors());
+        Assert.NotEqual(0, output.Length);
+    }
+
+    static Compilation CreateScriptWithGlobal(string type, string literal) =>
+        Compilation.CreateScript(null, SyntaxTree.Parse($"var value: {type} = {literal}"));
+
+    static GlobalVariableSymbol GetGlobal(Compilation compilation) =>
+        compilation.VisibleSymbols.OfType<GlobalVariableSymbol>().Single(global => global.Name == "value");
+
+    static void AssertInvalidInitializedGlobals(Compilation compilation, ImmutableDictionary<GlobalVariableSymbol, object> initializedGlobals)
+    {
+        using var output = new MemoryStream();
+        output.WriteByte(42);
+        var originalOutput = output.ToArray();
+
+        var exception = Assert.Throws<ArgumentException>(() =>
+            compilation.Emit("InvalidGlobals", ReferenceProvider.References, output, null, initializedGlobals));
+
+        Assert.Equal("initializedGlobalVariables", exception.ParamName);
+        Assert.Equal(originalOutput, output.ToArray());
+    }
+}

--- a/src/Balu/Emit/Emitter.cs
+++ b/src/Balu/Emit/Emitter.cs
@@ -825,6 +825,7 @@ sealed class Emitter : IDisposable
 
     public static EmitterResult Emit(BoundProgram program, string moduleName, EmitReferenceSet references, Stream outputStream, Stream? symbolStream, bool debug, ImmutableDictionary<GlobalVariableSymbol, object> initializedGlobalVariables, string? pdbPath = null, CancellationToken cancellationToken = default)
     {
+        ValidateInitializedGlobalVariables(program, initializedGlobalVariables, cancellationToken);
         try
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -836,6 +837,34 @@ sealed class Emitter : IDisposable
         catch (MissingReferencesException exception)
         {
             return new (exception.Diagnostics, ImmutableDictionary<Symbol, string>.Empty);
+        }
+    }
+
+    static void ValidateInitializedGlobalVariables(BoundProgram program, ImmutableDictionary<GlobalVariableSymbol, object> initializedGlobalVariables, CancellationToken cancellationToken)
+    {
+        if (initializedGlobalVariables is null) throw new ArgumentNullException(nameof(initializedGlobalVariables));
+        if (initializedGlobalVariables.Count == 0) return;
+        var programGlobals = new HashSet<GlobalVariableSymbol>(program.Symbols.OfType<GlobalVariableSymbol>());
+
+        foreach (var pair in initializedGlobalVariables)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var global = pair.Key;
+            var value = pair.Value;
+            if (!programGlobals.Contains(global))
+                throw new ArgumentException($"Global variable '{global.Name}' does not belong to the emitted program.", nameof(initializedGlobalVariables));
+            if (value is null)
+                throw new ArgumentException($"The value of global variable '{global.Name}' cannot be null.", nameof(initializedGlobalVariables));
+
+            var isValid = value switch
+            {
+                bool => global.Type == TypeSymbol.Boolean || global.Type == TypeSymbol.Any,
+                int => global.Type == TypeSymbol.Integer || global.Type == TypeSymbol.Any,
+                string => global.Type == TypeSymbol.String || global.Type == TypeSymbol.Any,
+                _ => false
+            };
+            if (!isValid)
+                throw new ArgumentException($"Value of type '{value.GetType().Name}' is not valid for global variable '{global.Name}' of type '{global.Type.Name}'.", nameof(initializedGlobalVariables));
         }
     }
 }


### PR DESCRIPTION
## Summary
- validate initialized global symbols before emission and reject symbols from unrelated programs
- reject null, mismatched, and unsupported runtime values while preserving inherited and shadowed script globals
- cover valid primitive and `any` values plus invalid inputs without modifying output streams

## Testing
- `dotnet test src/Balu.Tests/Balu.Tests.csproj` (21,787 passed)

Closes #146