### PR TITLE
Diagnose unsupported node declarations

### DIFF
--- a/src/Balu.SourceGenerator.Tests/Balu.SourceGenerator.Tests.csproj
+++ b/src/Balu.SourceGenerator.Tests/Balu.SourceGenerator.Tests.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
 		<PackageReference Include="xunit" Version="2.4.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/src/Balu.SourceGenerator.Tests/GeneratorOrderingTests.cs
+++ b/src/Balu.SourceGenerator.Tests/GeneratorOrderingTests.cs
@@ -43,6 +43,139 @@ public sealed class GeneratorOrderingTests
     }
 
     [Fact]
+    public void Generator_ReportsInaccessibleRewriterConstructor()
+    {
+        var source = ValidSource.Replace("public BoundPair(SyntaxNode syntax, BoundNode left, BoundNode right)",
+                                         "private BoundPair(SyntaxNode syntax, BoundNode left, BoundNode right)",
+                                         StringComparison.Ordinal);
+
+        AssertInvalidNodeModel(source, "constructor with 3 parameters is not accessible from the generated bound tree rewriter");
+    }
+
+    [Fact]
+    public void Generator_ReportsInaccessiblePropertyGetter()
+    {
+        var source = ValidSource.Replace("public BoundNode Left { get; }", "public BoundNode Left { private get; set; }", StringComparison.Ordinal);
+
+        AssertInvalidNodeModel(source, "property 'Left' has no getter accessible from the generated bound tree rewriter");
+    }
+
+    [Fact]
+    public void Generator_ReportsInheritedGetterInaccessibleFromGeneratedNodeMembers()
+    {
+        var source = ValidSource.Replace("public abstract int ChildrenCount { get; }",
+                                         "protected SyntaxNode First { private get; set; } = null!;\n        public abstract int ChildrenCount { get; }",
+                                         StringComparison.Ordinal)
+                                .Replace("public SyntaxNode First { get; }",
+                                         "public override int ChildrenCount => 0;\n        public override SyntaxNode GetChild(int index) => throw new ArgumentOutOfRangeException(nameof(index));",
+                                         StringComparison.Ordinal);
+
+        var (result, compilationDiagnostics, _) = RunGenerator(source);
+
+        var diagnostic = Assert.Single(result.Diagnostics.Where(candidate => candidate.Id == "BLS0001"));
+        Assert.Contains("property 'First' has no getter accessible from the generated syntax node members", diagnostic.GetMessage());
+        Assert.DoesNotContain(compilationDiagnostics,
+                              candidate => candidate.Severity == DiagnosticSeverity.Error && candidate.Id != "BLS0001");
+    }
+
+    [Fact]
+    public void Generator_AllowsInaccessibleConstructorWhenRewriterDoesNotReconstructNode()
+    {
+        const string boundNode = """
+    sealed partial class BoundLeaf : BoundNode
+    {
+        public int Value { get; }
+        public override BoundNodeKind Kind => BoundNodeKind.Leaf;
+
+        private BoundLeaf(SyntaxNode syntax, int value) : base(syntax)
+        {
+            Value = value;
+        }
+    }
+""";
+        var source = AddNodes(string.Empty, boundNode)
+                    .Replace("enum BoundNodeKind { Pair }", "enum BoundNodeKind { Pair, Leaf }", StringComparison.Ordinal);
+
+        var (result, compilationDiagnostics, _) = RunGenerator(source);
+
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        Assert.DoesNotContain(compilationDiagnostics, diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        Assert.Contains("VisitBoundLeaf", GetGeneratedSource(result, "BoundTreeRewriter.g.cs"));
+    }
+
+    [Fact]
+    public void Generator_RejectsRecordNodes()
+    {
+        var (result, compilationDiagnostics, _) = RunGenerator(RecordSource);
+
+        var diagnostics = result.Diagnostics.Where(candidate => candidate.Id == "BLS0002").ToImmutableArray();
+        Assert.Equal(5, diagnostics.Length);
+        Assert.Contains(diagnostics, diagnostic => diagnostic.GetMessage().Contains("'Balu.Syntax.RecordSyntax'", StringComparison.Ordinal));
+        Assert.Contains(diagnostics, diagnostic => diagnostic.GetMessage().Contains("'Balu.Binding.BoundRecord'", StringComparison.Ordinal));
+        Assert.All(diagnostics, diagnostic => Assert.Contains("must be a non-record, non-generic class", diagnostic.GetMessage()));
+        Assert.DoesNotContain(compilationDiagnostics,
+                              diagnostic => diagnostic.Severity == DiagnosticSeverity.Error && diagnostic.Id != "BLS0002");
+    }
+
+    [Fact]
+    public void Generator_EscapesKeywordPropertyIdentifiers()
+    {
+        var source = ValidSource.Replace("public SyntaxNode First { get; }", "public SyntaxNode @event { get; }", StringComparison.Ordinal)
+                                .Replace("public OrderedSyntax(SyntaxNode first, SyntaxNode second)", "public OrderedSyntax(SyntaxNode @event, SyntaxNode second)", StringComparison.Ordinal)
+                                .Replace("First = first;", "@event = @event;", StringComparison.Ordinal)
+                                .Replace("public BoundNode Left { get; }", "public BoundNode @event { get; }", StringComparison.Ordinal)
+                                .Replace("BoundNode left, BoundNode right", "BoundNode @event, BoundNode right", StringComparison.Ordinal)
+                                .Replace("Left = left;", "@event = @event;", StringComparison.Ordinal);
+
+        var (result, compilationDiagnostics, _) = RunGenerator(source);
+
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        Assert.DoesNotContain(compilationDiagnostics, diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        Assert.Contains("return @event;", GetGeneratedSource(result, "SyntaxNodeChildren.g.cs"));
+        Assert.Contains("return @event;", GetGeneratedSource(result, "BoundNodeChildren.g.cs"));
+        Assert.Contains("node.@event", GetGeneratedSource(result, "BoundTreeRewriter.g.cs"));
+    }
+
+    [Fact]
+    public void Generator_EscapesKeywordKindIdentifiers()
+    {
+        var source = ValidSource.Replace("public enum SyntaxKind { Ordered }", "public enum SyntaxKind { @class }", StringComparison.Ordinal)
+                                .Replace("OrderedSyntax", "classSyntax", StringComparison.Ordinal)
+                                .Replace("SyntaxKind.Ordered", "SyntaxKind.@class", StringComparison.Ordinal)
+                                .Replace("enum BoundNodeKind { Pair }", "enum BoundNodeKind { @event }", StringComparison.Ordinal)
+                                .Replace("BoundPair", "Boundevent", StringComparison.Ordinal)
+                                .Replace("BoundNodeKind.Pair", "BoundNodeKind.@event", StringComparison.Ordinal);
+
+        var (result, compilationDiagnostics, _) = RunGenerator(source);
+
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        Assert.DoesNotContain(compilationDiagnostics, diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        Assert.Contains("case SyntaxKind.@class:", GetGeneratedSource(result, "SyntaxTreeVisitor.g.cs"));
+        Assert.Contains("case BoundNodeKind.@event:", GetGeneratedSource(result, "BoundTreeVisitor.g.cs"));
+        Assert.Contains("BoundNodeKind.@event =>", GetGeneratedSource(result, "BoundTreeRewriter.g.cs"));
+    }
+
+    [Fact]
+    public void Generator_SupportsProductionStylePrimaryConstructors()
+    {
+        const string primaryConstructorNode = """
+    sealed partial class BoundPair(SyntaxNode syntax, BoundNode left, BoundNode right) : BoundNode(syntax)
+    {
+        public BoundNode Right { get; } = right;
+        public BoundNode Left { get; } = left;
+        public override BoundNodeKind Kind => BoundNodeKind.Pair;
+    }
+""";
+        var source = ValidSource.Replace(BoundPairSource, primaryConstructorNode, StringComparison.Ordinal);
+
+        var (result, compilationDiagnostics, _) = RunGenerator(source);
+
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        Assert.DoesNotContain(compilationDiagnostics, diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        Assert.Contains("new BoundPair(node.Syntax, rewrittenLeft, rewrittenRight)", GetGeneratedSource(result, "BoundTreeRewriter.g.cs"));
+    }
+
+    [Fact]
     public void Generator_TraversesSingleSeparatedListWithSeparators()
     {
         const string syntaxNodes = """
@@ -254,13 +387,25 @@ public sealed class GeneratorOrderingTests
                               diagnostic => diagnostic.Severity == DiagnosticSeverity.Error && diagnostic.Id != "BLS0002");
     }
 
+    static void AssertInvalidNodeModel(string source, string expectedReason)
+    {
+        var (result, compilationDiagnostics, _) = RunGenerator(source);
+
+        var diagnostic = Assert.Single(result.Diagnostics.Where(candidate => candidate.Id == "BLS0001"));
+        Assert.Contains(expectedReason, diagnostic.GetMessage());
+        Assert.True(diagnostic.Location.IsInSource);
+        Assert.DoesNotContain(compilationDiagnostics,
+                              candidate => candidate.Severity == DiagnosticSeverity.Error && candidate.Id != "BLS0001");
+        Assert.DoesNotContain("VisitBoundPair", GetGeneratedSource(result, "BoundTreeRewriter.g.cs"));
+    }
+
     static string AddNodes(string syntaxNodes, string boundNodes) =>
         ValidSource.Replace("    // Additional syntax nodes", syntaxNodes, StringComparison.Ordinal)
                    .Replace("    // Additional bound nodes", boundNodes, StringComparison.Ordinal);
 
     static (GeneratorDriverRunResult Result, ImmutableArray<Diagnostic> CompilationDiagnostics, CSharpCompilation OutputCompilation) RunGenerator(string source)
     {
-        var parseOptions = new CSharpParseOptions(LanguageVersion.CSharp10);
+        var parseOptions = new CSharpParseOptions(LanguageVersion.CSharp12);
         var syntaxTree = CSharpSyntaxTree.ParseText(source, parseOptions);
         var compilation = CSharpCompilation.Create("GeneratorTests",
                                                    new[] { syntaxTree },
@@ -375,6 +520,78 @@ namespace Balu.Binding
     }
 
     // Additional bound nodes
+}
+""";
+
+    const string BoundPairSource = """
+    sealed partial class BoundPair : BoundNode
+    {
+        public BoundNode Right { get; }
+        public BoundNode Left { get; }
+        public override BoundNodeKind Kind => BoundNodeKind.Pair;
+
+        public BoundPair(SyntaxNode syntax, BoundNode left, BoundNode right) : base(syntax)
+        {
+            Left = left;
+            Right = right;
+        }
+    }
+""";
+
+    const string RecordSource = """
+using System;
+using System.Collections.Immutable;
+
+namespace Balu.Syntax
+{
+    public enum SyntaxKind { Record }
+
+    public abstract record SyntaxNode
+    {
+        public abstract SyntaxKind Kind { get; }
+        public abstract int ChildrenCount { get; }
+        public abstract SyntaxNode GetChild(int index);
+    }
+
+    public sealed record SyntaxToken : SyntaxNode
+    {
+        public override SyntaxKind Kind => default;
+        public override int ChildrenCount => 0;
+        public override SyntaxNode GetChild(int index) => throw new ArgumentOutOfRangeException(nameof(index));
+    }
+
+    public sealed class SeparatedSyntaxList<T> where T : SyntaxNode
+    {
+        public ImmutableArray<SyntaxNode> ElementsWithSeparators { get; } = ImmutableArray<SyntaxNode>.Empty;
+    }
+
+    public sealed partial record RecordSyntax : SyntaxNode
+    {
+        public override SyntaxKind Kind => SyntaxKind.Record;
+        public override int ChildrenCount => 0;
+        public override SyntaxNode GetChild(int index) => throw new ArgumentOutOfRangeException(nameof(index));
+    }
+}
+
+namespace Balu.Binding
+{
+    using Balu.Syntax;
+
+    enum BoundNodeKind { Record }
+
+    abstract record BoundNode(SyntaxNode Syntax)
+    {
+        public abstract BoundNodeKind Kind { get; }
+        public abstract int ChildrenCount { get; }
+        public abstract BoundNode GetChild(int index);
+    }
+
+    sealed partial record BoundRecord(SyntaxNode Syntax) : BoundNode(Syntax)
+    {
+        public override BoundNodeKind Kind => BoundNodeKind.Record;
+        public override int ChildrenCount => 0;
+        public override BoundNode GetChild(int index) => throw new ArgumentOutOfRangeException(nameof(index));
+    }
 }
 """;
 }

--- a/src/Balu.SourceGenerator/BaluSourceGenerator.cs
+++ b/src/Balu.SourceGenerator/BaluSourceGenerator.cs
@@ -22,7 +22,7 @@ public sealed class BaluSourceGenerator : ISourceGenerator
                                                                      isEnabledByDefault: true);
     static readonly DiagnosticDescriptor UnsupportedNodeTypeDiagnostic = new(id: "BLS0002",
                                                                               title: "Unsupported node type",
-                                                                              messageFormat: "The node type '{0}' must be non-generic and declared at namespace scope.",
+                                                                               messageFormat: "The node type '{0}' must be a non-record, non-generic class declared at namespace scope.",
                                                                               category: "Balu source generation",
                                                                               DiagnosticSeverity.Error,
                                                                               isEnabledByDefault: true);

--- a/src/Balu.SourceGenerator/BoundNodeChildrenGenerator.cs
+++ b/src/Balu.SourceGenerator/BoundNodeChildrenGenerator.cs
@@ -49,7 +49,9 @@ sealed class BoundNodeChildrenGenerator : BaseGenerator
                                                  (propertyType.IsDerivedFrom(boundNodeType) ||
                                                   propertyType.IsGenericListOf(immutableArrayType, boundNodeType)))
                               .ToImmutableArray();
-        using(new CurlyIndenter(Writer, $"partial class {type.Name}"))
+        if (!model.ValidateAccessibility(context, type, constructorRequired: false, properties, "the generated bound node members")) return;
+
+        using(new CurlyIndenter(Writer, $"partial class {type.ToIdentifier()}"))
         {
             WriteChildrenCount(properties);
             WriteGetChild(properties);
@@ -72,7 +74,7 @@ sealed class BoundNodeChildrenGenerator : BaseGenerator
 
         if (nonNullableProperties.Length + collections.Length == 0 && nullableProperties.Length == 1)
         {
-            Writer.WriteLine($"public override int ChildrenCount => {nullableProperties[0].Name} is null ? 0 : 1;");
+            Writer.WriteLine($"public override int ChildrenCount => {nullableProperties[0].ToIdentifier()} is null ? 0 : 1;");
             return;
         }
 
@@ -84,7 +86,7 @@ sealed class BoundNodeChildrenGenerator : BaseGenerator
                 WriteNonNullableSum();
                 Writer.WriteLine(";");
                 Writer.WriteLine(
-                    string.Join(Environment.NewLine, nullableProperties.Select(property => $"if ({property.Name} is not null) count++;")));
+                    string.Join(Environment.NewLine, nullableProperties.Select(property => $"if ({property.ToIdentifier()} is not null) count++;")));
                 Writer.WriteLine("return count;");
             }
         }
@@ -97,7 +99,7 @@ sealed class BoundNodeChildrenGenerator : BaseGenerator
                 if (collections.Length > 0) Writer.Write(" + ");
             }
             else if (collections.Length == 0) Writer.Write("0");
-            Writer.Write(string.Join(" + ", collections.Select(collection => $"{collection.Name}.Length")));
+            Writer.Write(string.Join(" + ", collections.Select(collection => $"{collection.ToIdentifier()}.Length")));
         }
     }
     void WriteGetChild(ImmutableArray<IPropertySymbol> properties)
@@ -118,11 +120,11 @@ sealed class BoundNodeChildrenGenerator : BaseGenerator
             {
                 Writer.Write(signature + " => ");
                 if (property.NullableAnnotation == NullableAnnotation.Annotated)
-                    Writer.Write($"{property.Name} is not null && ");
-                Writer.WriteLine($"index == 0 ? {property.Name} : {exception};");
+                    Writer.Write($"{property.ToIdentifier()} is not null && ");
+                Writer.WriteLine($"index == 0 ? {property.ToIdentifier()} : {exception};");
             }
             else
-                Writer.WriteLine($"{signature} => {property.Name}[index];");
+                Writer.WriteLine($"{signature} => {property.ToIdentifier()}[index];");
 
             return;
         }
@@ -140,7 +142,7 @@ sealed class BoundNodeChildrenGenerator : BaseGenerator
 
             if (leadingNonNullableProperties.Length == 1)
             {
-                Writer.WriteLine($"if (index == 0) return {leadingNonNullableProperties[0].Name};");
+                Writer.WriteLine($"if (index == 0) return {leadingNonNullableProperties[0].ToIdentifier()};");
                 propIndex++;
             }
             else if (leadingNonNullableProperties.Length > 1)
@@ -148,7 +150,7 @@ sealed class BoundNodeChildrenGenerator : BaseGenerator
                 using(new CurlyIndenter(Writer, "switch(index)"))
                 {
                     foreach (var property in leadingNonNullableProperties)
-                        Writer.WriteLine($"case {propIndex++}: return {property.Name};");
+                        Writer.WriteLine($"case {propIndex++}: return {property.ToIdentifier()};");
                 }
             }
 
@@ -162,18 +164,18 @@ sealed class BoundNodeChildrenGenerator : BaseGenerator
                 {
                     if (propertyType.NullableAnnotation == NullableAnnotation.Annotated)
                     {
-                        Writer.WriteLine($"if ({property.Name} is null) adjustedIndex++;");
-                        Writer.WriteLine($"else if (adjustedIndex == propIndex) return {property.Name};");
+                        Writer.WriteLine($"if ({property.ToIdentifier()} is null) adjustedIndex++;");
+                        Writer.WriteLine($"else if (adjustedIndex == propIndex) return {property.ToIdentifier()};");
                     }
                     else
-                        Writer.WriteLine($"if (adjustedIndex == propIndex) return {property.Name};");
+                        Writer.WriteLine($"if (adjustedIndex == propIndex) return {property.ToIdentifier()};");
 
                     if (i < properties.Length - 1) Writer.WriteLine("propIndex++;");
                 }
                 else
                 {
-                    Writer.WriteLine($"if (adjustedIndex - propIndex < {property.Name}.Length) return {property.Name}[adjustedIndex-propIndex];");
-                    if (i < properties.Length - 1) Writer.WriteLine($"propIndex += {property.Name}.Length;");
+                    Writer.WriteLine($"if (adjustedIndex - propIndex < {property.ToIdentifier()}.Length) return {property.ToIdentifier()}[adjustedIndex-propIndex];");
+                    if (i < properties.Length - 1) Writer.WriteLine($"propIndex += {property.ToIdentifier()}.Length;");
                 }
             }
 

--- a/src/Balu.SourceGenerator/BoundTreeRewriterGenerator.cs
+++ b/src/Balu.SourceGenerator/BoundTreeRewriterGenerator.cs
@@ -26,11 +26,31 @@ sealed class BoundTreeRewriterGenerator : BaseGenerator
         var kindNames = boundNodeKindType.MemberNames.ToImmutableArray();
         var types = compilation.Assembly.GetAllTypes();
         var boundNodeTypes = types.Where(t => t.IsSupportedNodeType() && !t.IsAbstract && t.IsDerivedFrom(boundNodeType) && SymbolEqualityComparer.Default.Equals(t.ContainingNamespace, boundNodeType.ContainingNamespace));
-        var kindsToVisit = kindNames
-                           .Select(kindName => (kind: kindName,
-                                                   type: boundNodeTypes.SingleOrDefault(nodeType => nodeType.Name == $"Bound{kindName}")))
-                           .Where(x => x.type is not null)
-                           .ToImmutableArray();
+        var kindsToVisit = ImmutableArray.CreateBuilder<(string Kind, INamedTypeSymbol Type, NodeModel Model, ImmutableArray<IPropertySymbol> PropertiesToRewrite)>();
+        foreach (var kind in kindNames)
+        {
+            var type = boundNodeTypes.SingleOrDefault(nodeType => nodeType.Name == $"Bound{kind}");
+            if (type is null) continue;
+
+            var model = NodeModel.Create(type, context);
+            if (model is null) continue;
+
+            var propertiesToRewrite = model.Parameters
+                                           .Select(parameter => parameter.Property)
+                                           .Where(property => property.Type is INamedTypeSymbol propertyType &&
+                                                              (propertyType.IsDerivedFrom(boundNodeType) ||
+                                                               propertyType.IsGenericListOf(immutableArrayType, boundNodeType)))
+                                           .ToImmutableArray();
+            if (propertiesToRewrite.Length > 0 &&
+                !model.ValidateAccessibility(context,
+                                             boundNodeKindType,
+                                             constructorRequired: true,
+                                             model.Parameters.Select(parameter => parameter.Property).ToImmutableArray(),
+                                             "the generated bound tree rewriter"))
+                continue;
+
+            kindsToVisit.Add((kind, type, model, propertiesToRewrite));
+        }
 
         Writer.WriteLine("using System;");
         Writer.WriteLine("using System.Collections.Immutable;");
@@ -43,8 +63,8 @@ sealed class BoundTreeRewriterGenerator : BaseGenerator
         {
             using(new CurlyIndenter(Writer, "public virtual BoundNode Visit(BoundNode node) => node.Kind switch", semicolon: true))
             {
-                foreach (var (kind, type) in kindsToVisit)
-                    Writer.WriteLine($"BoundNodeKind.{kind} => VisitBound{kind}(({type!.Name})node),");
+                foreach (var (kind, type, _, _) in kindsToVisit)
+                    Writer.WriteLine($"BoundNodeKind.{kind.ToIdentifier()} => {$"VisitBound{kind}".ToIdentifier()}(({type.Name.ToIdentifier()})node),");
 
                 Writer.WriteLine("_ => throw new ArgumentException($\"Unexpected bound node kind '{node.Kind}'.\")");
             }
@@ -68,52 +88,44 @@ sealed class BoundTreeRewriterGenerator : BaseGenerator
     }
 ");
 
-            foreach (var (kind, type) in kindsToVisit)
+            foreach (var (kind, type, model, propertiesToRewrite) in kindsToVisit)
             {
-                var model = NodeModel.Create(type!, context);
-                if (model is null) continue;
-
-                var propertiesToRewrite = model.Parameters
-                                               .Select(parameter => parameter.Property)
-                                               .Where(property => property.Type is INamedTypeSymbol propertyType &&
-                                                                  (propertyType.IsDerivedFrom(boundNodeType) ||
-                                                                   propertyType.IsGenericListOf(immutableArrayType, boundNodeType)))
-                                               .ToImmutableArray();
-
                 if (propertiesToRewrite.Length == 0)
                 {
-                    Writer.WriteLine($"protected virtual BoundNode VisitBound{kind}({type.Name} node) => node;");
+                    Writer.WriteLine($"protected virtual BoundNode {$"VisitBound{kind}".ToIdentifier()}({type.Name.ToIdentifier()} node) => node;");
                     continue;
                 }
 
-                using(new CurlyIndenter(Writer, $"protected virtual BoundNode VisitBound{kind}({type.Name} node)"))
+                using(new CurlyIndenter(Writer, $"protected virtual BoundNode {$"VisitBound{kind}".ToIdentifier()}({type.Name.ToIdentifier()} node)"))
                 {
                     foreach (var property in propertiesToRewrite)
                     {
+                        var propertyName = property.Name.ToIdentifier();
+                        var rewrittenName = $"rewritten{property.Name}".ToIdentifier();
                         if (((INamedTypeSymbol)property.Type).IsDerivedFrom(boundNodeType))
                         {
                             if (property.NullableAnnotation == NullableAnnotation.Annotated)
                                 Writer.WriteLine(
-                                    $"var rewritten{property.Name} = node.{property.Name} is null ? null : ({property.Type.Name})Visit(node.{property.Name});");
+                                    $"var {rewrittenName} = node.{propertyName} is null ? null : ({property.Type.Name.ToIdentifier()})Visit(node.{propertyName});");
                             else
-                                Writer.WriteLine($"var rewritten{property.Name} = ({property.Type.Name})Visit(node.{property.Name});");
+                                Writer.WriteLine($"var {rewrittenName} = ({property.Type.Name.ToIdentifier()})Visit(node.{propertyName});");
                         }
                         else
-                            Writer.WriteLine($"var rewritten{property.Name} = RewriteList(node.{property.Name});");
+                            Writer.WriteLine($"var {rewrittenName} = RewriteList(node.{propertyName});");
                     }
 
                     Writer.WriteLine();
                     Writer.Write("return ");
-                    Writer.Write(string.Join(" && ", propertiesToRewrite.Select(property => $"node.{property.Name} == rewritten{property.Name}")));
-                    Writer.Write($" ? node : new {type.Name}(");
+                    Writer.Write(string.Join(" && ", propertiesToRewrite.Select(property => $"node.{property.Name.ToIdentifier()} == {$"rewritten{property.Name}".ToIdentifier()}")));
+                    Writer.Write($" ? node : new {type.Name.ToIdentifier()}(");
                     for (int i = 0; i < model.Parameters.Length; i++)
                     {
                         if (i > 0) Writer.Write(", ");
                         var property = model.Parameters[i].Property;
                         if (propertiesToRewrite.Contains(property))
-                            Writer.Write($"rewritten{property.Name}");
+                            Writer.Write($"rewritten{property.Name}".ToIdentifier());
                         else
-                            Writer.Write($"node.{property.Name}");
+                            Writer.Write($"node.{property.Name.ToIdentifier()}");
                     }
                     Writer.WriteLine(");");
                 }

--- a/src/Balu.SourceGenerator/BoundTreeVisitorGenerator.cs
+++ b/src/Balu.SourceGenerator/BoundTreeVisitorGenerator.cs
@@ -38,9 +38,9 @@ sealed class BoundTreeVisitorGenerator : BaseGenerator
                 {
                     foreach (var kind in kindsToVisit)
                     {
-                        Writer.WriteLine($"case BoundNodeKind.{kind}:");
+                        Writer.WriteLine($"case BoundNodeKind.{kind.ToIdentifier()}:");
                         Writer.Indent++;
-                        Writer.WriteLine($"VisitBound{kind}((Bound{kind})node);");
+                        Writer.WriteLine($"{$"VisitBound{kind}".ToIdentifier()}(({$"Bound{kind}".ToIdentifier()})node);");
                         Writer.WriteLine("break;");
                         Writer.Indent--;
                     }
@@ -62,7 +62,7 @@ sealed class BoundTreeVisitorGenerator : BaseGenerator
             Writer.WriteLine();
 
             foreach (var kind in kindsToVisit)
-                Writer.WriteLine($"protected virtual void VisitBound{kind}(Bound{kind} node) => VisitChildren(node);");
+                Writer.WriteLine($"protected virtual void {$"VisitBound{kind}".ToIdentifier()}({$"Bound{kind}".ToIdentifier()} node) => VisitChildren(node);");
         }
 
         context.AddSource(

--- a/src/Balu.SourceGenerator/NodeModel.cs
+++ b/src/Balu.SourceGenerator/NodeModel.cs
@@ -15,10 +15,15 @@ sealed class NodeModel
                                                                           DiagnosticSeverity.Error,
                                                                           isEnabledByDefault: true);
 
+    readonly INamedTypeSymbol type;
+    readonly IMethodSymbol constructor;
+
     internal ImmutableArray<(IParameterSymbol Parameter, IPropertySymbol Property)> Parameters { get; }
 
-    NodeModel(ImmutableArray<(IParameterSymbol Parameter, IPropertySymbol Property)> parameters)
+    NodeModel(INamedTypeSymbol type, IMethodSymbol constructor, ImmutableArray<(IParameterSymbol Parameter, IPropertySymbol Property)> parameters)
     {
+        this.type = type;
+        this.constructor = constructor;
         Parameters = parameters;
     }
 
@@ -46,7 +51,8 @@ sealed class NodeModel
         if (longestCandidates.Length != 1)
             return ReportError($"{longestCandidates.Length} constructors with {maximumParameterCount} parameters match the node properties");
 
-        return new NodeModel(longestCandidates[0].Parameters!.Value);
+        var selectedCandidate = longestCandidates[0];
+        return new NodeModel(type, selectedCandidate.Constructor, selectedCandidate.Parameters!.Value);
 
         ImmutableArray<(IParameterSymbol, IPropertySymbol)>? MapParameters(IMethodSymbol constructor) =>
             TryMapParameters(constructor, out _);
@@ -80,6 +86,29 @@ sealed class NodeModel
             var location = type.Locations.FirstOrDefault(candidate => candidate.IsInSource);
             context.ReportDiagnostic(Diagnostic.Create(InvalidNodeModel, location, type.Name, reason));
             return null;
+        }
+    }
+
+    internal bool ValidateAccessibility(GeneratorExecutionContext context,
+                                        INamedTypeSymbol accessibleWithin,
+                                        bool constructorRequired,
+                                        ImmutableArray<IPropertySymbol> properties,
+                                        string generatedContext)
+    {
+        if (constructorRequired && !context.Compilation.IsSymbolAccessibleWithin(constructor, accessibleWithin))
+            return ReportError($"constructor with {constructor.Parameters.Length} parameters is not accessible from {generatedContext}");
+
+        foreach (var property in properties)
+            if (property.GetMethod is null || !context.Compilation.IsSymbolAccessibleWithin(property.GetMethod, accessibleWithin))
+                return ReportError($"property '{property.Name}' has no getter accessible from {generatedContext}");
+
+        return true;
+
+        bool ReportError(string reason)
+        {
+            var location = type.Locations.FirstOrDefault(candidate => candidate.IsInSource);
+            context.ReportDiagnostic(Diagnostic.Create(InvalidNodeModel, location, type.Name, reason));
+            return false;
         }
     }
 

--- a/src/Balu.SourceGenerator/SyntaxNodeChildrenGenerator.cs
+++ b/src/Balu.SourceGenerator/SyntaxNodeChildrenGenerator.cs
@@ -52,7 +52,9 @@ sealed class SyntaxNodeChildrenGenerator : BaseGenerator
                                                   propertyType.IsGenericListOf(separatedListType, syntaxNodeType) ||
                                                   propertyType.IsGenericListOf(immutableArrayType, syntaxNodeType)))
                               .ToImmutableArray();
-        using(new CurlyIndenter(Writer, $"partial class {type.Name}"))
+        if (!model.ValidateAccessibility(context, type, constructorRequired: false, properties, "the generated syntax node members")) return;
+
+        using(new CurlyIndenter(Writer, $"partial class {type.ToIdentifier()}"))
         {
             WriteChildrenCount(properties);
             WriteGetChild(properties);
@@ -76,7 +78,7 @@ sealed class SyntaxNodeChildrenGenerator : BaseGenerator
 
         if (nonNullableProperties.Length + separatedLists.Length + immutableArrays.Length == 0 && nullableProperties.Length == 1)
         {
-            Writer.WriteLine($"public override int ChildrenCount => {nullableProperties[0].Name} is null ? 0 : 1;");
+            Writer.WriteLine($"public override int ChildrenCount => {nullableProperties[0].ToIdentifier()} is null ? 0 : 1;");
             return;
         }
 
@@ -88,7 +90,7 @@ sealed class SyntaxNodeChildrenGenerator : BaseGenerator
                 WriteNonNullableSum();
                 Writer.WriteLine(";");
                 Writer.WriteLine(
-                    string.Join(Environment.NewLine, nullableProperties.Select(property => $"if ({property.Name} is not null) count++;")));
+                    string.Join(Environment.NewLine, nullableProperties.Select(property => $"if ({property.ToIdentifier()} is not null) count++;")));
                 Writer.WriteLine("return count;");
             }
         }
@@ -101,12 +103,12 @@ sealed class SyntaxNodeChildrenGenerator : BaseGenerator
             if (immutableArrays.Length > 0)
             {
                 if (builder.Length > 0) builder.Append(" + ");
-                builder.Append(string.Join(" + ", immutableArrays.Select(prop => $"{prop.Name}.Length")));
+                builder.Append(string.Join(" + ", immutableArrays.Select(prop => $"{prop.ToIdentifier()}.Length")));
             }
             if (separatedLists.Length > 0)
             {
                 if (builder.Length > 0) builder.Append(" + ");
-                builder.Append(string.Join(" + ", separatedLists.Select(prop => $"{prop.Name}.ElementsWithSeparators.Length")));
+                builder.Append(string.Join(" + ", separatedLists.Select(prop => $"{prop.ToIdentifier()}.ElementsWithSeparators.Length")));
             }
 
             if (builder.Length == 0) builder.Append('0');
@@ -131,13 +133,13 @@ sealed class SyntaxNodeChildrenGenerator : BaseGenerator
             {
                 Writer.Write(signature + " => ");
                 if (property.NullableAnnotation == NullableAnnotation.Annotated)
-                    Writer.Write($"{property.Name} is not null && ");
-                Writer.WriteLine($"index == 0 ? {property.Name} : {exception};");
+                    Writer.Write($"{property.ToIdentifier()} is not null && ");
+                Writer.WriteLine($"index == 0 ? {property.ToIdentifier()} : {exception};");
             }
             else if (((INamedTypeSymbol)property.Type).IsGenericListOf(separatedListType, syntaxNodeType))
-                Writer.WriteLine($"{signature} => {property.Name}.ElementsWithSeparators[index];");
+                Writer.WriteLine($"{signature} => {property.ToIdentifier()}.ElementsWithSeparators[index];");
             else
-                Writer.WriteLine($"{signature} => {property.Name}[index];");
+                Writer.WriteLine($"{signature} => {property.ToIdentifier()}[index];");
 
             return;
         }
@@ -155,7 +157,7 @@ sealed class SyntaxNodeChildrenGenerator : BaseGenerator
 
             if (leadingNonNullableProperties.Length == 1)
             {
-                Writer.WriteLine($"if (index == 0) return {leadingNonNullableProperties[0].Name};");
+                Writer.WriteLine($"if (index == 0) return {leadingNonNullableProperties[0].ToIdentifier()};");
                 propIndex = 1;
             }
             else if (leadingNonNullableProperties.Length > 1)
@@ -163,7 +165,7 @@ sealed class SyntaxNodeChildrenGenerator : BaseGenerator
                 using(new CurlyIndenter(Writer, "switch(index)"))
                 {
                     foreach (var property in leadingNonNullableProperties)
-                        Writer.WriteLine($"case {propIndex++}: return {property.Name};");
+                        Writer.WriteLine($"case {propIndex++}: return {property.ToIdentifier()};");
                 }
             }
 
@@ -177,23 +179,23 @@ sealed class SyntaxNodeChildrenGenerator : BaseGenerator
                 {
                     if (propertyType.NullableAnnotation == NullableAnnotation.Annotated)
                     {
-                        Writer.WriteLine($"if ({property.Name} is null) adjustedIndex++;");
-                        Writer.WriteLine($"else if (adjustedIndex == propIndex) return {property.Name};");
+                        Writer.WriteLine($"if ({property.ToIdentifier()} is null) adjustedIndex++;");
+                        Writer.WriteLine($"else if (adjustedIndex == propIndex) return {property.ToIdentifier()};");
                     }
                     else
-                        Writer.WriteLine($"if (adjustedIndex == propIndex) return {property.Name};");
+                        Writer.WriteLine($"if (adjustedIndex == propIndex) return {property.ToIdentifier()};");
 
                     if (i < properties.Length - 1) Writer.WriteLine("propIndex++;");
                 }
                 else if (propertyType.IsGenericListOf(immutableArrayType, syntaxNodeType))
                 {
-                    Writer.WriteLine($"if (adjustedIndex - propIndex < {property.Name}.Length) return {property.Name}[adjustedIndex-propIndex];");
-                    if (i < properties.Length - 1) Writer.WriteLine($"propIndex += {property.Name}.Length;");
+                    Writer.WriteLine($"if (adjustedIndex - propIndex < {property.ToIdentifier()}.Length) return {property.ToIdentifier()}[adjustedIndex-propIndex];");
+                    if (i < properties.Length - 1) Writer.WriteLine($"propIndex += {property.ToIdentifier()}.Length;");
                 }
                 else
                 {
-                    Writer.WriteLine($"if (adjustedIndex - propIndex < {property.Name}.ElementsWithSeparators.Length) return {property.Name}.ElementsWithSeparators[adjustedIndex-propIndex];");
-                    if (i < properties.Length - 1) Writer.WriteLine($"propIndex += {property.Name}.ElementsWithSeparators.Length;");
+                    Writer.WriteLine($"if (adjustedIndex - propIndex < {property.ToIdentifier()}.ElementsWithSeparators.Length) return {property.ToIdentifier()}.ElementsWithSeparators[adjustedIndex-propIndex];");
+                    if (i < properties.Length - 1) Writer.WriteLine($"propIndex += {property.ToIdentifier()}.ElementsWithSeparators.Length;");
                 }
             }
 

--- a/src/Balu.SourceGenerator/SyntaxTreeVisitorGenerator.cs
+++ b/src/Balu.SourceGenerator/SyntaxTreeVisitorGenerator.cs
@@ -39,9 +39,9 @@ sealed class SyntaxTreeVisitorGenerator : BaseGenerator
                 {
                     foreach (var kind in kindsToVisit)
                     {
-                        Writer.WriteLine($"case SyntaxKind.{kind}:");
+                        Writer.WriteLine($"case SyntaxKind.{kind.ToIdentifier()}:");
                         Writer.Indent++;
-                        Writer.WriteLine($"Visit{kind}(({kind}Syntax)node);");
+                        Writer.WriteLine($"{$"Visit{kind}".ToIdentifier()}(({$"{kind}Syntax".ToIdentifier()})node);");
                         Writer.WriteLine("break;");
                         Writer.Indent--;
                     }
@@ -64,7 +64,7 @@ sealed class SyntaxTreeVisitorGenerator : BaseGenerator
             Writer.WriteLine();
 
             foreach (var kind in kindsToVisit)
-                Writer.WriteLine($"protected virtual void Visit{kind}({kind}Syntax node) => VisitChildren(node);");
+                Writer.WriteLine($"protected virtual void {$"Visit{kind}".ToIdentifier()}({$"{kind}Syntax".ToIdentifier()} node) => VisitChildren(node);");
             Writer.WriteLine("protected virtual void VisitToken(SyntaxToken node) => VisitChildren(node);");
         }
 

--- a/src/Balu.SourceGenerator/TypeExtensions.cs
+++ b/src/Balu.SourceGenerator/TypeExtensions.cs
@@ -1,6 +1,7 @@
 ﻿
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -39,7 +40,12 @@ static class TypeExtensions
     public static bool IsPartial(this INamedTypeSymbol type) => type.DeclaringSyntaxReferences.Select(declaration => declaration.GetSyntax())
                                                         .OfType<TypeDeclarationSyntax>()
                                                         .Any(syntax => syntax.Modifiers.Any(modifier => modifier.ValueText == "partial"));
-    public static bool IsSupportedNodeType(this INamedTypeSymbol type) => type.ContainingType is null && type.Arity == 0;
+    public static bool IsSupportedNodeType(this INamedTypeSymbol type) => type.ContainingType is null && type.Arity == 0 && !type.IsRecord;
+    public static string ToIdentifier(this string name) =>
+        SyntaxFacts.GetKeywordKind(name) != SyntaxKind.None || SyntaxFacts.GetContextualKeywordKind(name) != SyntaxKind.None
+            ? $"@{name}"
+            : name;
+    public static string ToIdentifier(this ISymbol symbol) => symbol.Name.ToIdentifier();
     public static bool IsGenericListOf(this INamedTypeSymbol type, INamedTypeSymbol listType, INamedTypeSymbol elementBaseType) =>
         type.TypeArguments.Length == 1 && type.TypeArguments[0].IsDerivedFrom(elementBaseType) &&
         SymbolEqualityComparer.Default.Equals(type.OriginalDefinition, listType);
@@ -50,9 +56,9 @@ static class TypeExtensions
         while (!string.IsNullOrWhiteSpace(current.Name))
         {
             if (builder.Length == 0)
-                builder.Append(current.Name);
+                builder.Append(current.Name.ToIdentifier());
             else
-                builder.Insert(0, $"{current.Name}.");
+                builder.Insert(0, $"{current.Name.ToIdentifier()}.");
             current = current.ContainingNamespace;
         }
         return builder.ToString();


### PR DESCRIPTION
## Summary
- validate constructor and property getter accessibility from each generated context
- reject record node declarations with `BLS0002` before emitting conflicting partial classes
- render generated symbol identifiers through Roslyn keyword escaping
- omit invalid rewriter dispatch entries and preserve valid leaf nodes
- cover inaccessible members, records, keyword identifiers, and C# 12 primary constructors

## Tests
- `dotnet test src/Balu.SourceGenerator.Tests/Balu.SourceGenerator.Tests.csproj --configuration Release` (15 passed)
- `dotnet test src/Balu.Tests/Balu.Tests.csproj --configuration Release` (21,805 passed)
- Visual Studio MSBuild `src/Balu.sln /restore /p:Configuration=Release` (succeeded)

Fixes #165