### PR TITLE
Harden source generator node handling

### DIFF
--- a/src/Balu.SourceGenerator.Tests/GeneratorOrderingTests.cs
+++ b/src/Balu.SourceGenerator.Tests/GeneratorOrderingTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using Balu.SourceGenerator;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -15,7 +16,7 @@ public sealed class GeneratorOrderingTests
     [Fact]
     public void Generator_UsesConstructorOrderForChildrenAndRewriterArguments()
     {
-        var (result, compilationDiagnostics) = RunGenerator(ValidSource);
+        var (result, compilationDiagnostics, _) = RunGenerator(ValidSource);
 
         Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
         Assert.DoesNotContain(compilationDiagnostics, diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
@@ -34,11 +35,60 @@ public sealed class GeneratorOrderingTests
     [Fact]
     public void Generator_ReportsParameterWithoutMatchingProperty()
     {
-        var (result, _) = RunGenerator(ValidSource.Replace("public SyntaxNode First { get; }", "public SyntaxNode Other { get; }", StringComparison.Ordinal));
+        var (result, _, _) = RunGenerator(ValidSource.Replace("public SyntaxNode First { get; }", "public SyntaxNode Other { get; }", StringComparison.Ordinal));
 
         var diagnostic = Assert.Single(result.Diagnostics.Where(candidate => candidate.Id == "BLS0001"));
         Assert.Contains("parameter 'first' has no property with the same name and type", diagnostic.GetMessage());
         Assert.True(diagnostic.Location.IsInSource);
+    }
+
+    [Fact]
+    public void Generator_TraversesSingleSeparatedListWithSeparators()
+    {
+        const string syntaxNodes = """
+    public sealed partial class SeparatedOnlySyntax : SyntaxNode
+    {
+        public SeparatedSyntaxList<SyntaxToken> Items { get; }
+        public override SyntaxKind Kind => SyntaxKind.Ordered;
+
+        public SeparatedOnlySyntax(SeparatedSyntaxList<SyntaxToken> items)
+        {
+            Items = items;
+        }
+    }
+
+    public static class SeparatedOnlySyntaxProbe
+    {
+        public static int ChildrenCount => CreateNode().ChildrenCount;
+        public static int GetChildId(int index) => ((SyntaxToken)CreateNode().GetChild(index)).Id;
+
+        static SeparatedOnlySyntax CreateNode()
+        {
+            var children = ImmutableArray.Create<SyntaxNode>(new SyntaxToken(1), new SyntaxToken(2), new SyntaxToken(3));
+            return new SeparatedOnlySyntax(new SeparatedSyntaxList<SyntaxToken>(children));
+        }
+    }
+""";
+        var (_, compilationDiagnostics, outputCompilation) = RunGenerator(AddNodes(syntaxNodes, string.Empty));
+
+        Assert.DoesNotContain(compilationDiagnostics, diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        using var stream = new MemoryStream();
+        var emitResult = outputCompilation.Emit(stream);
+        Assert.True(emitResult.Success, string.Join(Environment.NewLine, emitResult.Diagnostics));
+
+        var assembly = Assembly.Load(stream.ToArray());
+        var probe = assembly.GetType("Balu.Syntax.SeparatedOnlySyntaxProbe", throwOnError: true)!;
+        var childrenCount = probe.GetProperty("ChildrenCount")!;
+        var getChildId = probe.GetMethod("GetChildId")!;
+
+        Assert.Equal(3, childrenCount.GetValue(null));
+        Assert.Equal(1, InvokeGetChildId(0));
+        Assert.Equal(2, InvokeGetChildId(1));
+        Assert.Equal(3, InvokeGetChildId(2));
+        Assert.IsType<IndexOutOfRangeException>(Assert.Throws<TargetInvocationException>(() => InvokeGetChildId(-1)).InnerException);
+        Assert.IsType<IndexOutOfRangeException>(Assert.Throws<TargetInvocationException>(() => InvokeGetChildId(3)).InnerException);
+
+        int InvokeGetChildId(int index) => (int)getChildId.Invoke(null, new object[] { index })!;
     }
 
     [Fact]
@@ -189,7 +239,7 @@ public sealed class GeneratorOrderingTests
 
     static void AssertUnsupportedNodeTypes(string source, params string[] typeNames)
     {
-        var (result, compilationDiagnostics) = RunGenerator(source);
+        var (result, compilationDiagnostics, _) = RunGenerator(source);
         var generatorResult = Assert.Single(result.Results);
 
         Assert.Null(generatorResult.Exception);
@@ -208,7 +258,7 @@ public sealed class GeneratorOrderingTests
         ValidSource.Replace("    // Additional syntax nodes", syntaxNodes, StringComparison.Ordinal)
                    .Replace("    // Additional bound nodes", boundNodes, StringComparison.Ordinal);
 
-    static (GeneratorDriverRunResult Result, ImmutableArray<Diagnostic> CompilationDiagnostics) RunGenerator(string source)
+    static (GeneratorDriverRunResult Result, ImmutableArray<Diagnostic> CompilationDiagnostics, CSharpCompilation OutputCompilation) RunGenerator(string source)
     {
         var parseOptions = new CSharpParseOptions(LanguageVersion.CSharp10);
         var syntaxTree = CSharpSyntaxTree.ParseText(source, parseOptions);
@@ -218,7 +268,7 @@ public sealed class GeneratorOrderingTests
                                                    new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
         GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { new BaluSourceGenerator() }, parseOptions: parseOptions);
         driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out _);
-        return (driver.GetRunResult(), outputCompilation.GetDiagnostics());
+        return (driver.GetRunResult(), outputCompilation.GetDiagnostics(), (CSharpCompilation)outputCompilation);
     }
 
     static string GetGeneratedSource(GeneratorDriverRunResult result, string hintName) =>
@@ -249,15 +299,26 @@ namespace Balu.Syntax
 
     public sealed class SyntaxToken : SyntaxNode
     {
+        public int Id { get; }
         public override SyntaxKind Kind => default;
         public override int ChildrenCount => 0;
         public override SyntaxNode GetChild(int index) => throw new ArgumentOutOfRangeException(nameof(index));
+
+        public SyntaxToken(int id = 0)
+        {
+            Id = id;
+        }
     }
 
-    sealed class SeparatedSyntaxList<T> where T : SyntaxNode
+    public sealed class SeparatedSyntaxList<T> where T : SyntaxNode
     {
-        public ImmutableArray<SyntaxNode> ElementsWithSeparators { get; } = ImmutableArray<SyntaxNode>.Empty;
-        public SyntaxNode this[int index] => ElementsWithSeparators[index];
+        public ImmutableArray<SyntaxNode> ElementsWithSeparators { get; }
+        public T this[int index] => (T)ElementsWithSeparators[index * 2];
+
+        public SeparatedSyntaxList(ImmutableArray<SyntaxNode> elementsWithSeparators)
+        {
+            ElementsWithSeparators = elementsWithSeparators;
+        }
     }
 
     public sealed partial class OrderedSyntax : SyntaxNode

--- a/src/Balu.SourceGenerator.Tests/GeneratorOrderingTests.cs
+++ b/src/Balu.SourceGenerator.Tests/GeneratorOrderingTests.cs
@@ -41,6 +41,173 @@ public sealed class GeneratorOrderingTests
         Assert.True(diagnostic.Location.IsInSource);
     }
 
+    [Fact]
+    public void Generator_RejectsNestedSyntaxAndBoundNodes()
+    {
+        const string syntaxNodes = """
+    public partial class SyntaxContainer
+    {
+        public sealed partial class NestedSyntax : SyntaxNode
+        {
+            public override SyntaxKind Kind => SyntaxKind.Ordered;
+            public override int ChildrenCount => 0;
+            public override SyntaxNode GetChild(int index) => throw new ArgumentOutOfRangeException(nameof(index));
+        }
+    }
+""";
+        const string boundNodes = """
+    partial class BoundContainer
+    {
+        sealed partial class NestedBoundNode : BoundNode
+        {
+            public override BoundNodeKind Kind => BoundNodeKind.Pair;
+            public override int ChildrenCount => 0;
+            public override BoundNode GetChild(int index) => throw new ArgumentOutOfRangeException(nameof(index));
+            public NestedBoundNode(SyntaxNode syntax) : base(syntax) { }
+        }
+    }
+""";
+
+        AssertUnsupportedNodeTypes(AddNodes(syntaxNodes, boundNodes),
+                                   "Balu.Syntax.SyntaxContainer.NestedSyntax",
+                                   "Balu.Binding.BoundContainer.NestedBoundNode");
+    }
+
+    [Fact]
+    public void Generator_RejectsGenericSyntaxAndBoundNodes()
+    {
+        const string syntaxNodes = """
+    public sealed partial class GenericSyntax<T> : SyntaxNode
+    {
+        public override SyntaxKind Kind => SyntaxKind.Ordered;
+        public override int ChildrenCount => 0;
+        public override SyntaxNode GetChild(int index) => throw new ArgumentOutOfRangeException(nameof(index));
+    }
+""";
+        const string boundNodes = """
+    sealed partial class GenericBoundNode<T> : BoundNode
+    {
+        public override BoundNodeKind Kind => BoundNodeKind.Pair;
+        public override int ChildrenCount => 0;
+        public override BoundNode GetChild(int index) => throw new ArgumentOutOfRangeException(nameof(index));
+        public GenericBoundNode(SyntaxNode syntax) : base(syntax) { }
+    }
+""";
+
+        AssertUnsupportedNodeTypes(AddNodes(syntaxNodes, boundNodes),
+                                   "Balu.Syntax.GenericSyntax<T>",
+                                   "Balu.Binding.GenericBoundNode<T>");
+    }
+
+    [Fact]
+    public void Generator_RejectsNodesInGenericContainers()
+    {
+        const string syntaxNodes = """
+    public partial class GenericContainer<T>
+    {
+        public sealed partial class NestedSyntax : SyntaxNode
+        {
+            public override SyntaxKind Kind => SyntaxKind.Ordered;
+            public override int ChildrenCount => 0;
+            public override SyntaxNode GetChild(int index) => throw new ArgumentOutOfRangeException(nameof(index));
+        }
+    }
+""";
+        const string boundNodes = """
+    partial class GenericContainer<T>
+    {
+        sealed partial class NestedBoundNode : BoundNode
+        {
+            public override BoundNodeKind Kind => BoundNodeKind.Pair;
+            public override int ChildrenCount => 0;
+            public override BoundNode GetChild(int index) => throw new ArgumentOutOfRangeException(nameof(index));
+            public NestedBoundNode(SyntaxNode syntax) : base(syntax) { }
+        }
+    }
+""";
+
+        AssertUnsupportedNodeTypes(AddNodes(syntaxNodes, boundNodes),
+                                   "Balu.Syntax.GenericContainer<T>.NestedSyntax",
+                                   "Balu.Binding.GenericContainer<T>.NestedBoundNode");
+    }
+
+    [Fact]
+    public void Generator_RejectsDuplicateSimpleNamesWithoutCrashing()
+    {
+        const string syntaxNodes = """
+    public partial class FirstContainer
+    {
+        public sealed partial class OrderedSyntax : SyntaxNode
+        {
+            public override SyntaxKind Kind => SyntaxKind.Ordered;
+            public override int ChildrenCount => 0;
+            public override SyntaxNode GetChild(int index) => throw new ArgumentOutOfRangeException(nameof(index));
+        }
+    }
+
+    public partial class SecondContainer
+    {
+        public sealed partial class OrderedSyntax : SyntaxNode
+        {
+            public override SyntaxKind Kind => SyntaxKind.Ordered;
+            public override int ChildrenCount => 0;
+            public override SyntaxNode GetChild(int index) => throw new ArgumentOutOfRangeException(nameof(index));
+        }
+    }
+""";
+        const string boundNodes = """
+    partial class FirstContainer
+    {
+        sealed partial class BoundPair : BoundNode
+        {
+            public override BoundNodeKind Kind => BoundNodeKind.Pair;
+            public override int ChildrenCount => 0;
+            public override BoundNode GetChild(int index) => throw new ArgumentOutOfRangeException(nameof(index));
+            public BoundPair(SyntaxNode syntax) : base(syntax) { }
+        }
+    }
+
+    partial class SecondContainer
+    {
+        sealed partial class BoundPair : BoundNode
+        {
+            public override BoundNodeKind Kind => BoundNodeKind.Pair;
+            public override int ChildrenCount => 0;
+            public override BoundNode GetChild(int index) => throw new ArgumentOutOfRangeException(nameof(index));
+            public BoundPair(SyntaxNode syntax) : base(syntax) { }
+        }
+    }
+""";
+        var source = AddNodes(syntaxNodes, boundNodes);
+
+        AssertUnsupportedNodeTypes(source,
+                                   "Balu.Syntax.FirstContainer.OrderedSyntax",
+                                   "Balu.Syntax.SecondContainer.OrderedSyntax",
+                                   "Balu.Binding.FirstContainer.BoundPair",
+                                   "Balu.Binding.SecondContainer.BoundPair");
+    }
+
+    static void AssertUnsupportedNodeTypes(string source, params string[] typeNames)
+    {
+        var (result, compilationDiagnostics) = RunGenerator(source);
+        var generatorResult = Assert.Single(result.Results);
+
+        Assert.Null(generatorResult.Exception);
+        var diagnostics = result.Diagnostics.Where(candidate => candidate.Id == "BLS0002").ToImmutableArray();
+        Assert.Equal(typeNames.Length, diagnostics.Length);
+        foreach (var typeName in typeNames)
+        {
+            var diagnostic = Assert.Single(diagnostics.Where(candidate => candidate.GetMessage().Contains($"'{typeName}'", StringComparison.Ordinal)));
+            Assert.True(diagnostic.Location.IsInSource);
+        }
+        Assert.DoesNotContain(compilationDiagnostics,
+                              diagnostic => diagnostic.Severity == DiagnosticSeverity.Error && diagnostic.Id != "BLS0002");
+    }
+
+    static string AddNodes(string syntaxNodes, string boundNodes) =>
+        ValidSource.Replace("    // Additional syntax nodes", syntaxNodes, StringComparison.Ordinal)
+                   .Replace("    // Additional bound nodes", boundNodes, StringComparison.Ordinal);
+
     static (GeneratorDriverRunResult Result, ImmutableArray<Diagnostic> CompilationDiagnostics) RunGenerator(string source)
     {
         var parseOptions = new CSharpParseOptions(LanguageVersion.CSharp10);
@@ -109,6 +276,8 @@ namespace Balu.Syntax
 
         public OrderedSyntax(string value, int count) : this(new SyntaxToken(), new SyntaxToken()) { }
     }
+
+    // Additional syntax nodes
 }
 
 namespace Balu.Binding
@@ -143,6 +312,8 @@ namespace Balu.Binding
             Right = right;
         }
     }
+
+    // Additional bound nodes
 }
 """;
 }

--- a/src/Balu.SourceGenerator/BaluSourceGenerator.cs
+++ b/src/Balu.SourceGenerator/BaluSourceGenerator.cs
@@ -20,6 +20,12 @@ public sealed class BaluSourceGenerator : ISourceGenerator
                                                                      category: "Balu source generation",
                                                                      DiagnosticSeverity.Error,
                                                                      isEnabledByDefault: true);
+    static readonly DiagnosticDescriptor UnsupportedNodeTypeDiagnostic = new(id: "BLS0002",
+                                                                              title: "Unsupported node type",
+                                                                              messageFormat: "The node type '{0}' must be non-generic and declared at namespace scope.",
+                                                                              category: "Balu source generation",
+                                                                              DiagnosticSeverity.Error,
+                                                                              isEnabledByDefault: true);
 
     public void Initialize(GeneratorInitializationContext context)
     {
@@ -36,6 +42,14 @@ public sealed class BaluSourceGenerator : ISourceGenerator
 
         if (boundNodeType is null || boundNodeKindType is null || immutableArrayType is null || syntaxNodeType is null ||
             syntaxNodeKindType is null || separatedListType is null) return;
+
+        var types = compilation.Assembly.GetAllTypes();
+        foreach (var type in types.Where(type => !type.IsSupportedNodeType() &&
+                                                (type.IsDerivedFrom(syntaxNodeType) || type.IsDerivedFrom(boundNodeType))))
+        {
+            var location = type.Locations.FirstOrDefault(candidate => candidate.IsInSource);
+            context.ReportDiagnostic(Diagnostic.Create(UnsupportedNodeTypeDiagnostic, location, type.ToDisplayString()));
+        }
 
         var generators = new BaseGenerator[]
         {

--- a/src/Balu.SourceGenerator/BoundNodeChildrenGenerator.cs
+++ b/src/Balu.SourceGenerator/BoundNodeChildrenGenerator.cs
@@ -29,7 +29,7 @@ sealed class BoundNodeChildrenGenerator : BaseGenerator
         Writer.WriteLine("namespace Balu.Binding;");
 
         var types = compilation.Assembly.GetAllTypes();
-        var boundNodeTypes = types.Where(t => !t.IsAbstract && t.IsPartial() && t.IsDerivedFrom(boundNodeType) && SymbolEqualityComparer.Default.Equals(boundNodeType.ContainingNamespace, t.ContainingNamespace));
+        var boundNodeTypes = types.Where(t => t.IsSupportedNodeType() && !t.IsAbstract && t.IsPartial() && t.IsDerivedFrom(boundNodeType) && SymbolEqualityComparer.Default.Equals(boundNodeType.ContainingNamespace, t.ContainingNamespace));
 
         foreach (var type in boundNodeTypes.TakeWhile(_ => !context.CancellationToken.IsCancellationRequested))
                 WriteType(type, context);

--- a/src/Balu.SourceGenerator/BoundTreeRewriterGenerator.cs
+++ b/src/Balu.SourceGenerator/BoundTreeRewriterGenerator.cs
@@ -25,7 +25,7 @@ sealed class BoundTreeRewriterGenerator : BaseGenerator
     {
         var kindNames = boundNodeKindType.MemberNames.ToImmutableArray();
         var types = compilation.Assembly.GetAllTypes();
-        var boundNodeTypes = types.Where(t => !t.IsAbstract && t.IsDerivedFrom(boundNodeType) && SymbolEqualityComparer.Default.Equals(t.ContainingNamespace, boundNodeType.ContainingNamespace));
+        var boundNodeTypes = types.Where(t => t.IsSupportedNodeType() && !t.IsAbstract && t.IsDerivedFrom(boundNodeType) && SymbolEqualityComparer.Default.Equals(t.ContainingNamespace, boundNodeType.ContainingNamespace));
         var kindsToVisit = kindNames
                            .Select(kindName => (kind: kindName,
                                                    type: boundNodeTypes.SingleOrDefault(nodeType => nodeType.Name == $"Bound{kindName}")))

--- a/src/Balu.SourceGenerator/BoundTreeVisitorGenerator.cs
+++ b/src/Balu.SourceGenerator/BoundTreeVisitorGenerator.cs
@@ -23,7 +23,7 @@ sealed class BoundTreeVisitorGenerator : BaseGenerator
     {
         var kindNames = boundNodeKindType.MemberNames.ToImmutableArray();
         var types = compilation.Assembly.GetAllTypes();
-        var boundNodeTypes = types.Where(t => !t.IsAbstract && t.IsDerivedFrom(boundNodeType) && SymbolEqualityComparer.Default.Equals(boundNodeType.ContainingNamespace, t.ContainingNamespace));
+        var boundNodeTypes = types.Where(t => t.IsSupportedNodeType() && !t.IsAbstract && t.IsDerivedFrom(boundNodeType) && SymbolEqualityComparer.Default.Equals(boundNodeType.ContainingNamespace, t.ContainingNamespace));
         var kindsToVisit = kindNames.Where(kindName => boundNodeTypes.Any(nodeType => nodeType.Name == $"Bound{kindName}")).ToImmutableArray();
 
         Writer.WriteLine("using System;");

--- a/src/Balu.SourceGenerator/SyntaxNodeChildrenGenerator.cs
+++ b/src/Balu.SourceGenerator/SyntaxNodeChildrenGenerator.cs
@@ -30,7 +30,7 @@ sealed class SyntaxNodeChildrenGenerator : BaseGenerator
         Writer.WriteLine("namespace Balu.Syntax;");
 
         var types = compilation.Assembly.GetAllTypes();
-        var syntaxNodeTypes = types.Where(t => !t.IsAbstract && t.IsPartial() && t.IsDerivedFrom(syntaxNodeType) &&
+        var syntaxNodeTypes = types.Where(t => t.IsSupportedNodeType() && !t.IsAbstract && t.IsPartial() && t.IsDerivedFrom(syntaxNodeType) &&
                                                SymbolEqualityComparer.Default.Equals(syntaxNodeType.ContainingNamespace, t.ContainingNamespace));
 
         foreach (var type in syntaxNodeTypes.TakeWhile(_ => !context.CancellationToken.IsCancellationRequested))

--- a/src/Balu.SourceGenerator/SyntaxNodeChildrenGenerator.cs
+++ b/src/Balu.SourceGenerator/SyntaxNodeChildrenGenerator.cs
@@ -134,6 +134,8 @@ sealed class SyntaxNodeChildrenGenerator : BaseGenerator
                     Writer.Write($"{property.Name} is not null && ");
                 Writer.WriteLine($"index == 0 ? {property.Name} : {exception};");
             }
+            else if (((INamedTypeSymbol)property.Type).IsGenericListOf(separatedListType, syntaxNodeType))
+                Writer.WriteLine($"{signature} => {property.Name}.ElementsWithSeparators[index];");
             else
                 Writer.WriteLine($"{signature} => {property.Name}[index];");
 

--- a/src/Balu.SourceGenerator/SyntaxTreeVisitorGenerator.cs
+++ b/src/Balu.SourceGenerator/SyntaxTreeVisitorGenerator.cs
@@ -24,7 +24,7 @@ sealed class SyntaxTreeVisitorGenerator : BaseGenerator
     {
         var kindNames = syntaxNodeKindType.MemberNames.Where(name => !(name.EndsWith("Token", StringComparison.InvariantCulture) || name.EndsWith("Keyword", StringComparison.InvariantCulture))).ToImmutableArray();
         var types = compilation.Assembly.GetAllTypes();
-        var syntaxNodeTypes = types.Where(t => !t.IsAbstract && t.IsDerivedFrom(syntaxNodeType) && SymbolEqualityComparer.Default.Equals(t.ContainingNamespace, syntaxNodeType.ContainingNamespace));
+        var syntaxNodeTypes = types.Where(t => t.IsSupportedNodeType() && !t.IsAbstract && t.IsDerivedFrom(syntaxNodeType) && SymbolEqualityComparer.Default.Equals(t.ContainingNamespace, syntaxNodeType.ContainingNamespace));
         var kindsToVisit = kindNames.Where(kindName => syntaxNodeTypes.Any(nodeType => nodeType.Name == $"{kindName}Syntax")).ToImmutableArray();
 
         Writer.WriteLine("using System;");

--- a/src/Balu.SourceGenerator/TypeExtensions.cs
+++ b/src/Balu.SourceGenerator/TypeExtensions.cs
@@ -39,6 +39,7 @@ static class TypeExtensions
     public static bool IsPartial(this INamedTypeSymbol type) => type.DeclaringSyntaxReferences.Select(declaration => declaration.GetSyntax())
                                                         .OfType<TypeDeclarationSyntax>()
                                                         .Any(syntax => syntax.Modifiers.Any(modifier => modifier.ValueText == "partial"));
+    public static bool IsSupportedNodeType(this INamedTypeSymbol type) => type.ContainingType is null && type.Arity == 0;
     public static bool IsGenericListOf(this INamedTypeSymbol type, INamedTypeSymbol listType, INamedTypeSymbol elementBaseType) =>
         type.TypeArguments.Length == 1 && type.TypeArguments[0].IsDerivedFrom(elementBaseType) &&
         SymbolEqualityComparer.Default.Equals(type.OriginalDefinition, listType);


### PR DESCRIPTION
## Summary
- report `BLS0002` for nested or generic syntax and bound node types
- exclude unsupported node types from child, visitor, and rewriter generation
- traverse separators correctly when a syntax node contains only one separated-list child
- cover nested and generic nodes, duplicate simple names, and executable separated-list traversal in generator tests

## Testing
- `dotnet test src/Balu.SourceGenerator.Tests/Balu.SourceGenerator.Tests.csproj`
- `dotnet test src/Balu.Tests/Balu.Tests.csproj`

Closes #136
Closes #138