### PR TITLE
Give missing tokens zero-width spans

### DIFF
--- a/src/Balu.Tests/BinderTests/MissingTokenDiagnosticTests.cs
+++ b/src/Balu.Tests/BinderTests/MissingTokenDiagnosticTests.cs
@@ -1,0 +1,28 @@
+using Balu.Diagnostics;
+using Balu.Syntax;
+using Balu.Text;
+using Xunit;
+
+namespace Balu.Tests.BinderTests;
+
+public sealed partial class BinderTests
+{
+    [Fact]
+    public void Binder_MissingTypeIdentifier_ReportsAtInsertionPoint()
+    {
+        var compilation = Compilation.CreateScript(null, SyntaxTree.Parse("var x: = 1"));
+
+        Assert.Collection(
+            compilation.Diagnostics,
+            diagnostic =>
+            {
+                Assert.Equal(DiagnosticId.UnexpectedToken, diagnostic.Id);
+                Assert.Equal(new TextSpan(7, 1), diagnostic.Location.Span);
+            },
+            diagnostic =>
+            {
+                Assert.Equal(DiagnosticId.UndefinedType, diagnostic.Id);
+                Assert.Equal(new TextSpan(7, 0), diagnostic.Location.Span);
+            });
+    }
+}

--- a/src/Balu.Tests/ExecutionTests/ReturnStatementTests.cs
+++ b/src/Balu.Tests/ExecutionTests/ReturnStatementTests.cs
@@ -1,4 +1,7 @@
-﻿using TestHelpers;
+﻿using Balu.Diagnostics;
+using Balu.Syntax;
+using Balu.Text;
+using TestHelpers;
 using Xunit;
 
 namespace Balu.Tests.CompilationTests.ExecutionTests;
@@ -29,13 +32,20 @@ public partial class ExecutionTests
     [Fact]
     public void Script_Return_ReportsUnexpectedTokenIfEspressionIsMissing()
     {
-        @"
-            function test() : int 
-            { 
-                return [[}]]".AssertScriptEvaluation(@"
-                    BL0001: Unexpected ClosedBraceToken ('}'), expected IdentifierToken.
-                    BL1024: 'test' needs to return a value of type 'int', not '?'.
-");
+        var compilation = Compilation.CreateScript(null, SyntaxTree.Parse("function test() : int { return }"));
+
+        Assert.Collection(
+            compilation.Diagnostics,
+            diagnostic =>
+            {
+                Assert.Equal(DiagnosticId.UnexpectedToken, diagnostic.Id);
+                Assert.Equal(new TextSpan(31, 1), diagnostic.Location.Span);
+            },
+            diagnostic =>
+            {
+                Assert.Equal(DiagnosticId.ReturnTypeMismatch, diagnostic.Id);
+                Assert.Equal(new TextSpan(31, 0), diagnostic.Location.Span);
+            });
     }
     [Fact]
     public void Script_Return_ReportsWrongExpressionType()

--- a/src/Balu.Tests/ParserTests/MissingTokenTests.cs
+++ b/src/Balu.Tests/ParserTests/MissingTokenTests.cs
@@ -1,0 +1,46 @@
+using Balu.Diagnostics;
+using Balu.Syntax;
+using Balu.Text;
+using Xunit;
+
+namespace Balu.Tests.ParserTests;
+
+public sealed class MissingTokenTests
+{
+    [Fact]
+    public void Parser_MissingTypeIdentifier_HasZeroWidthSpan()
+    {
+        var tree = SyntaxTree.Parse("var x: = 1");
+        var globalStatement = Assert.IsType<GlobalStatementSyntax>(Assert.Single(tree.Root.Members));
+        var declaration = Assert.IsType<VariableDeclarationStatementSyntax>(globalStatement.Statement);
+        var typeClause = Assert.IsType<TypeClauseSyntax>(declaration.TypeClause);
+
+        Assert.True(typeClause.Identifier.IsMissing);
+        Assert.Equal(new TextSpan(7, 0), typeClause.Identifier.Span);
+        Assert.Equal(new TextSpan(7, 0), typeClause.Identifier.FullSpan);
+        Assert.Equal(new TextSpan(7, 1), declaration.EqualsToken.Span);
+
+        var diagnostic = Assert.Single(tree.Diagnostics);
+        Assert.Equal(DiagnosticId.UnexpectedToken, diagnostic.Id);
+        Assert.Equal(new TextSpan(7, 1), diagnostic.Location.Span);
+    }
+
+    [Fact]
+    public void Parser_MissingDelimiter_HasZeroWidthSpan()
+    {
+        var tree = SyntaxTree.Parse("{ var x = (1 }");
+        var globalStatement = Assert.IsType<GlobalStatementSyntax>(Assert.Single(tree.Root.Members));
+        var block = Assert.IsType<BlockStatementSyntax>(globalStatement.Statement);
+        var declaration = Assert.IsType<VariableDeclarationStatementSyntax>(Assert.Single(block.Statements));
+        var expression = Assert.IsType<ParenthesizedExpressionSyntax>(declaration.Expression);
+
+        Assert.True(expression.ClosedParenthesisToken.IsMissing);
+        Assert.Equal(new TextSpan(13, 0), expression.ClosedParenthesisToken.Span);
+        Assert.Equal(new TextSpan(13, 0), expression.ClosedParenthesisToken.FullSpan);
+        Assert.Equal(new TextSpan(13, 1), block.ClosedBraceToken.Span);
+
+        var diagnostic = Assert.Single(tree.Diagnostics);
+        Assert.Equal(DiagnosticId.UnexpectedToken, diagnostic.Id);
+        Assert.Equal(new TextSpan(13, 1), diagnostic.Location.Span);
+    }
+}

--- a/src/Balu/Syntax/Parser.cs
+++ b/src/Balu/Syntax/Parser.cs
@@ -385,7 +385,7 @@ sealed class Parser
             return NextToken();
 
         diagnostics.ReportUnexpectedToken(Current, kind);
-        return new(syntaxTree, kind, Current.Span, null, null, ImmutableArray<SyntaxTrivia>.Empty, ImmutableArray<SyntaxTrivia>.Empty);
+        return new(syntaxTree, kind, new(Current.Span.Start, 0), null, null, ImmutableArray<SyntaxTrivia>.Empty, ImmutableArray<SyntaxTrivia>.Empty);
     }
     void SkipToken()
     {

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<BaluVersion Condition="'$(BaluVersion)' == ''">0.5.2</BaluVersion>
+		<BaluVersion Condition="'$(BaluVersion)' == ''">0.5.3</BaluVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(MSBuildProjectName)' == 'Balu' Or

--- a/src/HelloWorld/helloworld.csproj
+++ b/src/HelloWorld/helloworld.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.5.2">
+﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.5.3">
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
 		<OutputType>Exe</OutputType>


### PR DESCRIPTION
## Summary
- synthesize missing parser tokens with zero-width spans at the current insertion point
- keep unexpected-token diagnostics located on the actual token
- cover missing type identifiers, missing delimiters, and secondary binder diagnostics with regression tests

## Testing
- `dotnet test src/Balu.Tests/Balu.Tests.csproj` (21,799 passed)

Closes #168