### PR TITLE
Remove REPL submission persistence

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -145,18 +145,16 @@ REPL commands start with `#` and are case-sensitive:
 | `#showSyntax` | Toggle syntax-tree output |
 | `#showProgram` | Toggle bound-program output |
 | `#showVars` | Toggle global-variable output after evaluation |
-| `#reset` | Reset the interpreter and delete persisted submissions |
+| `#load <path>` | Execute a script file in the current session |
+| `#reset` | Reset the current interpreter session |
 | `#exit` | Exit the REPL |
 
-On Windows, successful submissions are stored below
-`%LOCALAPPDATA%\Balu\Submissions`. On other platforms, they are stored below the
-platform's local application-data directory. They are loaded again when the
-REPL starts. Loading means executing the submissions again, so previous console
-output, calls to `input()`, and other side effects can occur again. Use
-`#reset` when you want to discard that state.
+Interpreter state is kept only for the current REPL process. Restarting the REPL
+starts a fresh session. Use `#load <path>` to explicitly execute a script file
+in the current session.
 
-`#clearHistory` only clears the in-memory editor history. It does not reset the
-interpreter and does not delete persisted submissions.
+`#clearHistory` clears the in-memory editor history without resetting the
+interpreter.
 
 ## Next steps
 

--- a/src/bi/BaluRepl.cs
+++ b/src/bi/BaluRepl.cs
@@ -24,19 +24,6 @@ sealed class BaluRepl : Repl, IDisposable
         Path.Combine(AppContext.BaseDirectory, "reference-assemblies", "System.Console.dll")
     ]) {Out = Console.Out, Error = Console.Error};
 
-
-    public BaluRepl()
-    {
-        try
-        {
-            LoadSubmissions();
-        }
-        catch
-        {
-            interpreter.Dispose();
-            throw;
-        }
-    }
     public void Dispose() => interpreter.Dispose();
 
     protected override bool IsCompleteSubmission(string text) => string.IsNullOrWhiteSpace(text) || text.EndsWith(Environment.NewLine+Environment.NewLine, StringComparison.InvariantCultureIgnoreCase) || !SyntaxTree.Parse(text).IsLastTokenMissing;
@@ -58,7 +45,6 @@ sealed class BaluRepl : Repl, IDisposable
             Console.Out.WriteLine();
         }
 
-        SaveSubmission(text);
         if (showVars)
         {
             Console.Out.WriteColoredText("Variables:", ConsoleColor.Yellow);
@@ -78,41 +64,6 @@ sealed class BaluRepl : Repl, IDisposable
         }
 
         Console.ResetColor();
-    }
-
-    bool loadingSubmission;
-    void LoadSubmissions()
-    {
-        var submissionsPath = GetSubmissionsPath();
-        if (!Directory.Exists(submissionsPath)) return;
-        var files = Directory.GetFiles(submissionsPath).OrderBy(f => f).ToArray();
-        if (files.Length == 0) return;
-        loadingSubmission = true;
-        Console.Out.WritePunctuation($"Loading {files.Length} submissions...{Environment.NewLine}");
-        foreach (var text in files.Select(File.ReadAllText)) { AddToHistory(text); EvaluateSubmission(text);}
-        loadingSubmission = false;
-    }
-    void SaveSubmission(string text)
-    {
-        if (loadingSubmission) return;
-        var submissionFolder = GetSubmissionsPath();
-        Directory.CreateDirectory(submissionFolder);
-        var existingCount = Directory.GetFiles(submissionFolder).Length;
-        var name = $"submission{existingCount:0000}";
-        var fileName = Path.Combine(submissionFolder, name);
-        File.WriteAllText(fileName, text);
-    }
-    static void ClearSubmissions()
-    {
-        var path = GetSubmissionsPath();
-        if (Directory.Exists(path))
-            Directory.Delete(path, true);
-    }
-    static string GetSubmissionsPath()
-    {
-        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        var submissionFolder = Path.Combine(localAppData, "Balu", "Submissions");
-        return submissionFolder;
     }
 
     protected override object? RenderLine(IReadOnlyList<string> lines, int lineIndex, object? state)
@@ -159,12 +110,8 @@ sealed class BaluRepl : Repl, IDisposable
     }
     [MetaCommand("cls", "Clears the screen.")]
     static void ClearScreen() => Console.Clear();
-    [MetaCommand("reset", "Resets the submission cache.")]
-    void Reset()
-    {
-        interpreter.Reset();
-        ClearSubmissions();
-    }
+    [MetaCommand("reset", "Resets the current interpreter session.")]
+    void Reset() => interpreter.Reset();
     [MetaCommand("load", "Loads a script file.")]
     void Load(string path)
     {


### PR DESCRIPTION
## Summary
- stop saving successful REPL submissions to local application data
- start every `bi` process with a fresh interpreter session instead of replaying prior code and its side effects
- keep `#load` as the explicit way to execute a script in the current session
- make `#reset` reset only the current session and update the REPL documentation

Existing files under the former submissions directory are intentionally left untouched, but are no longer read or modified by `bi`.

## Testing
- `dotnet build src/bi/bi.csproj --no-restore`
- `dotnet test src/Balu.Interpretation.Tests/Balu.Interpretation.Tests.csproj --no-restore` (14 passed)
- `dotnet test src/Balu.Tests/Balu.Tests.csproj --no-restore` (21,787 passed)

Closes #137