### PR TITLE
Fix REPL editor viewport rendering

### DIFF
--- a/src/Balu.sln
+++ b/src/Balu.sln
@@ -46,6 +46,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Balu.Sdk.Tests", "Balu.Sdk.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Balu.SourceGenerator.Tests", "Balu.SourceGenerator.Tests\Balu.SourceGenerator.Tests.csproj", "{BFD94C17-20E7-462E-95A1-C5F4D36E7CA4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "bi.Tests", "bi.Tests\bi.Tests.csproj", "{402B1D2E-7A92-4F8D-BE4F-A811A0642151}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -224,6 +226,18 @@ Global
 		{BFD94C17-20E7-462E-95A1-C5F4D36E7CA4}.Release|arm64.Build.0 = Release|Any CPU
 		{BFD94C17-20E7-462E-95A1-C5F4D36E7CA4}.Release|x86.ActiveCfg = Release|Any CPU
 		{BFD94C17-20E7-462E-95A1-C5F4D36E7CA4}.Release|x86.Build.0 = Release|Any CPU
+		{402B1D2E-7A92-4F8D-BE4F-A811A0642151}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{402B1D2E-7A92-4F8D-BE4F-A811A0642151}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{402B1D2E-7A92-4F8D-BE4F-A811A0642151}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{402B1D2E-7A92-4F8D-BE4F-A811A0642151}.Debug|arm64.Build.0 = Debug|Any CPU
+		{402B1D2E-7A92-4F8D-BE4F-A811A0642151}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{402B1D2E-7A92-4F8D-BE4F-A811A0642151}.Debug|x86.Build.0 = Debug|Any CPU
+		{402B1D2E-7A92-4F8D-BE4F-A811A0642151}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{402B1D2E-7A92-4F8D-BE4F-A811A0642151}.Release|Any CPU.Build.0 = Release|Any CPU
+		{402B1D2E-7A92-4F8D-BE4F-A811A0642151}.Release|arm64.ActiveCfg = Release|Any CPU
+		{402B1D2E-7A92-4F8D-BE4F-A811A0642151}.Release|arm64.Build.0 = Release|Any CPU
+		{402B1D2E-7A92-4F8D-BE4F-A811A0642151}.Release|x86.ActiveCfg = Release|Any CPU
+		{402B1D2E-7A92-4F8D-BE4F-A811A0642151}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/bi.Tests/SubmissionViewTests.cs
+++ b/src/bi.Tests/SubmissionViewTests.cs
@@ -1,0 +1,265 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Text;
+using Balu.Interactive;
+using Xunit;
+
+namespace bi.Tests;
+
+public sealed class SubmissionViewTests
+{
+    [Fact]
+    public void LongLineIsClippedAndCursorRemainsVisible()
+    {
+        var console = new TestConsole(width: 8, height: 4);
+        var view = CreateView(console, "0123456789");
+
+        view.CursorX = view.SubmissionDocument[0].Length;
+
+        Assert.Equal(0, console.InvalidPositionAttempts);
+        Assert.Equal(0, console.WrapCount);
+        Assert.InRange(console.CursorLeft, 0, console.BufferWidth - 1);
+        Assert.Equal("» 6789 ", console.GetRow(0)[..7]);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    public void NarrowWindowDoesNotProduceInvalidCoordinates(int width)
+    {
+        var console = new TestConsole(width, height: 2);
+        var view = CreateView(console, "a long line");
+
+        view.CursorX = view.SubmissionDocument[0].Length;
+
+        Assert.Equal(0, console.InvalidPositionAttempts);
+        Assert.Equal(0, console.WrapCount);
+        Assert.InRange(console.CursorLeft, 0, width - 1);
+    }
+
+    [Fact]
+    public void TallDocumentUsesVerticalViewport()
+    {
+        var console = new TestConsole(width: 12, height: 3, cursorTop: 2);
+        var view = CreateView(console, "line0", "line1", "line2", "line3", "line4", "line5");
+
+        view.CursorY = 5;
+
+        Assert.Equal(0, console.InvalidPositionAttempts);
+        Assert.Equal(0, console.WrapCount);
+        Assert.Equal(2, console.CursorTop);
+        Assert.StartsWith("· line3", console.GetRow(0), StringComparison.Ordinal);
+
+        view.CursorY = 1;
+
+        Assert.Equal(0, console.CursorTop);
+        Assert.StartsWith("· line1", console.GetRow(0), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RemovingLinesClearsPreviouslyRenderedRows()
+    {
+        var console = new TestConsole(width: 12, height: 3);
+        var view = CreateView(console, "line0", "line1", "line2");
+
+        using (view.CreateUpdateContext())
+        {
+            view.CursorY = 0;
+            view.SubmissionDocument.RemoveAt(2);
+            view.SubmissionDocument.RemoveAt(1);
+        }
+
+        Assert.Equal(new string(' ', 11), console.GetRow(1)[..11]);
+        Assert.Equal(new string(' ', 11), console.GetRow(2)[..11]);
+    }
+
+    [Fact]
+    public void ResizeKeepsLongLineInsideNewWindowBounds()
+    {
+        var console = new TestConsole(width: 12, height: 3);
+        var view = CreateView(console, "01234567890123456789");
+        view.CursorX = view.SubmissionDocument[0].Length;
+
+        console.WindowWidth = 3;
+        view.SubmissionDocument[0] += "x";
+
+        Assert.Equal(0, console.InvalidPositionAttempts);
+        Assert.Equal(0, console.WrapCount);
+        Assert.InRange(console.CursorLeft, 0, console.WindowWidth - 1);
+    }
+
+    [Fact]
+    public void HeightResizeDoesNotForgetRowsThatStillNeedClearing()
+    {
+        var console = new TestConsole(width: 12, height: 3);
+        var view = CreateView(console, "line0", "line1", "line2");
+
+        console.WindowHeight = 1;
+        using (view.CreateUpdateContext())
+        {
+            view.CursorY = 0;
+            view.SubmissionDocument.RemoveAt(2);
+            view.SubmissionDocument.RemoveAt(1);
+        }
+        console.WindowHeight = 3;
+        view.SubmissionDocument[0] = "updated";
+
+        Assert.Equal(new string(' ', 11), console.GetRow(1)[..11]);
+        Assert.Equal(new string(' ', 11), console.GetRow(2)[..11]);
+    }
+
+    [Fact]
+    public void CursorFailureDuringResizeDoesNotLoseSubmission()
+    {
+        var console = new TestConsole(width: 12, height: 3);
+        var view = CreateView(console, "text");
+        console.CursorMoveFailuresRemaining = 2;
+
+        view.SubmissionDocument[0] = "edited";
+
+        Assert.Equal("edited", view.SubmissionDocument[0]);
+        Assert.True(console.CursorVisible);
+    }
+
+    [Fact]
+    public void RenderingFailureRestoresConsoleState()
+    {
+        var console = new TestConsole(width: 10, height: 3)
+        {
+            CursorVisible = true,
+            ForegroundColor = ConsoleColor.Yellow,
+            BackgroundColor = ConsoleColor.DarkBlue
+        };
+        var document = new ObservableCollection<string>(["text"]);
+
+        _ = Assert.Throws<InvalidOperationException>(() => new SubmissionView(document, ThrowingRenderer, console));
+
+        Assert.True(console.CursorVisible);
+        Assert.Equal(ConsoleColor.Yellow, console.ForegroundColor);
+        Assert.Equal(ConsoleColor.DarkBlue, console.BackgroundColor);
+    }
+
+    static SubmissionView CreateView(TestConsole console, params string[] lines) =>
+        new(new ObservableCollection<string>(lines), RenderLine, console);
+
+    static object? RenderLine(IReadOnlyList<string> lines, int lineIndex, int start, int length, TextWriter writer, object? state)
+    {
+        writer.Write(lines[lineIndex].AsSpan(start, length));
+        return state;
+    }
+
+    static object? ThrowingRenderer(IReadOnlyList<string> lines, int lineIndex, int start, int length, TextWriter writer, object? state) =>
+        throw new InvalidOperationException("Rendering failed.");
+
+    sealed class TestConsole : IConsole
+    {
+        sealed class ConsoleWriter(TestConsole console) : TextWriter
+        {
+            public override Encoding Encoding => Encoding.UTF8;
+            public override void Write(char value) => console.Write(value);
+            public override void Write(string? value)
+            {
+                if (value is null) return;
+                foreach (var character in value) console.Write(character);
+            }
+            public override void Write(ReadOnlySpan<char> buffer)
+            {
+                foreach (var character in buffer) console.Write(character);
+            }
+        }
+
+        readonly char[,] buffer;
+        int cursorLeft;
+        int cursorTop;
+
+        public TestConsole(int width, int height, int cursorTop = 0)
+        {
+            BufferWidth = width;
+            BufferHeight = height;
+            WindowWidth = width;
+            WindowHeight = height;
+            buffer = new char[height, width];
+            for (int row = 0; row < height; row++) ClearRow(row);
+            this.cursorTop = cursorTop;
+            Out = new ConsoleWriter(this);
+        }
+
+        public int BufferWidth { get; }
+        public int BufferHeight { get; }
+        public int WindowWidth { get; set; }
+        public int WindowHeight { get; set; }
+        public int CursorLeft => cursorLeft;
+        public int CursorTop => cursorTop;
+        public bool CursorVisible { get; set; } = true;
+        public ConsoleColor ForegroundColor { get; set; } = ConsoleColor.Gray;
+        public ConsoleColor BackgroundColor { get; set; } = ConsoleColor.Black;
+        public TextWriter Out { get; }
+        public int InvalidPositionAttempts { get; private set; }
+        public int WrapCount { get; private set; }
+        public int CursorMoveFailuresRemaining { get; set; }
+
+        public bool TrySetCursorPosition(int left, int top)
+        {
+            if (CursorMoveFailuresRemaining > 0)
+            {
+                CursorMoveFailuresRemaining--;
+                return false;
+            }
+            if (!ValidatePosition(left, top)) return false;
+            cursorLeft = left;
+            cursorTop = top;
+            return true;
+        }
+
+        public void WriteLine()
+        {
+            cursorLeft = 0;
+            if (cursorTop < BufferHeight - 1)
+            {
+                cursorTop++;
+                return;
+            }
+
+            for (int row = 1; row < BufferHeight; row++)
+                for (int column = 0; column < BufferWidth; column++)
+                    buffer[row - 1, column] = buffer[row, column];
+            ClearRow(BufferHeight - 1);
+        }
+
+        public string GetRow(int row)
+        {
+            var result = new char[BufferWidth];
+            for (int column = 0; column < BufferWidth; column++) result[column] = buffer[row, column];
+            return new(result);
+        }
+
+        void Write(char value)
+        {
+            buffer[cursorTop, cursorLeft] = value;
+            if (cursorLeft < BufferWidth - 1)
+            {
+                cursorLeft++;
+                return;
+            }
+
+            WrapCount++;
+            cursorLeft = 0;
+            if (cursorTop < BufferHeight - 1) cursorTop++;
+        }
+
+        bool ValidatePosition(int left, int top)
+        {
+            if (left >= 0 && left < BufferWidth && top >= 0 && top < BufferHeight) return true;
+            InvalidPositionAttempts++;
+            return false;
+        }
+
+        void ClearRow(int row)
+        {
+            for (int column = 0; column < BufferWidth; column++) buffer[row, column] = ' ';
+        }
+    }
+}

--- a/src/bi.Tests/bi.Tests.csproj
+++ b/src/bi.Tests/bi.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+		<PackageReference Include="xunit" Version="2.4.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.2.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\bi\bi.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/bi/BaluRepl.cs
+++ b/src/bi/BaluRepl.cs
@@ -8,6 +8,7 @@ using Balu.Diagnostics;
 using Balu.Interpretation;
 using Balu.Symbols;
 using Balu.Syntax;
+using Balu.Text;
 using Balu.Visualization;
 
 #pragma warning disable CA1303
@@ -66,12 +67,12 @@ sealed class BaluRepl : Repl, IDisposable
         Console.ResetColor();
     }
 
-    protected override object? RenderLine(IReadOnlyList<string> lines, int lineIndex, object? state)
+    protected override object? RenderLine(IReadOnlyList<string> lines, int lineIndex, int start, int length, TextWriter writer, object? state)
     {
         var syntaxTree = state as SyntaxTree ?? SyntaxTree.Parse(string.Join(Environment.NewLine, lines));
 
         var line = syntaxTree.Text.Lines[lineIndex];
-        var classifiedSpans = Classifier.Classify(syntaxTree, line.Span);
+        var classifiedSpans = Classifier.Classify(syntaxTree, new TextSpan(line.Start + start, length));
         foreach (var classifiedSpan in classifiedSpans)
         {
             var color = classifiedSpan.Classification switch
@@ -85,7 +86,7 @@ sealed class BaluRepl : Repl, IDisposable
                 _ => ConsoleColor.DarkGray
             };
 
-            Console.Out.WriteColoredText(syntaxTree.Text.ToString(classifiedSpan.Span), color);
+            writer.WriteColoredText(syntaxTree.Text.ToString(classifiedSpan.Span), color);
         }
         return syntaxTree;
     }

--- a/src/bi/IConsole.cs
+++ b/src/bi/IConsole.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+
+namespace Balu.Interactive;
+
+interface IConsole
+{
+    int BufferWidth { get; }
+    int BufferHeight { get; }
+    int WindowWidth { get; }
+    int WindowHeight { get; }
+    int CursorLeft { get; }
+    int CursorTop { get; }
+    bool CursorVisible { get; set; }
+    ConsoleColor ForegroundColor { get; set; }
+    ConsoleColor BackgroundColor { get; set; }
+    TextWriter Out { get; }
+
+    bool TrySetCursorPosition(int left, int top);
+    void WriteLine();
+}
+
+sealed class SystemConsole : IConsole
+{
+    public static SystemConsole Instance { get; } = new();
+
+    SystemConsole() { }
+
+    public int BufferWidth => Console.BufferWidth;
+    public int BufferHeight => Console.BufferHeight;
+    public int WindowWidth => Console.WindowWidth;
+    public int WindowHeight => Console.WindowHeight;
+    public int CursorLeft => Console.CursorLeft;
+    public int CursorTop => Console.CursorTop;
+    [SuppressMessage("Interoperability", "CA1416", Justification = "The REPL requires an interactive console that supports cursor positioning.")]
+    public bool CursorVisible { get => Console.CursorVisible; set => Console.CursorVisible = value; }
+    public ConsoleColor ForegroundColor { get => Console.ForegroundColor; set => Console.ForegroundColor = value; }
+    public ConsoleColor BackgroundColor { get => Console.BackgroundColor; set => Console.BackgroundColor = value; }
+    public TextWriter Out => Console.Out;
+
+    public bool TrySetCursorPosition(int left, int top)
+    {
+        try
+        {
+            Console.SetCursorPosition(left, top);
+            return true;
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return false;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+    }
+    public void WriteLine() => Console.WriteLine();
+}

--- a/src/bi/Repl.cs
+++ b/src/bi/Repl.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
-using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -27,118 +27,6 @@ abstract class Repl
         public string Description { get; } = description;
         public MethodInfo Method { get; } = method;
     }
-    sealed class Document : ObservableCollection<string>
-    {
-        public Document()
-            : base(new[] { string.Empty }) { }
-    }
-
-    delegate object? LineRenderHandler(IReadOnlyList<string> lines, int lineIndex, object? state);
-
-    sealed class SubmissionView
-    {
-        sealed class UpdateDisposable : IDisposable
-        {
-            readonly SubmissionView parent;
-            public UpdateDisposable(SubmissionView parent)
-            {
-                this.parent = parent;
-                Console.CursorVisible = false;
-                parent.updatesInProgress++;
-            }
-            public void Dispose()
-            {
-                parent.updatesInProgress--;
-                if (parent.updatesInProgress != 0) return;
-                parent.Render();
-            }
-        }
-
-        readonly LineRenderHandler lineRenderer;
-        int cursorTop, renderedLinesCount, cursorX, cursorY, updatesInProgress;
-
-        public Document SubmissionDocument { get; }
-        public int CursorX
-        {
-            get => cursorX;
-            set
-            {
-                if (value == cursorX) return;
-                cursorX = value;
-                UpdateCursorPosition();
-            }
-        }
-        public int CursorY
-        {
-            get => cursorY;
-            set
-            {
-                if (value == cursorY) return;
-                cursorY = value;
-                if (cursorX > SubmissionDocument[cursorY].Length) cursorX = SubmissionDocument[cursorY].Length;
-                UpdateCursorPosition();
-            }
-        }
-
-        public SubmissionView(Document submissionDocument, LineRenderHandler lineRenderer)
-        {
-            SubmissionDocument = submissionDocument;
-            this.lineRenderer = lineRenderer;
-            SubmissionDocument.CollectionChanged += OnSubmissionDocumentChanged;
-            cursorTop = Console.CursorTop;
-            Render();
-        }
-        void OnSubmissionDocumentChanged(object? sender, NotifyCollectionChangedEventArgs e)
-        {
-            Render();
-        }
-
-        void Render()
-        {
-            if (updatesInProgress > 0) return;
-            Console.CursorVisible = false;
-            object? state = null;
-            for (int i = 0; i < SubmissionDocument.Count; i++)
-            {
-                EnsureLineFitsInConsoleBuffer(i);
-                Console.SetCursorPosition(0, cursorTop + i);
-                Console.ForegroundColor = ConsoleColor.Green;
-                Console.Write(i == 0 ? "» " : "· ");
-                Console.ResetColor();
-                state = lineRenderer(SubmissionDocument, i, state);
-                Console.Write(new string(' ', Console.WindowWidth - SubmissionDocument[i].Length - 2));
-            }
-
-            int blankLines = renderedLinesCount - SubmissionDocument.Count;
-            for (int i = 0; i < blankLines; i++)
-            {
-                int lineIndex = SubmissionDocument.Count + i;
-                EnsureLineFitsInConsoleBuffer(lineIndex);
-                Console.SetCursorPosition(0, cursorTop + lineIndex);
-                Console.Write(new string(' ', Console.WindowWidth));
-            }
-            renderedLinesCount = SubmissionDocument.Count;
-            Console.CursorVisible = true;
-            UpdateCursorPosition();
-        }
-        void EnsureLineFitsInConsoleBuffer(int lineIndex)
-        {
-            if (cursorTop + lineIndex < Console.BufferHeight) return;
-
-            Console.SetCursorPosition(0, Console.BufferHeight - 1);
-            Console.WriteLine();
-            if (cursorTop > 0) cursorTop--;
-        }
-
-        void UpdateCursorPosition()
-        {
-            if (updatesInProgress > 0) return;
-            Console.CursorTop = cursorTop + CursorY;
-            Console.CursorLeft = 2 + CursorX;
-        }
-        public IDisposable CreateUpdateContext() => new UpdateDisposable(this);
-    }
-
     readonly ImmutableDictionary<string, MetaCommand> metaCommands;
     readonly List<string> history = [];
 
@@ -269,9 +157,9 @@ abstract class Repl
         }
     }
 
-    protected virtual object? RenderLine(IReadOnlyList<string> lines, int lineIndex, object? state)
+    protected virtual object? RenderLine(IReadOnlyList<string> lines, int lineIndex, int start, int length, TextWriter writer, object? state)
     {
-        Console.Write(lines[lineIndex]);
+        writer.Write(lines[lineIndex].AsSpan(start, length));
         return state;
     }
 
@@ -287,7 +175,7 @@ abstract class Repl
     string EditSubmission()
     {
         editDone = false;
-        var view = new SubmissionView(new (), RenderLine);
+        var view = new SubmissionView(new ObservableCollection<string>([string.Empty]), RenderLine);
 
         while (!editDone)
             HandleKey(Console.ReadKey(true), view);

--- a/src/bi/SubmissionView.cs
+++ b/src/bi/SubmissionView.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.IO;
+
+namespace Balu.Interactive;
+
+delegate object? LineRenderHandler(IReadOnlyList<string> lines, int lineIndex, int start, int length, TextWriter writer, object? state);
+
+sealed class SubmissionView
+{
+    sealed class UpdateDisposable : IDisposable
+    {
+        readonly SubmissionView parent;
+
+        public UpdateDisposable(SubmissionView parent)
+        {
+            this.parent = parent;
+            parent.updatesInProgress++;
+        }
+
+        public void Dispose()
+        {
+            parent.updatesInProgress--;
+            if (parent.updatesInProgress == 0) parent.Render();
+        }
+    }
+
+    const int PromptWidth = 2;
+
+    readonly LineRenderHandler lineRenderer;
+    readonly IConsole console;
+    int cursorTop;
+    int renderedRowsCount;
+    int firstVisibleLine;
+    int firstVisibleColumn;
+    int cursorX;
+    int cursorY;
+    int updatesInProgress;
+
+    public ObservableCollection<string> SubmissionDocument { get; }
+    public int CursorX
+    {
+        get => cursorX;
+        set
+        {
+            if (value == cursorX) return;
+            cursorX = value;
+            Render();
+        }
+    }
+    public int CursorY
+    {
+        get => cursorY;
+        set
+        {
+            if (value == cursorY) return;
+            cursorY = value;
+            if (cursorX > SubmissionDocument[cursorY].Length) cursorX = SubmissionDocument[cursorY].Length;
+            Render();
+        }
+    }
+
+    public SubmissionView(ObservableCollection<string> submissionDocument, LineRenderHandler lineRenderer, IConsole? console = null)
+    {
+        SubmissionDocument = submissionDocument;
+        this.lineRenderer = lineRenderer;
+        this.console = console ?? SystemConsole.Instance;
+        SubmissionDocument.CollectionChanged += OnSubmissionDocumentChanged;
+        cursorTop = this.console.CursorTop;
+        Render();
+    }
+
+    void OnSubmissionDocumentChanged(object? sender, NotifyCollectionChangedEventArgs e) => Render();
+
+    void Render()
+    {
+        if (updatesInProgress > 0) return;
+
+        var cursorVisible = console.CursorVisible;
+        var foregroundColor = console.ForegroundColor;
+        var backgroundColor = console.BackgroundColor;
+        try
+        {
+            console.CursorVisible = false;
+            for (int attempt = 0; attempt < 2; attempt++)
+                if (RenderCore(foregroundColor)) break;
+        }
+        finally
+        {
+            console.ForegroundColor = foregroundColor;
+            console.BackgroundColor = backgroundColor;
+            console.CursorVisible = cursorVisible;
+        }
+    }
+
+    bool RenderCore(ConsoleColor foregroundColor)
+    {
+        int bufferWidth = Math.Max(1, console.BufferWidth);
+        int bufferHeight = Math.Max(1, console.BufferHeight);
+        int windowWidth = Math.Max(1, Math.Min(console.WindowWidth, bufferWidth));
+        int windowHeight = Math.Max(1, Math.Min(console.WindowHeight, bufferHeight));
+        int renderWidth = Math.Max(0, windowWidth - 1);
+        int promptWidth = Math.Min(PromptWidth, renderWidth);
+        int contentWidth = Math.Max(0, renderWidth - promptWidth);
+
+        cursorTop = Math.Clamp(cursorTop, 0, bufferHeight - 1);
+        int desiredRows = Math.Min(Math.Max(Math.Min(SubmissionDocument.Count, windowHeight), renderedRowsCount), windowHeight);
+        if (!EnsureRowsFitInConsoleBuffer(desiredRows, bufferHeight)) return false;
+        int viewportHeight = Math.Max(1, Math.Min(windowHeight, bufferHeight - cursorTop));
+
+        UpdateViewport(viewportHeight, contentWidth);
+
+        int visibleRowsCount = Math.Min(SubmissionDocument.Count - firstVisibleLine, viewportHeight);
+        int rowsToRender = Math.Min(Math.Max(visibleRowsCount, renderedRowsCount), viewportHeight);
+        object? state = null;
+        for (int row = 0; row < rowsToRender; row++)
+        {
+            if (!console.TrySetCursorPosition(0, cursorTop + row)) return false;
+            if (row >= visibleRowsCount)
+            {
+                console.Out.Write(new string(' ', renderWidth));
+                continue;
+            }
+
+            int lineIndex = firstVisibleLine + row;
+            var prompt = lineIndex == 0 ? "» " : "· ";
+            console.ForegroundColor = ConsoleColor.Green;
+            console.Out.Write(prompt[..promptWidth]);
+            console.ForegroundColor = foregroundColor;
+
+            var line = SubmissionDocument[lineIndex];
+            int start = Math.Min(firstVisibleColumn, line.Length);
+            int length = Math.Min(contentWidth, line.Length - start);
+            state = lineRenderer(SubmissionDocument, lineIndex, start, length, console.Out, state);
+            console.Out.Write(new string(' ', renderWidth - promptWidth - length));
+        }
+
+        if (rowsToRender >= renderedRowsCount) renderedRowsCount = visibleRowsCount;
+        return UpdateCursorPosition(promptWidth);
+    }
+
+    bool EnsureRowsFitInConsoleBuffer(int rowsCount, int bufferHeight)
+    {
+        while (cursorTop + rowsCount > bufferHeight)
+        {
+            if (!console.TrySetCursorPosition(0, bufferHeight - 1)) return false;
+            console.WriteLine();
+            if (cursorTop > 0) cursorTop--;
+        }
+        return true;
+    }
+
+    void UpdateViewport(int viewportHeight, int contentWidth)
+    {
+        if (cursorY < firstVisibleLine)
+            firstVisibleLine = cursorY;
+        else if (cursorY >= firstVisibleLine + viewportHeight)
+            firstVisibleLine = cursorY - viewportHeight + 1;
+
+        int maximumFirstVisibleLine = Math.Max(0, SubmissionDocument.Count - viewportHeight);
+        firstVisibleLine = Math.Clamp(firstVisibleLine, 0, maximumFirstVisibleLine);
+
+        if (contentWidth == 0)
+        {
+            firstVisibleColumn = cursorX;
+            return;
+        }
+
+        if (cursorX < firstVisibleColumn)
+            firstVisibleColumn = cursorX;
+        else if (cursorX >= firstVisibleColumn + contentWidth)
+            firstVisibleColumn = cursorX - contentWidth + 1;
+    }
+
+    bool UpdateCursorPosition(int promptWidth) =>
+        console.TrySetCursorPosition(promptWidth + cursorX - firstVisibleColumn, cursorTop + cursorY - firstVisibleLine);
+
+    public IDisposable CreateUpdateContext() => new UpdateDisposable(this);
+}

--- a/src/bi/bi.csproj
+++ b/src/bi/bi.csproj
@@ -16,6 +16,10 @@
 	  <ProjectReference Include="..\Balu.Interpretation\Balu.Interpretation.csproj" />
   </ItemGroup>
 
+	<ItemGroup>
+		<InternalsVisibleTo Include="bi.Tests" />
+	</ItemGroup>
+
 	<Target Name="CollectInterpreterReferenceAssemblies" DependsOnTargets="ResolveReferences">
 		<ItemGroup>
 			<_InterpreterReferenceAssembly Include="@(ReferencePath)" Condition="'%(Filename)' == 'System.Runtime' OR '%(Filename)' == 'System.Runtime.Extensions' OR '%(Filename)' == 'System.Console'" />


### PR DESCRIPTION
## Summary
- render long submission lines through a cursor-following horizontal viewport
- render tall submissions through a cursor-following vertical viewport without invalid buffer coordinates
- preserve console colors and cursor visibility when rendering fails or the console is resized
- add a testable console abstraction and focused REPL editor tests

## Tests
- `dotnet test src/bi.Tests/bi.Tests.csproj --no-restore`
- `dotnet test src/Balu.Tests/Balu.Tests.csproj --no-restore`
- `dotnet test src/Balu.Interpretation.Tests/Balu.Interpretation.Tests.csproj --no-restore`
- `dotnet test src/bc.Tests/bc.Tests.csproj --no-restore`
- `dotnet test src/Balu.SourceGenerator.Tests/Balu.SourceGenerator.Tests.csproj --no-restore`
- `dotnet test src/Balu.Sdk.Tests/Balu.Sdk.Tests.csproj --no-restore`
- Full Release solution build with Visual Studio MSBuild

Closes #144