### PR TITLE
Prevent #help from hanging in narrow terminals

### DIFF
--- a/src/bi.Tests/ReplTests.cs
+++ b/src/bi.Tests/ReplTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.IO;
+using Balu.Interactive;
+using Xunit;
+
+namespace bi.Tests;
+
+public sealed class ReplTests
+{
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    public void HelpMakesProgressInNarrowWindows(int windowWidth)
+    {
+        var console = new TestConsole(windowWidth);
+
+        new TestRepl().EvaluateHelp(console);
+
+        Assert.Contains("#help", console.Output, StringComparison.Ordinal);
+        Assert.Contains("  S", console.Output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HelpFallsBackWhenWindowWidthCannotBeRead()
+    {
+        var console = new TestConsole(windowWidth: null);
+
+        new TestRepl().EvaluateHelp(console);
+
+        Assert.Contains("#help", console.Output, StringComparison.Ordinal);
+        Assert.Contains("  Shows this help.", console.Output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HelpWrapsDescriptionsAtOrdinaryWidths()
+    {
+        var console = new TestConsole(windowWidth: 10);
+
+        new TestRepl().EvaluateHelp(console);
+
+        Assert.Contains($"  Clears {Environment.NewLine}  the inp", console.Output, StringComparison.Ordinal);
+    }
+
+    sealed class TestRepl : Repl
+    {
+        protected override bool IsCompleteSubmission(string text) => true;
+        protected override void EvaluateSubmission(string text) { }
+    }
+
+    sealed class TestConsole(int? windowWidth) : IConsole
+    {
+        readonly StringWriter output = new();
+
+        public string Output => output.ToString();
+        public int BufferWidth => windowWidth ?? 80;
+        public int BufferHeight => 25;
+        public int WindowWidth => windowWidth ?? throw new IOException();
+        public int WindowHeight => 25;
+        public int CursorLeft => 0;
+        public int CursorTop => 0;
+        public bool CursorVisible { get; set; }
+        public ConsoleColor ForegroundColor { get; set; }
+        public ConsoleColor BackgroundColor { get; set; }
+        public TextWriter Out => output;
+
+        public bool TryGetWindowWidth(out int width)
+        {
+            width = windowWidth.GetValueOrDefault();
+            return windowWidth.HasValue;
+        }
+
+        public bool TrySetCursorPosition(int left, int top) => true;
+        public void WriteLine() => output.WriteLine();
+    }
+}

--- a/src/bi.Tests/SubmissionViewTests.cs
+++ b/src/bi.Tests/SubmissionViewTests.cs
@@ -201,6 +201,12 @@ public sealed class SubmissionViewTests
         public int WrapCount { get; private set; }
         public int CursorMoveFailuresRemaining { get; set; }
 
+        public bool TryGetWindowWidth(out int width)
+        {
+            width = WindowWidth;
+            return true;
+        }
+
         public bool TrySetCursorPosition(int left, int top)
         {
             if (CursorMoveFailuresRemaining > 0)

--- a/src/bi/IConsole.cs
+++ b/src/bi/IConsole.cs
@@ -17,6 +17,7 @@ interface IConsole
     ConsoleColor BackgroundColor { get; set; }
     TextWriter Out { get; }
 
+    bool TryGetWindowWidth(out int width);
     bool TrySetCursorPosition(int left, int top);
     void WriteLine();
 }
@@ -38,6 +39,20 @@ sealed class SystemConsole : IConsole
     public ConsoleColor ForegroundColor { get => Console.ForegroundColor; set => Console.ForegroundColor = value; }
     public ConsoleColor BackgroundColor { get => Console.BackgroundColor; set => Console.BackgroundColor = value; }
     public TextWriter Out => Console.Out;
+
+    public bool TryGetWindowWidth(out int width)
+    {
+        try
+        {
+            width = Console.WindowWidth;
+            return true;
+        }
+        catch (IOException)
+        {
+            width = 0;
+            return false;
+        }
+    }
 
     public bool TrySetCursorPosition(int left, int top)
     {

--- a/src/bi/Repl.cs
+++ b/src/bi/Repl.cs
@@ -131,22 +131,26 @@ abstract class Repl
     [MetaCommand("exit", "Closes Balu interpreter.")]
     protected static void EvaluateExit() => Environment.Exit(0);
     [MetaCommand("help", "Shows this help.")]
-    protected void EvaluateHelp()
+    protected void EvaluateHelp() => EvaluateHelp(SystemConsole.Instance);
+    internal void EvaluateHelp(IConsole console)
     {
+        const int DefaultWindowWidth = 80;
+        int windowWidth = console.TryGetWindowWidth(out var width) ? width : DefaultWindowWidth;
+        int chunkSize = Math.Max(1, windowWidth - 3);
+
         foreach (var command in metaCommands.Values.OrderBy(mc => mc.Name))
         {
-            Console.Out.WritePunctuation("#");
-            Console.Out.WriteIdentifier(command.Name);
-            Console.Out.WriteSpace();
-            Console.Out.WritePunctuation(string.Join(" ", command.Method.GetParameters().Select(parameter => $"<{parameter.Name}>")));
-            Console.Out.WriteLine();
-            Console.Out.WritePunctuation(string.Join(Environment.NewLine, Chunks(command.Description)));
-            Console.Out.WriteLine();
+            console.Out.WritePunctuation("#");
+            console.Out.WriteIdentifier(command.Name);
+            console.Out.WriteSpace();
+            console.Out.WritePunctuation(string.Join(" ", command.Method.GetParameters().Select(parameter => $"<{parameter.Name}>")));
+            console.Out.WriteLine();
+            console.Out.WritePunctuation(string.Join(Environment.NewLine, Chunks(command.Description, chunkSize)));
+            console.Out.WriteLine();
         }
 
-        static IEnumerable<string> Chunks(string s)
+        static IEnumerable<string> Chunks(string s, int chunkSize)
         {
-            int chunkSize = Console.WindowWidth - 3;
             int position = 0;
             while (position < s.Length)
             {


### PR DESCRIPTION
## Summary
- render REPL help through the existing console abstraction
- guarantee a positive description chunk size for terminal widths 1, 2, and 3
- fall back to an 80-column width when the terminal width cannot be queried
- add focused help-rendering regression tests

## Tests
- `dotnet test src/bi.Tests/bi.Tests.csproj --no-restore`
- `dotnet test src/Balu.Tests/Balu.Tests.csproj --no-restore`
- `dotnet test src/Balu.Interpretation.Tests/Balu.Interpretation.Tests.csproj --no-restore`
- `dotnet test src/bc.Tests/bc.Tests.csproj --no-restore`
- `dotnet test src/Balu.SourceGenerator.Tests/Balu.SourceGenerator.Tests.csproj --no-restore`
- `dotnet test src/Balu.Sdk.Tests/Balu.Sdk.Tests.csproj --no-restore`
- Full Release solution build with Visual Studio MSBuild (0 warnings, 0 errors)

Closes #166