### PR TITLE
Exit REPL cleanly without interactive input

### DIFF
--- a/src/bi.Tests/ProcessTests.cs
+++ b/src/bi.Tests/ProcessTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace bi.Tests;
+
+public sealed class ProcessTests
+{
+    static readonly string BiAssemblyPath = Assembly.GetExecutingAssembly()
+                                                    .GetCustomAttributes<AssemblyMetadataAttribute>()
+                                                    .Single(attribute => attribute.Key == "BiAssemblyPath")
+                                                    .Value!;
+
+    [Fact]
+    public async Task RedirectedInputExitsCleanly()
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+        startInfo.ArgumentList.Add(BiAssemblyPath);
+
+        using var process = Process.Start(startInfo)!;
+        process.StandardInput.Close();
+        Task<string> outputTask = process.StandardOutput.ReadToEndAsync();
+        Task<string> errorTask = process.StandardError.ReadToEndAsync();
+
+        bool exited = process.WaitForExit(5_000);
+        if (!exited)
+        {
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit();
+        }
+
+        string output = await outputTask;
+        string error = await errorTask;
+
+        Assert.True(exited, "bi did not exit when its input was redirected.");
+        Assert.Equal(1, process.ExitCode);
+        Assert.Empty(output);
+        Assert.Equal($"Error: Interactive console input is unavailable.{Environment.NewLine}", error);
+    }
+}

--- a/src/bi.Tests/bi.Tests.csproj
+++ b/src/bi.Tests/bi.Tests.csproj
@@ -22,6 +22,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\bi\bi.csproj" />
+		<AssemblyMetadata Include="BiAssemblyPath" Value="$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..\bi\bin\$(Configuration)\$(TargetFramework)\bi.dll'))" />
 	</ItemGroup>
 
 </Project>

--- a/src/bi/Program.cs
+++ b/src/bi/Program.cs
@@ -1,4 +1,4 @@
 ﻿using Balu.Interactive;
 
 using var repl = new BaluRepl();
-repl.Run();
+return repl.Run();

--- a/src/bi/Repl.cs
+++ b/src/bi/Repl.cs
@@ -404,14 +404,30 @@ abstract class Repl
     }
 
     [SuppressMessage("Design", "CA1031", Justification = "This is the application's main method.")]
-    public void Run()
+    public int Run()
     {
+        if (Console.IsInputRedirected)
+            return ReportUnavailableConsole();
+
         Console.ResetColor();
         while (true)
         {
+            string text;
             try
             {
-                var text = EditSubmission();
+                text = EditSubmission();
+            }
+            catch (IOException)
+            {
+                return ReportUnavailableConsole();
+            }
+            catch (InvalidOperationException)
+            {
+                return ReportUnavailableConsole();
+            }
+
+            try
+            {
                 if (string.IsNullOrWhiteSpace(text)) continue;
                 AddToHistory(text);
                 if (text.StartsWith('#'))
@@ -427,5 +443,11 @@ abstract class Repl
             }
         }
         // ReSharper disable once FunctionNeverReturns
+    }
+
+    static int ReportUnavailableConsole()
+    {
+        Console.Error.WriteLine("Error: Interactive console input is unavailable.");
+        return 1;
     }
 }


### PR DESCRIPTION
## Summary
- reject redirected stdin before entering the REPL editor
- terminate console read failures with exit code 1 and one concise stderr message
- add a process-level regression test that verifies prompt termination and output

## Tests
- `dotnet test src/bi.Tests/bi.Tests.csproj --no-restore`

Closes #158