### PR TITLE
Handle bodyless symbols in control flow graph output

### DIFF
--- a/src/Balu.Tests/CompilationTests/CompilationTests.cs
+++ b/src/Balu.Tests/CompilationTests/CompilationTests.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.IO;
+using System.Linq;
 using Balu.Diagnostics;
+using Balu.Symbols;
 using Balu.Syntax;
 using Xunit;
 
@@ -14,4 +17,55 @@ public sealed class CompilationTests
         Assert.True(compilation.Diagnostics.HasErrors());
         Assert.Throws<ArgumentException>("previous", () => Compilation.CreateScript(compilation, SyntaxTree.Parse("function a() { var x = y }")));
     }
+
+    [Fact]
+    public void WriteControlFlowGraph_ThrowsForNullFunction()
+    {
+        var compilation = Compilation.Create(SyntaxTree.Parse("function main() {}"));
+
+        Assert.Throws<ArgumentNullException>("function", () => compilation.WriteControlFlowGraph(TextWriter.Null, null!));
+    }
+
+    [Fact]
+    public void WriteControlFlowGraph_ThrowsForNullWriter()
+    {
+        var compilation = Compilation.Create(SyntaxTree.Parse("function main() {}"));
+        var function = GetFunction(compilation, "main");
+
+        Assert.Throws<ArgumentNullException>("writer", () => compilation.WriteControlFlowGraph(null!, function));
+    }
+
+    [Fact]
+    public void WriteControlFlowGraph_ThrowsForBuiltInFunction()
+    {
+        var compilation = Compilation.Create(SyntaxTree.Parse("function main() {}"));
+        var function = GetFunction(compilation, "print");
+
+        Assert.Throws<ArgumentException>("function", () => compilation.WriteControlFlowGraph(TextWriter.Null, function));
+    }
+
+    [Fact]
+    public void WriteControlFlowGraph_ThrowsForFunctionFromAnotherCompilation()
+    {
+        var compilation = Compilation.Create(SyntaxTree.Parse("function main() {}"));
+        var otherCompilation = Compilation.Create(SyntaxTree.Parse("function other() {}"));
+        var function = GetFunction(otherCompilation, "other");
+
+        Assert.Throws<ArgumentException>("function", () => compilation.WriteControlFlowGraph(TextWriter.Null, function));
+    }
+
+    [Fact]
+    public void WriteControlFlowGraph_WritesGraphForUserFunction()
+    {
+        var compilation = Compilation.Create(SyntaxTree.Parse("function main() {}"));
+        var function = GetFunction(compilation, "main");
+        using var writer = new StringWriter();
+
+        compilation.WriteControlFlowGraph(writer, function);
+
+        Assert.StartsWith("digraph G {", writer.ToString());
+    }
+
+    static FunctionSymbol GetFunction(Compilation compilation, string name) =>
+        compilation.VisibleSymbols.OfType<FunctionSymbol>().Single(function => function.Name == name);
 }

--- a/src/Balu/Compilation.cs
+++ b/src/Balu/Compilation.cs
@@ -326,9 +326,12 @@ public sealed class Compilation
     }
     public void WriteControlFlowGraph(TextWriter writer, FunctionSymbol function, CancellationToken cancellationToken = default)
     {
+        _ = function ?? throw new ArgumentNullException(nameof(function));
         _ = writer ?? throw new ArgumentNullException(nameof(writer));
         cancellationToken.ThrowIfCancellationRequested();
-        var cfg = ControlFlowGraph.Create(GetProgram(cancellationToken).Functions[function], cancellationToken);
+        if (!GetProgram(cancellationToken).Functions.TryGetValue(function, out var body))
+            throw new ArgumentException($"Function '{function.Name}' does not have a body in this compilation.", nameof(function));
+        var cfg = ControlFlowGraph.Create(body, cancellationToken);
         cfg.WriteTo(writer);
     }
     public static Compilation Create(params SyntaxTree[] syntaxTrees) => new (false, null, default, syntaxTrees);


### PR DESCRIPTION
## Summary
- validate both `function` and `writer` in `WriteControlFlowGraph`
- reject built-in and foreign function symbols with an `ArgumentException` tied to `function`
- cover null arguments, bodyless symbols, foreign symbols, and normal user functions

## Tests
- `dotnet test src/Balu.Tests/Balu.Tests.csproj` (21,792 passed)

Closes #170