### PR TITLE
Include trivia in excess-argument diagnostic spans

### DIFF
--- a/src/Balu.Tests/ExecutionTests/CallExpressionTests.cs
+++ b/src/Balu.Tests/ExecutionTests/CallExpressionTests.cs
@@ -22,6 +22,15 @@ public partial class ExecutionTests
 
         text.AssertScriptEvaluation(diagnostics);
     }
+    [Theory]
+    [InlineData("function test(value: int) {} test(1[,     2])")]
+    [InlineData("function test(value: int) {} test(1[,\r\n/* comment */\r\n2])")]
+    public void Script_Call_ReportsWrongNumberOfArgumentsIncludingTrivia(string text)
+    {
+        const string diagnostics = "BL1011: Function 'test' takes 1 parameters, but is invoked with 2 arguments.";
+
+        text.AssertScriptEvaluation(diagnostics);
+    }
     [Fact]
     public void Script_Call_ReportsWrongArgumentType()
     {

--- a/src/Balu/Diagnostics/DiagnosticBag.cs
+++ b/src/Balu/Diagnostics/DiagnosticBag.cs
@@ -64,10 +64,8 @@ sealed class DiagnosticBag : List<Diagnostic>
         var location = syntax.Arguments.Count < function.Parameters.Length
                            ? syntax.ClosedParenthesis.Location
                            : new(syntax.SyntaxTree.Text,
-                                 new(
-                                     syntax.Arguments.ElementsWithSeparators[Math.Max(0, function.Parameters.Length * 2 - 1)].Span.Start,
-                                     syntax.Arguments.ElementsWithSeparators.Skip(function.Parameters.Length * 2 - 1)
-                                           .Aggregate(0, (acc, token) => acc + token.Span.Length)));
+                                 syntax.Arguments.ElementsWithSeparators[Math.Max(0, function.Parameters.Length * 2 - 1)].Span
+                               + syntax.Arguments[syntax.Arguments.Count - 1].Span);
         Add(
             new(DiagnosticId.WrongNumberOfArguments,
                 location,


### PR DESCRIPTION
## Summary
- calculate excess-argument diagnostics from the first offending separator or argument through the final argument
- include intervening whitespace, comments, and line breaks in the diagnostic span
- add exact-span regression coverage for spaced and multiline calls

## Tests
- `dotnet test src/Balu.Tests/Balu.Tests.csproj --filter "FullyQualifiedName~Script_Call_ReportsWrongNumberOfArguments"`
- `dotnet test src/Balu.Tests/Balu.Tests.csproj`

Closes #164