### PR TITLE
Diagnose invalid reference access failures

### DIFF
--- a/src/Balu.Tests/EmitterTests/ReferenceLifetimeTests.cs
+++ b/src/Balu.Tests/EmitterTests/ReferenceLifetimeTests.cs
@@ -58,6 +58,74 @@ public partial class EmitterTests
     }
 
     [Fact]
+    public void Emitter_EmptyReferencePathProducesDiagnostic()
+    {
+        var compilation = Compilation.Create(SyntaxTree.Parse("function main() {}"));
+        using var output = new MemoryStream();
+
+        var diagnostics = compilation.Emit("InvalidReference", [string.Empty], output, null);
+
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Id == DiagnosticId.InvalidAssemblyReference);
+    }
+
+    [Fact]
+    public void Emitter_DirectoryReferenceProducesDiagnosticAndReleasesLoadedReferences()
+    {
+        var directory = Directory.CreateTempSubdirectory("BaluEmitterReferences-");
+        try
+        {
+            var validReference = Path.Combine(directory.FullName, Path.GetFileName(ReferenceProvider.References[0]));
+            File.Copy(ReferenceProvider.References[0], validReference);
+            var compilation = Compilation.Create(SyntaxTree.Parse("function main() {}"));
+            using var output = new MemoryStream();
+
+            var diagnostics = compilation.Emit("InvalidReference", [validReference, directory.FullName], output, null);
+
+            Assert.Contains(diagnostics, diagnostic => diagnostic.Id == DiagnosticId.InvalidAssemblyReference);
+            AssertCanOpenExclusively([validReference]);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Emitter_PermissionDeniedReferenceProducesDiagnosticWhereSupported()
+    {
+        if (OperatingSystem.IsWindows()) return;
+
+        var directory = Directory.CreateTempSubdirectory("BaluEmitterReferences-");
+        var reference = Path.Combine(directory.FullName, "denied.dll");
+        File.Copy(ReferenceProvider.References[0], reference);
+        var originalMode = File.GetUnixFileMode(reference);
+        try
+        {
+            File.SetUnixFileMode(reference, UnixFileMode.None);
+            try
+            {
+                using var _ = File.OpenRead(reference);
+                return;
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+
+            var compilation = Compilation.Create(SyntaxTree.Parse("function main() {}"));
+            using var output = new MemoryStream();
+
+            var diagnostics = compilation.Emit("InvalidReference", [reference], output, null);
+
+            Assert.Contains(diagnostics, diagnostic => diagnostic.Id == DiagnosticId.InvalidAssemblyReference);
+        }
+        finally
+        {
+            File.SetUnixFileMode(reference, originalMode);
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
     public void Emitter_ReleasesReferencesAfterValidationFailure()
     {
         var directory = Directory.CreateTempSubdirectory("BaluEmitterReferences-");

--- a/src/Balu/Emit/EmitReferenceSet.cs
+++ b/src/Balu/Emit/EmitReferenceSet.cs
@@ -116,11 +116,7 @@ public sealed class EmitReferenceSet : IDisposable
             {
                 assemblies.Add(AssemblyDefinition.ReadAssembly(reference, new ReaderParameters { InMemory = true }));
             }
-            catch (BadImageFormatException exception)
-            {
-                diagnosticBag.ReportInvalidAssemblyReference(reference, exception.Message);
-            }
-            catch (IOException exception)
+            catch (Exception exception) when (exception is ArgumentException or BadImageFormatException or IOException or UnauthorizedAccessException)
             {
                 diagnosticBag.ReportInvalidAssemblyReference(reference, exception.Message);
             }


### PR DESCRIPTION
## Summary
- convert invalid reference path and access exceptions into `InvalidAssemblyReference` diagnostics
- preserve cleanup of assemblies loaded before a reference failure
- cover empty paths, directory references, and permission-denied files where supported

## Tests
- `dotnet test src/Balu.Tests/Balu.Tests.csproj --filter "FullyQualifiedName~Balu.Tests.EmitterTests.EmitterTests"`
- `dotnet test src/Balu.Tests/Balu.Tests.csproj`

Closes #160