### PR TITLE
Diagnose constant zero divisors

### DIFF
--- a/src/Balu.Tests/BinderTests/ConstantDivisionByZeroTests.cs
+++ b/src/Balu.Tests/BinderTests/ConstantDivisionByZeroTests.cs
@@ -10,6 +10,10 @@ public sealed partial class BinderTests
     [InlineData("[(12 + 1) / (3 - 3)]")]
     [InlineData("var y = 7 + [3/0]")]
     [InlineData("let zero = 2 - 2 [10 / zero]")]
+    [InlineData("var value = 10 [value / 0]")]
+    [InlineData("var value = 10 let zero = 0 [value / zero]")]
+    [InlineData("var value = 10 [value /= 0]")]
+    [InlineData("var value = 10 let zero = 0 [value /= zero]")]
     [InlineData(@"
         function test()
         {

--- a/src/Balu/Binding/Binder.cs
+++ b/src/Balu/Binding/Binder.cs
@@ -160,7 +160,15 @@ sealed class Binder : SyntaxTreeVisitor
             return;
         }
 
-        boundNode = Assignment(node, variable, Binary(node, Variable(node.IdentifierToken, variable), op, right));
+        var binaryExpression = Binary(node, Variable(node.IdentifierToken, variable), op, right);
+        if (binaryExpression.FoldingError == ConstantFoldingError.DivisionByZero)
+        {
+            diagnostics.ReportConstantDivisionByZero(node.Location);
+            SetErrorExpression(node);
+            return;
+        }
+
+        boundNode = Assignment(node, variable, binaryExpression);
     }
     protected override void VisitPostfixExpression(PostfixExpressionSyntax node)
     {

--- a/src/Balu/Binding/ConstantFolder.cs
+++ b/src/Balu/Binding/ConstantFolder.cs
@@ -19,18 +19,17 @@ static class ConstantFolder
                 return Constant(true);
         }
 
-        if (left.Constant is null || right.Constant is null)
-            return default;
-
+        if (right.Constant is null) return default;
         if (operation.OperatorKind == BoundBinaryOperatorKind.Division)
         {
-            var dividend = (int)left.Constant.Value;
             var divisor = (int)right.Constant.Value;
             if (divisor == 0)
                 return new(null, ConstantFoldingError.DivisionByZero);
-            if (dividend == int.MinValue && divisor == -1)
+            if (divisor == -1 && left.Constant is { Value: int.MinValue })
                 return new(null, ConstantFoldingError.IntegerOverflow);
         }
+
+        if (left.Constant is null) return default;
 
         return operation.OperatorKind switch
         {


### PR DESCRIPTION
## Summary
- diagnose a constant zero divisor when the dividend is nonconstant
- report the same diagnostic for compound division assignments
- cover literal and readonly constant zero divisors with regression tests

## Testing
- `dotnet test src/Balu.Tests/Balu.Tests.csproj --no-restore` (21,796 passed)

Closes #157