### PR TITLE
Reject identical PE and PDB output streams

### DIFF
--- a/src/Balu.Tests/EmitterTests/StreamValidationTests.cs
+++ b/src/Balu.Tests/EmitterTests/StreamValidationTests.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+using Balu.Syntax;
+using Balu.Text;
+using TestHelpers;
+using Xunit;
+
+namespace Balu.Tests.EmitterTests;
+
+public partial class EmitterTests
+{
+    [Fact]
+    public void Emitter_DebugSymbols_RejectIdenticalOutputStreamsWithoutModification()
+    {
+        var compilation = Compilation.Create(SyntaxTree.Parse(SourceText.From("function main() {}", "main.b")));
+        using var stream = new MemoryStream([1, 2, 3, 4]);
+        var originalContent = stream.ToArray();
+
+        var exception = Assert.Throws<ArgumentException>("symbolStream", () =>
+            compilation.Emit("DebugSymbols", ReferenceProvider.References, stream, stream));
+
+        Assert.Equal("The symbol stream must be a different instance than the output stream. (Parameter 'symbolStream')", exception.Message);
+        Assert.Equal(originalContent, stream.ToArray());
+    }
+}

--- a/src/Balu/Compilation.cs
+++ b/src/Balu/Compilation.cs
@@ -134,7 +134,7 @@ public sealed class Compilation
     {
         _ = moduleName ?? throw new ArgumentNullException(nameof(moduleName));
         _ = references ?? throw new ArgumentNullException(nameof(references));
-        _ = outputStream ?? throw new ArgumentNullException(nameof(outputStream));
+        Emitter.ValidateEmitStreams(outputStream, symbolStream);
         cancellationToken.ThrowIfCancellationRequested();
         return Emitter.Emit(GetProgram(cancellationToken), moduleName, references, outputStream, symbolStream, ImmutableDictionary<GlobalVariableSymbol, object>.Empty, cancellationToken: cancellationToken).Diagnostics;
     }
@@ -142,7 +142,7 @@ public sealed class Compilation
     {
         _ = moduleName ?? throw new ArgumentNullException(nameof(moduleName));
         _ = references ?? throw new ArgumentNullException(nameof(references));
-        _ = outputStream ?? throw new ArgumentNullException(nameof(outputStream));
+        Emitter.ValidateEmitStreams(outputStream, symbolStream);
         cancellationToken.ThrowIfCancellationRequested();
         return Emitter.Emit(GetProgram(cancellationToken), moduleName, references, outputStream, symbolStream, initializedGlobalVariables, cancellationToken);
     }
@@ -150,7 +150,7 @@ public sealed class Compilation
     {
         _ = moduleName ?? throw new ArgumentNullException(nameof(moduleName));
         _ = references ?? throw new ArgumentNullException(nameof(references));
-        _ = outputStream ?? throw new ArgumentNullException(nameof(outputStream));
+        Emitter.ValidateEmitStreams(outputStream, symbolStream);
         cancellationToken.ThrowIfCancellationRequested();
         return Emitter.Emit(GetProgram(cancellationToken), moduleName, references, outputStream, symbolStream, ImmutableDictionary<GlobalVariableSymbol, object>.Empty, cancellationToken: cancellationToken).Diagnostics;
     }
@@ -158,7 +158,7 @@ public sealed class Compilation
     {
         _ = moduleName ?? throw new ArgumentNullException(nameof(moduleName));
         _ = references ?? throw new ArgumentNullException(nameof(references));
-        _ = outputStream ?? throw new ArgumentNullException(nameof(outputStream));
+        Emitter.ValidateEmitStreams(outputStream, symbolStream);
         cancellationToken.ThrowIfCancellationRequested();
         return Emitter.Emit(GetProgram(cancellationToken), moduleName, references, outputStream, symbolStream, debug, ImmutableDictionary<GlobalVariableSymbol, object>.Empty, cancellationToken: cancellationToken).Diagnostics;
     }
@@ -166,7 +166,7 @@ public sealed class Compilation
     {
         _ = moduleName ?? throw new ArgumentNullException(nameof(moduleName));
         _ = references ?? throw new ArgumentNullException(nameof(references));
-        _ = outputStream ?? throw new ArgumentNullException(nameof(outputStream));
+        Emitter.ValidateEmitStreams(outputStream, symbolStream);
         cancellationToken.ThrowIfCancellationRequested();
         using var referenceSet = new EmitReferenceSet(references);
         return Emitter.Emit(GetProgram(cancellationToken), moduleName, referenceSet, outputStream, symbolStream, debug, ImmutableDictionary<GlobalVariableSymbol, object>.Empty, cancellationToken: cancellationToken).Diagnostics;
@@ -177,7 +177,7 @@ public sealed class Compilation
     {
         _ = moduleName ?? throw new ArgumentNullException(nameof(moduleName));
         _ = references ?? throw new ArgumentNullException(nameof(references));
-        _ = outputStream ?? throw new ArgumentNullException(nameof(outputStream));
+        Emitter.ValidateEmitStreams(outputStream, symbolStream);
         cancellationToken.ThrowIfCancellationRequested();
         return Emitter.Emit(GetProgram(cancellationToken), moduleName, references, outputStream, symbolStream, debug, initializedGlobalVariables, cancellationToken: cancellationToken);
     }

--- a/src/Balu/Emit/Emitter.cs
+++ b/src/Balu/Emit/Emitter.cs
@@ -814,6 +814,7 @@ sealed class Emitter : IDisposable
 
     public static EmitterResult Emit(BoundProgram program, string moduleName, string[] references, Stream outputStream, Stream? symbolStream, ImmutableDictionary<GlobalVariableSymbol, object> initializedGlobalVariables, CancellationToken cancellationToken = default)
     {
+        ValidateEmitStreams(outputStream, symbolStream);
         cancellationToken.ThrowIfCancellationRequested();
         if (program.Diagnostics.HasErrors()) return new(program.Diagnostics, ImmutableDictionary<Symbol, string>.Empty);
         using var referenceSet = new EmitReferenceSet(references);
@@ -825,6 +826,7 @@ sealed class Emitter : IDisposable
 
     public static EmitterResult Emit(BoundProgram program, string moduleName, EmitReferenceSet references, Stream outputStream, Stream? symbolStream, bool debug, ImmutableDictionary<GlobalVariableSymbol, object> initializedGlobalVariables, string? pdbPath = null, CancellationToken cancellationToken = default)
     {
+        ValidateEmitStreams(outputStream, symbolStream);
         ValidateInitializedGlobalVariables(program, initializedGlobalVariables, cancellationToken);
         try
         {
@@ -838,6 +840,13 @@ sealed class Emitter : IDisposable
         {
             return new (exception.Diagnostics, ImmutableDictionary<Symbol, string>.Empty);
         }
+    }
+
+    internal static void ValidateEmitStreams(Stream outputStream, Stream? symbolStream)
+    {
+        _ = outputStream ?? throw new ArgumentNullException(nameof(outputStream));
+        if (ReferenceEquals(outputStream, symbolStream))
+            throw new ArgumentException("The symbol stream must be a different instance than the output stream.", nameof(symbolStream));
     }
 
     static void ValidateInitializedGlobalVariables(BoundProgram program, ImmutableDictionary<GlobalVariableSymbol, object> initializedGlobalVariables, CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary
- validate PE and PDB stream identity before binding or emitting
- reject collisions with a deterministic `ArgumentException` for `symbolStream`
- verify a pre-populated shared stream remains unchanged

## Tests
- `dotnet test src/Balu.Tests/Balu.Tests.csproj` (21,802 passed)

Closes #159