### PR TITLE
Validate source generator node mappings

### DIFF
--- a/src/Balu.SourceGenerator.Tests/GeneratorOrderingTests.cs
+++ b/src/Balu.SourceGenerator.Tests/GeneratorOrderingTests.cs
@@ -29,7 +29,7 @@ public sealed class GeneratorOrderingTests
                     boundChildren.IndexOf("case 1: return Right;", StringComparison.Ordinal));
 
         var rewriter = GetGeneratedSource(result, "BoundTreeRewriter.g.cs");
-        Assert.Contains("new BoundPair(node.Syntax, rewrittenLeft, rewrittenRight)", rewriter);
+        Assert.Contains("new global::Balu.Binding.BoundPair(node.Syntax, rewrittenLeft, rewrittenRight)", rewriter);
     }
 
     [Fact]
@@ -172,7 +172,7 @@ public sealed class GeneratorOrderingTests
 
         Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
         Assert.DoesNotContain(compilationDiagnostics, diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
-        Assert.Contains("new BoundPair(node.Syntax, rewrittenLeft, rewrittenRight)", GetGeneratedSource(result, "BoundTreeRewriter.g.cs"));
+        Assert.Contains("new global::Balu.Binding.BoundPair(node.Syntax, rewrittenLeft, rewrittenRight)", GetGeneratedSource(result, "BoundTreeRewriter.g.cs"));
     }
 
     [Fact]
@@ -182,7 +182,7 @@ public sealed class GeneratorOrderingTests
     public sealed partial class SeparatedOnlySyntax : SyntaxNode
     {
         public SeparatedSyntaxList<SyntaxToken> Items { get; }
-        public override SyntaxKind Kind => SyntaxKind.Ordered;
+        public override SyntaxKind Kind => SyntaxKind.SeparatedOnly;
 
         public SeparatedOnlySyntax(SeparatedSyntaxList<SyntaxToken> items)
         {
@@ -202,8 +202,11 @@ public sealed class GeneratorOrderingTests
         }
     }
 """;
-        var (_, compilationDiagnostics, outputCompilation) = RunGenerator(AddNodes(syntaxNodes, string.Empty));
+        var source = AddNodes(syntaxNodes, string.Empty)
+                    .Replace("public enum SyntaxKind { Ordered }", "public enum SyntaxKind { Ordered, SeparatedOnly }", StringComparison.Ordinal);
+        var (result, compilationDiagnostics, outputCompilation) = RunGenerator(source);
 
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
         Assert.DoesNotContain(compilationDiagnostics, diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
         using var stream = new MemoryStream();
         var emitResult = outputCompilation.Emit(stream);
@@ -280,6 +283,32 @@ public sealed class GeneratorOrderingTests
         AssertUnsupportedNodeTypes(AddNodes(syntaxNodes, boundNodes),
                                    "Balu.Syntax.GenericSyntax<T>",
                                    "Balu.Binding.GenericBoundNode<T>");
+    }
+
+    [Fact]
+    public void Generator_RejectsFileLocalSyntaxAndBoundNodes()
+    {
+        const string syntaxNodes = """
+    file sealed partial class FileSyntax : SyntaxNode
+    {
+        public override SyntaxKind Kind => SyntaxKind.Ordered;
+        public override int ChildrenCount => 0;
+        public override SyntaxNode GetChild(int index) => throw new ArgumentOutOfRangeException(nameof(index));
+    }
+""";
+        const string boundNodes = """
+    file sealed partial class BoundFile : BoundNode
+    {
+        public override BoundNodeKind Kind => BoundNodeKind.Pair;
+        public override int ChildrenCount => 0;
+        public override BoundNode GetChild(int index) => throw new ArgumentOutOfRangeException(nameof(index));
+        public BoundFile(SyntaxNode syntax) : base(syntax) { }
+    }
+""";
+
+        AssertUnsupportedNodeTypes(AddNodes(syntaxNodes, boundNodes),
+                                   "Balu.Syntax.FileSyntax",
+                                   "Balu.Binding.BoundFile");
     }
 
     [Fact]
@@ -368,6 +397,167 @@ public sealed class GeneratorOrderingTests
                                    "Balu.Syntax.SecondContainer.OrderedSyntax",
                                    "Balu.Binding.FirstContainer.BoundPair",
                                    "Balu.Binding.SecondContainer.BoundPair");
+    }
+
+    [Fact]
+    public void Generator_SupportsNodesOutsideBaseNamespaces()
+    {
+        const string additionalSource = """
+
+namespace Other.Syntax
+{
+    internal sealed partial class RemoteSyntax : Balu.Syntax.SyntaxNode
+    {
+        public override Balu.Syntax.SyntaxKind Kind => Balu.Syntax.SyntaxKind.Remote;
+    }
+}
+
+namespace Other.Binding
+{
+    sealed partial class BoundRemote : Balu.Binding.BoundNode
+    {
+        public override Balu.Binding.BoundNodeKind Kind => Balu.Binding.BoundNodeKind.Remote;
+        public BoundRemote(Balu.Syntax.SyntaxNode syntax) : base(syntax) { }
+    }
+}
+""";
+        var source = ValidSource.Replace("public enum SyntaxKind { Ordered }", "public enum SyntaxKind { Ordered, Remote }", StringComparison.Ordinal)
+                                .Replace("enum BoundNodeKind { Pair }", "enum BoundNodeKind { Pair, Remote }", StringComparison.Ordinal) +
+                     additionalSource;
+
+        var (result, compilationDiagnostics, _) = RunGenerator(source);
+
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        Assert.DoesNotContain(compilationDiagnostics, diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        Assert.Contains("namespace Other.Syntax", GetGeneratedSource(result, "SyntaxNodeChildren.g.cs"));
+        Assert.Contains("private protected virtual void VisitRemote(global::Other.Syntax.RemoteSyntax", GetGeneratedSource(result, "SyntaxTreeVisitor.g.cs"));
+        Assert.Contains("namespace Other.Binding", GetGeneratedSource(result, "BoundNodeChildren.g.cs"));
+        Assert.Contains("global::Other.Binding.BoundRemote", GetGeneratedSource(result, "BoundTreeRewriter.g.cs"));
+    }
+
+    [Fact]
+    public void Generator_ReportsConcreteNodeWithoutMatchingKind()
+    {
+        const string syntaxNode = """
+    public sealed class OrphanSyntax : SyntaxNode
+    {
+        public override SyntaxKind Kind => SyntaxKind.Ordered;
+        public override int ChildrenCount => 0;
+        public override SyntaxNode GetChild(int index) => throw new ArgumentOutOfRangeException(nameof(index));
+    }
+""";
+
+        var (result, _, _) = RunGenerator(AddNodes(syntaxNode, string.Empty));
+
+        var diagnostic = Assert.Single(result.Diagnostics.Where(candidate => candidate.Id == "BLS0003"));
+        Assert.Contains("Balu.Syntax.OrphanSyntax", diagnostic.GetMessage());
+        Assert.True(diagnostic.Location.IsInSource);
+    }
+
+    [Fact]
+    public void Generator_ReportsKindWithoutMatchingNode()
+    {
+        var source = ValidSource.Replace("public enum SyntaxKind { Ordered }", "public enum SyntaxKind { Ordered, Missing }", StringComparison.Ordinal);
+
+        var (result, _, _) = RunGenerator(source);
+
+        var diagnostic = Assert.Single(result.Diagnostics.Where(candidate => candidate.Id == "BLS0004"));
+        Assert.Contains("SyntaxKind.Missing", diagnostic.GetMessage());
+        Assert.Contains("MissingSyntax", diagnostic.GetMessage());
+        Assert.True(diagnostic.Location.IsInSource);
+    }
+
+    [Fact]
+    public void Generator_ReportsMultipleNodesForOneKindWithoutGeneratingCast()
+    {
+        const string duplicateNode = """
+
+namespace Other.Syntax
+{
+    public sealed class OrderedSyntax : Balu.Syntax.SyntaxNode
+    {
+        public override Balu.Syntax.SyntaxKind Kind => Balu.Syntax.SyntaxKind.Ordered;
+        public override int ChildrenCount => 0;
+        public override Balu.Syntax.SyntaxNode GetChild(int index) => throw new ArgumentOutOfRangeException(nameof(index));
+    }
+}
+""";
+
+        var (result, _, _) = RunGenerator(ValidSource + duplicateNode);
+
+        var diagnostic = Assert.Single(result.Diagnostics.Where(candidate => candidate.Id == "BLS0005"));
+        Assert.Contains("Balu.Syntax.OrderedSyntax", diagnostic.GetMessage());
+        Assert.Contains("Other.Syntax.OrderedSyntax", diagnostic.GetMessage());
+        Assert.DoesNotContain("case SyntaxKind.Ordered:", GetGeneratedSource(result, "SyntaxTreeVisitor.g.cs"));
+    }
+
+    [Fact]
+    public void Generator_ReportsDetectableSyntaxAndBoundKindMismatchesWithoutGeneratingCasts()
+    {
+        const string syntaxNode = """
+    public sealed partial class OtherSyntax : SyntaxNode
+    {
+        public override SyntaxKind Kind => SyntaxKind.Other;
+    }
+""";
+        const string boundNode = """
+    sealed partial class BoundOther : BoundNode
+    {
+        public override BoundNodeKind Kind => BoundNodeKind.Other;
+        public BoundOther(SyntaxNode syntax) : base(syntax) { }
+    }
+""";
+        var source = AddNodes(syntaxNode, boundNode)
+                    .Replace("public enum SyntaxKind { Ordered }", "public enum SyntaxKind { Ordered, Other }", StringComparison.Ordinal)
+                    .Replace("public override SyntaxKind Kind => SyntaxKind.Ordered;", "public override SyntaxKind Kind => (SyntaxKind)(1);", StringComparison.Ordinal)
+                    .Replace("enum BoundNodeKind { Pair }", "enum BoundNodeKind { Pair, Other }", StringComparison.Ordinal)
+                    .Replace("public override BoundNodeKind Kind => BoundNodeKind.Pair;",
+                             "public override BoundNodeKind Kind { get { return BoundNodeKind.Other; } }",
+                             StringComparison.Ordinal);
+
+        var (result, _, _) = RunGenerator(source);
+
+        var diagnostics = result.Diagnostics.Where(candidate => candidate.Id == "BLS0006").ToImmutableArray();
+        Assert.Equal(2, diagnostics.Length);
+        Assert.Contains(diagnostics, diagnostic => diagnostic.GetMessage().Contains("OrderedSyntax", StringComparison.Ordinal));
+        Assert.Contains(diagnostics, diagnostic => diagnostic.GetMessage().Contains("BoundPair", StringComparison.Ordinal));
+        Assert.DoesNotContain("case SyntaxKind.Ordered:", GetGeneratedSource(result, "SyntaxTreeVisitor.g.cs"));
+        Assert.DoesNotContain("BoundNodeKind.Pair =>", GetGeneratedSource(result, "BoundTreeRewriter.g.cs"));
+    }
+
+    [Fact]
+    public void Generator_ReportsDuplicateKindValuesBeforeGeneratingSwitchCases()
+    {
+        const string syntaxNode = """
+    public sealed partial class AliasSyntax : SyntaxNode
+    {
+        public override SyntaxKind Kind => SyntaxKind.Alias;
+    }
+""";
+        var source = AddNodes(syntaxNode, string.Empty)
+                    .Replace("public enum SyntaxKind { Ordered }", "public enum SyntaxKind { Ordered = 0, Alias = 0 }", StringComparison.Ordinal);
+
+        var (result, _, _) = RunGenerator(source);
+
+        var diagnostic = Assert.Single(result.Diagnostics.Where(candidate => candidate.Id == "BLS0007"));
+        Assert.Contains("SyntaxKind.Ordered", diagnostic.GetMessage());
+        Assert.Contains("SyntaxKind.Alias", diagnostic.GetMessage());
+        var visitor = GetGeneratedSource(result, "SyntaxTreeVisitor.g.cs");
+        Assert.DoesNotContain("case SyntaxKind.Ordered:", visitor);
+        Assert.DoesNotContain("case SyntaxKind.Alias:", visitor);
+    }
+
+    [Fact]
+    public void Generator_ExemptsTokenKeywordAndTriviaKindsFromNodeMappings()
+    {
+        var source = ValidSource.Replace("public enum SyntaxKind { Ordered }",
+                                         "public enum SyntaxKind { Ordered, BadToken, TrueKeyword, WhiteSpaceTrivia }",
+                                         StringComparison.Ordinal);
+
+        var (result, compilationDiagnostics, _) = RunGenerator(source);
+
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        Assert.DoesNotContain(compilationDiagnostics, diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
     }
 
     static void AssertUnsupportedNodeTypes(string source, params string[] typeNames)

--- a/src/Balu.SourceGenerator/BaluSourceGenerator.cs
+++ b/src/Balu.SourceGenerator/BaluSourceGenerator.cs
@@ -11,6 +11,7 @@ public sealed class BaluSourceGenerator : ISourceGenerator
     public const string BoundNodeKindTypeName = "Balu.Binding.BoundNodeKind";
     public const string SyntaxNodeTypeName = "Balu.Syntax.SyntaxNode";
     public const string SyntaxKindTypeName = "Balu.Syntax.SyntaxKind";
+    public const string SyntaxTokenTypeName = "Balu.Syntax.SyntaxToken";
     public const string SeparatedSyntaxListTypeName = "Balu.Syntax.SeparatedSyntaxList`1";
     public const string ImmutableArrayTypeName = "System.Collections.Immutable.ImmutableArray`1";
 
@@ -21,9 +22,9 @@ public sealed class BaluSourceGenerator : ISourceGenerator
                                                                      DiagnosticSeverity.Error,
                                                                      isEnabledByDefault: true);
     static readonly DiagnosticDescriptor UnsupportedNodeTypeDiagnostic = new(id: "BLS0002",
-                                                                              title: "Unsupported node type",
-                                                                               messageFormat: "The node type '{0}' must be a non-record, non-generic class declared at namespace scope.",
-                                                                              category: "Balu source generation",
+                                                                               title: "Unsupported node type",
+                                                                               messageFormat: "The node type '{0}' must be a non-record, non-generic class declared at namespace scope and must not be file-local.",
+                                                                               category: "Balu source generation",
                                                                               DiagnosticSeverity.Error,
                                                                               isEnabledByDefault: true);
 
@@ -38,10 +39,11 @@ public sealed class BaluSourceGenerator : ISourceGenerator
         var immutableArrayType = FindType(context, ImmutableArrayTypeName);
         var syntaxNodeType = FindType(context, SyntaxNodeTypeName);
         var syntaxNodeKindType = FindType(context, SyntaxKindTypeName);
+        var syntaxTokenType = FindType(context, SyntaxTokenTypeName);
         var separatedListType = FindType(context, SeparatedSyntaxListTypeName);
 
         if (boundNodeType is null || boundNodeKindType is null || immutableArrayType is null || syntaxNodeType is null ||
-            syntaxNodeKindType is null || separatedListType is null) return;
+            syntaxNodeKindType is null || syntaxTokenType is null || separatedListType is null) return;
 
         var types = compilation.Assembly.GetAllTypes();
         foreach (var type in types.Where(type => !type.IsSupportedNodeType() &&
@@ -51,13 +53,31 @@ public sealed class BaluSourceGenerator : ISourceGenerator
             context.ReportDiagnostic(Diagnostic.Create(UnsupportedNodeTypeDiagnostic, location, type.ToDisplayString()));
         }
 
+        var syntaxMapping = NodeKindMapping.Create(context,
+                                                   types,
+                                                   syntaxNodeType,
+                                                   syntaxNodeKindType,
+                                                   nodePrefix: string.Empty,
+                                                   nodeSuffix: "Syntax",
+                                                   kind => !(kind.Name.EndsWith("Token", System.StringComparison.Ordinal) ||
+                                                             kind.Name.EndsWith("Keyword", System.StringComparison.Ordinal) ||
+                                                             kind.Name.EndsWith("Trivia", System.StringComparison.Ordinal)),
+                                                   syntaxTokenType);
+        var boundMapping = NodeKindMapping.Create(context,
+                                                  types,
+                                                  boundNodeType,
+                                                  boundNodeKindType,
+                                                  nodePrefix: "Bound",
+                                                  nodeSuffix: string.Empty,
+                                                  _ => true);
+
         var generators = new BaseGenerator[]
         {
-            new SyntaxNodeChildrenGenerator(compilation, syntaxNodeType, separatedListType, immutableArrayType),
-            new SyntaxTreeVisitorGenerator(compilation, syntaxNodeType, syntaxNodeKindType), 
-            new BoundNodeChildrenGenerator(compilation, boundNodeType, immutableArrayType), 
-            new BoundTreeVisitorGenerator(compilation, boundNodeType, boundNodeKindType),
-            new BoundTreeRewriterGenerator(compilation, boundNodeType, boundNodeKindType, immutableArrayType)
+            new SyntaxNodeChildrenGenerator(syntaxMapping.Nodes, syntaxNodeType, separatedListType, immutableArrayType),
+            new SyntaxTreeVisitorGenerator(syntaxMapping),
+            new BoundNodeChildrenGenerator(boundMapping.Nodes, boundNodeType, immutableArrayType),
+            new BoundTreeVisitorGenerator(boundMapping),
+            new BoundTreeRewriterGenerator(boundMapping, boundNodeType, boundNodeKindType, immutableArrayType)
         };
 
         foreach (var generator in generators.TakeWhile(_ => !context.CancellationToken.IsCancellationRequested))

--- a/src/Balu.SourceGenerator/BoundNodeChildrenGenerator.cs
+++ b/src/Balu.SourceGenerator/BoundNodeChildrenGenerator.cs
@@ -3,19 +3,18 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Balu.SourceGenerator;
 
 sealed class BoundNodeChildrenGenerator : BaseGenerator
 {
-    readonly CSharpCompilation compilation;
+    readonly ImmutableArray<INamedTypeSymbol> nodes;
     readonly INamedTypeSymbol boundNodeType, immutableArrayType;
 
-    internal BoundNodeChildrenGenerator(CSharpCompilation compilation, INamedTypeSymbol boundNodeType, INamedTypeSymbol immutableArrayType)
+    internal BoundNodeChildrenGenerator(ImmutableArray<INamedTypeSymbol> nodes, INamedTypeSymbol boundNodeType, INamedTypeSymbol immutableArrayType)
     {
-        this.compilation = compilation;
+        this.nodes = nodes;
         this.boundNodeType = boundNodeType;
         this.immutableArrayType = immutableArrayType;
     }
@@ -26,13 +25,23 @@ sealed class BoundNodeChildrenGenerator : BaseGenerator
         Writer.WriteLine("using System.Collections.Generic;");
         Writer.WriteLine("using System.Collections.Immutable;");
         Writer.WriteLine();
-        Writer.WriteLine("namespace Balu.Binding;");
-
-        var types = compilation.Assembly.GetAllTypes();
-        var boundNodeTypes = types.Where(t => t.IsSupportedNodeType() && !t.IsAbstract && t.IsPartial() && t.IsDerivedFrom(boundNodeType) && SymbolEqualityComparer.Default.Equals(boundNodeType.ContainingNamespace, t.ContainingNamespace));
-
-        foreach (var type in boundNodeTypes.TakeWhile(_ => !context.CancellationToken.IsCancellationRequested))
-                WriteType(type, context);
+        foreach (var namespaceGroup in nodes.Where(type => type.IsPartial())
+                                            .GroupBy(type => type.ContainingNamespace.GetFullName())
+                                            .TakeWhile(_ => !context.CancellationToken.IsCancellationRequested))
+        {
+            if (namespaceGroup.Key.Length > 0)
+            {
+                Writer.WriteLine($"namespace {namespaceGroup.Key}");
+                using (new CurlyIndenter(Writer))
+                    foreach (var type in namespaceGroup)
+                        WriteType(type, context);
+            }
+            else
+            {
+                foreach (var type in namespaceGroup)
+                    WriteType(type, context);
+            }
+        }
 
         context.AddSource(
             "BoundNodeChildren.g.cs",

--- a/src/Balu.SourceGenerator/BoundTreeRewriterGenerator.cs
+++ b/src/Balu.SourceGenerator/BoundTreeRewriterGenerator.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Balu.SourceGenerator;
@@ -10,12 +9,12 @@ namespace Balu.SourceGenerator;
 sealed class BoundTreeRewriterGenerator : BaseGenerator
 {
 
-    readonly CSharpCompilation compilation;
+    readonly NodeKindMapping mapping;
     readonly INamedTypeSymbol boundNodeType, boundNodeKindType, immutableArrayType;
 
-    internal BoundTreeRewriterGenerator(CSharpCompilation compilation, INamedTypeSymbol boundNodeType, INamedTypeSymbol boundNodeKindType, INamedTypeSymbol immutableArrayType)
+    internal BoundTreeRewriterGenerator(NodeKindMapping mapping, INamedTypeSymbol boundNodeType, INamedTypeSymbol boundNodeKindType, INamedTypeSymbol immutableArrayType)
     {
-        this.compilation = compilation;
+        this.mapping = mapping;
         this.boundNodeType = boundNodeType;
         this.boundNodeKindType = boundNodeKindType;
         this.immutableArrayType = immutableArrayType;
@@ -23,15 +22,9 @@ sealed class BoundTreeRewriterGenerator : BaseGenerator
 
     public override void Generate(GeneratorExecutionContext context)
     {
-        var kindNames = boundNodeKindType.MemberNames.ToImmutableArray();
-        var types = compilation.Assembly.GetAllTypes();
-        var boundNodeTypes = types.Where(t => t.IsSupportedNodeType() && !t.IsAbstract && t.IsDerivedFrom(boundNodeType) && SymbolEqualityComparer.Default.Equals(t.ContainingNamespace, boundNodeType.ContainingNamespace));
-        var kindsToVisit = ImmutableArray.CreateBuilder<(string Kind, INamedTypeSymbol Type, NodeModel Model, ImmutableArray<IPropertySymbol> PropertiesToRewrite)>();
-        foreach (var kind in kindNames)
+        var kindsToVisit = ImmutableArray.CreateBuilder<(IFieldSymbol Kind, INamedTypeSymbol Type, NodeModel Model, ImmutableArray<IPropertySymbol> PropertiesToRewrite)>();
+        foreach (var (kind, type) in mapping.Mappings)
         {
-            var type = boundNodeTypes.SingleOrDefault(nodeType => nodeType.Name == $"Bound{kind}");
-            if (type is null) continue;
-
             var model = NodeModel.Create(type, context);
             if (model is null) continue;
 
@@ -64,7 +57,7 @@ sealed class BoundTreeRewriterGenerator : BaseGenerator
             using(new CurlyIndenter(Writer, "public virtual BoundNode Visit(BoundNode node) => node.Kind switch", semicolon: true))
             {
                 foreach (var (kind, type, _, _) in kindsToVisit)
-                    Writer.WriteLine($"BoundNodeKind.{kind.ToIdentifier()} => {$"VisitBound{kind}".ToIdentifier()}(({type.Name.ToIdentifier()})node),");
+                    Writer.WriteLine($"BoundNodeKind.{kind.ToIdentifier()} => {$"VisitBound{kind.Name}".ToIdentifier()}(({type.ToFullyQualifiedName()})node),");
 
                 Writer.WriteLine("_ => throw new ArgumentException($\"Unexpected bound node kind '{node.Kind}'.\")");
             }
@@ -92,11 +85,11 @@ sealed class BoundTreeRewriterGenerator : BaseGenerator
             {
                 if (propertiesToRewrite.Length == 0)
                 {
-                    Writer.WriteLine($"protected virtual BoundNode {$"VisitBound{kind}".ToIdentifier()}({type.Name.ToIdentifier()} node) => node;");
+                    Writer.WriteLine($"protected virtual BoundNode {$"VisitBound{kind.Name}".ToIdentifier()}({type.ToFullyQualifiedName()} node) => node;");
                     continue;
                 }
 
-                using(new CurlyIndenter(Writer, $"protected virtual BoundNode {$"VisitBound{kind}".ToIdentifier()}({type.Name.ToIdentifier()} node)"))
+                using(new CurlyIndenter(Writer, $"protected virtual BoundNode {$"VisitBound{kind.Name}".ToIdentifier()}({type.ToFullyQualifiedName()} node)"))
                 {
                     foreach (var property in propertiesToRewrite)
                     {
@@ -106,9 +99,9 @@ sealed class BoundTreeRewriterGenerator : BaseGenerator
                         {
                             if (property.NullableAnnotation == NullableAnnotation.Annotated)
                                 Writer.WriteLine(
-                                    $"var {rewrittenName} = node.{propertyName} is null ? null : ({property.Type.Name.ToIdentifier()})Visit(node.{propertyName});");
+                                    $"var {rewrittenName} = node.{propertyName} is null ? null : ({property.Type.ToFullyQualifiedName()})Visit(node.{propertyName});");
                             else
-                                Writer.WriteLine($"var {rewrittenName} = ({property.Type.Name.ToIdentifier()})Visit(node.{propertyName});");
+                                Writer.WriteLine($"var {rewrittenName} = ({property.Type.ToFullyQualifiedName()})Visit(node.{propertyName});");
                         }
                         else
                             Writer.WriteLine($"var {rewrittenName} = RewriteList(node.{propertyName});");
@@ -117,7 +110,7 @@ sealed class BoundTreeRewriterGenerator : BaseGenerator
                     Writer.WriteLine();
                     Writer.Write("return ");
                     Writer.Write(string.Join(" && ", propertiesToRewrite.Select(property => $"node.{property.Name.ToIdentifier()} == {$"rewritten{property.Name}".ToIdentifier()}")));
-                    Writer.Write($" ? node : new {type.Name.ToIdentifier()}(");
+                    Writer.Write($" ? node : new {type.ToFullyQualifiedName()}(");
                     for (int i = 0; i < model.Parameters.Length; i++)
                     {
                         if (i > 0) Writer.Write(", ");

--- a/src/Balu.SourceGenerator/BoundTreeVisitorGenerator.cs
+++ b/src/Balu.SourceGenerator/BoundTreeVisitorGenerator.cs
@@ -1,31 +1,20 @@
-﻿using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
+﻿using System.Text;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Balu.SourceGenerator;
 
 sealed class BoundTreeVisitorGenerator : BaseGenerator
 {
-    readonly CSharpCompilation compilation;
-    readonly INamedTypeSymbol boundNodeType, boundNodeKindType;
+    readonly NodeKindMapping mapping;
 
-    internal BoundTreeVisitorGenerator(CSharpCompilation compilation, INamedTypeSymbol boundNodeType, INamedTypeSymbol boundNodeKindType)
+    internal BoundTreeVisitorGenerator(NodeKindMapping mapping)
     {
-        this.compilation = compilation;
-        this.boundNodeType = boundNodeType;
-        this.boundNodeKindType = boundNodeKindType;
+        this.mapping = mapping;
     }
 
     public override void Generate(GeneratorExecutionContext context)
     {
-        var kindNames = boundNodeKindType.MemberNames.ToImmutableArray();
-        var types = compilation.Assembly.GetAllTypes();
-        var boundNodeTypes = types.Where(t => t.IsSupportedNodeType() && !t.IsAbstract && t.IsDerivedFrom(boundNodeType) && SymbolEqualityComparer.Default.Equals(boundNodeType.ContainingNamespace, t.ContainingNamespace));
-        var kindsToVisit = kindNames.Where(kindName => boundNodeTypes.Any(nodeType => nodeType.Name == $"Bound{kindName}")).ToImmutableArray();
-
         Writer.WriteLine("using System;");
         Writer.WriteLine();
         Writer.WriteLine("namespace Balu.Binding;");
@@ -36,11 +25,11 @@ sealed class BoundTreeVisitorGenerator : BaseGenerator
             {
                 using(new CurlyIndenter(Writer, "switch (node.Kind)"))
                 {
-                    foreach (var kind in kindsToVisit)
+                    foreach (var (kind, node) in mapping.Mappings)
                     {
                         Writer.WriteLine($"case BoundNodeKind.{kind.ToIdentifier()}:");
                         Writer.Indent++;
-                        Writer.WriteLine($"{$"VisitBound{kind}".ToIdentifier()}(({$"Bound{kind}".ToIdentifier()})node);");
+                        Writer.WriteLine($"{$"VisitBound{kind.Name}".ToIdentifier()}(({node.ToFullyQualifiedName()})node);");
                         Writer.WriteLine("break;");
                         Writer.Indent--;
                     }
@@ -61,8 +50,8 @@ sealed class BoundTreeVisitorGenerator : BaseGenerator
 
             Writer.WriteLine();
 
-            foreach (var kind in kindsToVisit)
-                Writer.WriteLine($"protected virtual void {$"VisitBound{kind}".ToIdentifier()}({$"Bound{kind}".ToIdentifier()} node) => VisitChildren(node);");
+            foreach (var (kind, node) in mapping.Mappings)
+                Writer.WriteLine($"protected virtual void {$"VisitBound{kind.Name}".ToIdentifier()}({node.ToFullyQualifiedName()} node) => VisitChildren(node);");
         }
 
         context.AddSource(

--- a/src/Balu.SourceGenerator/NodeKindMapping.cs
+++ b/src/Balu.SourceGenerator/NodeKindMapping.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Balu.SourceGenerator;
+
+sealed class NodeKindMapping
+{
+    internal static readonly DiagnosticDescriptor UnmatchedNode = new(id: "BLS0003",
+                                                                       title: "Unmatched node type",
+                                                                       messageFormat: "The node type '{0}' has no matching member in '{1}'.",
+                                                                       category: "Balu source generation",
+                                                                       DiagnosticSeverity.Error,
+                                                                       isEnabledByDefault: true);
+    internal static readonly DiagnosticDescriptor UnmatchedKind = new(id: "BLS0004",
+                                                                       title: "Unmatched node kind",
+                                                                       messageFormat: "The kind '{0}' has no matching concrete node type '{1}'.",
+                                                                       category: "Balu source generation",
+                                                                       DiagnosticSeverity.Error,
+                                                                       isEnabledByDefault: true);
+    internal static readonly DiagnosticDescriptor DuplicateNodes = new(id: "BLS0005",
+                                                                        title: "Duplicate node implementations",
+                                                                        messageFormat: "The kind '{0}' is implemented by multiple node types: {1}.",
+                                                                        category: "Balu source generation",
+                                                                        DiagnosticSeverity.Error,
+                                                                        isEnabledByDefault: true);
+    internal static readonly DiagnosticDescriptor MismatchedKind = new(id: "BLS0006",
+                                                                        title: "Mismatched node kind",
+                                                                        messageFormat: "The node type '{0}' returns kind '{1}', but its name maps to '{2}'.",
+                                                                        category: "Balu source generation",
+                                                                        DiagnosticSeverity.Error,
+                                                                        isEnabledByDefault: true);
+    internal static readonly DiagnosticDescriptor DuplicateKindValues = new(id: "BLS0007",
+                                                                             title: "Duplicate node kind values",
+                                                                             messageFormat: "The kinds {0} have the duplicate value '{1}'.",
+                                                                             category: "Balu source generation",
+                                                                             DiagnosticSeverity.Error,
+                                                                             isEnabledByDefault: true);
+
+    internal ImmutableArray<INamedTypeSymbol> Nodes { get; }
+    internal ImmutableArray<(IFieldSymbol Kind, INamedTypeSymbol Node)> Mappings { get; }
+
+    NodeKindMapping(ImmutableArray<INamedTypeSymbol> nodes,
+                    ImmutableArray<(IFieldSymbol Kind, INamedTypeSymbol Node)> mappings)
+    {
+        Nodes = nodes;
+        Mappings = mappings;
+    }
+
+    internal static NodeKindMapping Create(GeneratorExecutionContext context,
+                                           ImmutableArray<INamedTypeSymbol> allTypes,
+                                           INamedTypeSymbol baseNodeType,
+                                           INamedTypeSymbol kindType,
+                                           string nodePrefix,
+                                           string nodeSuffix,
+                                           Func<IFieldSymbol, bool> isDispatchKind,
+                                           INamedTypeSymbol? specialNode = null)
+    {
+        var concreteNodes = allTypes.Where(type => !type.IsAbstract && type.IsDerivedFrom(baseNodeType)).ToImmutableArray();
+        var nodes = concreteNodes.Where(type => type.IsSupportedNodeType()).ToImmutableArray();
+        var dispatchNodes = nodes.Where(type => !SymbolEqualityComparer.Default.Equals(type, specialNode)).ToImmutableArray();
+        var allDispatchNodes = concreteNodes.Where(type => !SymbolEqualityComparer.Default.Equals(type, specialNode)).ToImmutableArray();
+        var kinds = kindType.GetMembers()
+                            .OfType<IFieldSymbol>()
+                            .Where(field => field.HasConstantValue && isDispatchKind(field))
+                            .ToImmutableArray();
+        var invalidKinds = new HashSet<IFieldSymbol>(SymbolEqualityComparer.Default);
+
+        foreach (var duplicateGroup in kinds.GroupBy(field => field.ConstantValue).Where(group => group.Count() > 1))
+        {
+            var duplicateKinds = duplicateGroup.ToImmutableArray();
+            foreach (var kind in duplicateKinds)
+                invalidKinds.Add(kind);
+
+            var names = string.Join(", ", duplicateKinds.Select(kind => $"'{kind.ToDisplayString()}'"));
+            context.ReportDiagnostic(Diagnostic.Create(DuplicateKindValues,
+                                                       duplicateKinds[0].Locations.FirstOrDefault(location => location.IsInSource),
+                                                       names,
+                                                       duplicateGroup.Key));
+        }
+
+        var mappings = ImmutableArray.CreateBuilder<(IFieldSymbol Kind, INamedTypeSymbol Node)>();
+        var matchedNodes = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+        foreach (var kind in kinds)
+        {
+            var expectedNodeName = $"{nodePrefix}{kind.Name}{nodeSuffix}";
+            var allCandidates = allDispatchNodes.Where(node => node.Name == expectedNodeName).ToImmutableArray();
+            var candidates = dispatchNodes.Where(node => node.Name == expectedNodeName).ToImmutableArray();
+            foreach (var candidate in candidates)
+                matchedNodes.Add(candidate);
+
+            if (candidates.Length == 0)
+            {
+                if (allCandidates.Length > 0) continue;
+
+                context.ReportDiagnostic(Diagnostic.Create(UnmatchedKind,
+                                                           kind.Locations.FirstOrDefault(location => location.IsInSource),
+                                                           kind.ToDisplayString(),
+                                                           expectedNodeName));
+                continue;
+            }
+
+            if (candidates.Length > 1)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(DuplicateNodes,
+                                                           kind.Locations.FirstOrDefault(location => location.IsInSource),
+                                                           kind.ToDisplayString(),
+                                                           string.Join(", ", candidates.Select(candidate => $"'{candidate.ToDisplayString()}'"))));
+                continue;
+            }
+
+            var node = candidates[0];
+            var returnedKind = TryGetReturnedKind(context.Compilation, node, kindType);
+            if (returnedKind is not null && !Equals(returnedKind.Value.ConstantValue, kind.ConstantValue))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(MismatchedKind,
+                                                           GetKindLocation(node),
+                                                           node.ToDisplayString(),
+                                                           returnedKind.Value.Display,
+                                                           kind.ToDisplayString()));
+                continue;
+            }
+
+            if (!invalidKinds.Contains(kind))
+                mappings.Add((kind, node));
+        }
+
+        foreach (var node in dispatchNodes.Where(node => !matchedNodes.Contains(node)))
+            context.ReportDiagnostic(Diagnostic.Create(UnmatchedNode,
+                                                       node.Locations.FirstOrDefault(location => location.IsInSource),
+                                                       node.ToDisplayString(),
+                                                       kindType.ToDisplayString()));
+
+        return new NodeKindMapping(nodes, mappings.ToImmutable());
+    }
+
+    static (object? ConstantValue, string Display)? TryGetReturnedKind(Compilation compilation,
+                                                                       INamedTypeSymbol node,
+                                                                       INamedTypeSymbol kindType)
+    {
+        IPropertySymbol? property = null;
+        for (var current = node; current is not null && property is null; current = current.BaseType)
+            property = current.GetMembers("Kind").OfType<IPropertySymbol>().FirstOrDefault();
+        if (property is null) return null;
+
+        foreach (var syntaxReference in property.DeclaringSyntaxReferences)
+        {
+            if (syntaxReference.GetSyntax() is not PropertyDeclarationSyntax declaration) continue;
+
+            ExpressionSyntax? expression = declaration.ExpressionBody?.Expression;
+            if (expression is null)
+            {
+                var getter = declaration.AccessorList?.Accessors.FirstOrDefault(accessor => accessor.Keyword.ValueText == "get");
+                expression = getter?.ExpressionBody?.Expression;
+                if (expression is null && getter?.Body?.Statements.Count == 1 && getter.Body.Statements[0] is ReturnStatementSyntax returnStatement)
+                    expression = returnStatement.Expression;
+            }
+
+            if (expression is null) continue;
+            var semanticModel = compilation.GetSemanticModel(declaration.SyntaxTree);
+            var constant = semanticModel.GetConstantValue(expression);
+            if (!constant.HasValue) continue;
+
+            var field = kindType.GetMembers()
+                                .OfType<IFieldSymbol>()
+                                .FirstOrDefault(candidate => candidate.HasConstantValue && Equals(candidate.ConstantValue, constant.Value));
+            return (constant.Value, field?.ToDisplayString() ?? expression.ToString());
+        }
+
+        return null;
+    }
+
+    static Location? GetKindLocation(INamedTypeSymbol node) =>
+        node.GetMembers("Kind")
+            .OfType<IPropertySymbol>()
+            .SelectMany(property => property.Locations)
+            .FirstOrDefault(location => location.IsInSource) ??
+        node.Locations.FirstOrDefault(location => location.IsInSource);
+}

--- a/src/Balu.SourceGenerator/SyntaxNodeChildrenGenerator.cs
+++ b/src/Balu.SourceGenerator/SyntaxNodeChildrenGenerator.cs
@@ -3,19 +3,18 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Balu.SourceGenerator;
 
 sealed class SyntaxNodeChildrenGenerator : BaseGenerator
 {
-    readonly CSharpCompilation compilation;
+    readonly ImmutableArray<INamedTypeSymbol> nodes;
     readonly INamedTypeSymbol syntaxNodeType, separatedListType, immutableArrayType;
 
-    internal SyntaxNodeChildrenGenerator(CSharpCompilation compilation, INamedTypeSymbol syntaxNodeType, INamedTypeSymbol separatedListType, INamedTypeSymbol immutableArrayType)
+    internal SyntaxNodeChildrenGenerator(ImmutableArray<INamedTypeSymbol> nodes, INamedTypeSymbol syntaxNodeType, INamedTypeSymbol separatedListType, INamedTypeSymbol immutableArrayType)
     {
-        this.compilation = compilation;
+        this.nodes = nodes;
         this.syntaxNodeType = syntaxNodeType;
         this.separatedListType = separatedListType;
         this.immutableArrayType = immutableArrayType;
@@ -27,14 +26,23 @@ sealed class SyntaxNodeChildrenGenerator : BaseGenerator
         Writer.WriteLine("using System.Collections.Generic;");
         Writer.WriteLine("using System.Collections.Immutable;");
         Writer.WriteLine();
-        Writer.WriteLine("namespace Balu.Syntax;");
-
-        var types = compilation.Assembly.GetAllTypes();
-        var syntaxNodeTypes = types.Where(t => t.IsSupportedNodeType() && !t.IsAbstract && t.IsPartial() && t.IsDerivedFrom(syntaxNodeType) &&
-                                               SymbolEqualityComparer.Default.Equals(syntaxNodeType.ContainingNamespace, t.ContainingNamespace));
-
-        foreach (var type in syntaxNodeTypes.TakeWhile(_ => !context.CancellationToken.IsCancellationRequested))
-            WriteType(type, context);
+        foreach (var namespaceGroup in nodes.Where(type => type.IsPartial())
+                                            .GroupBy(type => type.ContainingNamespace.GetFullName())
+                                            .TakeWhile(_ => !context.CancellationToken.IsCancellationRequested))
+        {
+            if (namespaceGroup.Key.Length > 0)
+            {
+                Writer.WriteLine($"namespace {namespaceGroup.Key}");
+                using (new CurlyIndenter(Writer))
+                    foreach (var type in namespaceGroup)
+                        WriteType(type, context);
+            }
+            else
+            {
+                foreach (var type in namespaceGroup)
+                    WriteType(type, context);
+            }
+        }
 
         context.AddSource(
             "SyntaxNodeChildren.g.cs",

--- a/src/Balu.SourceGenerator/SyntaxTreeVisitorGenerator.cs
+++ b/src/Balu.SourceGenerator/SyntaxTreeVisitorGenerator.cs
@@ -1,32 +1,20 @@
-﻿using System;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
+﻿using System.Text;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Balu.SourceGenerator;
 
 sealed class SyntaxTreeVisitorGenerator : BaseGenerator
 {
-    readonly CSharpCompilation compilation;
-    readonly INamedTypeSymbol syntaxNodeType, syntaxNodeKindType;
+    readonly NodeKindMapping mapping;
 
-    internal SyntaxTreeVisitorGenerator(CSharpCompilation compilation, INamedTypeSymbol syntaxNodeType, INamedTypeSymbol syntaxNodeKindType)
+    internal SyntaxTreeVisitorGenerator(NodeKindMapping mapping)
     {
-        this.compilation = compilation;
-        this.syntaxNodeType = syntaxNodeType;
-        this.syntaxNodeKindType = syntaxNodeKindType;
+        this.mapping = mapping;
     }
 
     public override void Generate(GeneratorExecutionContext context)
     {
-        var kindNames = syntaxNodeKindType.MemberNames.Where(name => !(name.EndsWith("Token", StringComparison.InvariantCulture) || name.EndsWith("Keyword", StringComparison.InvariantCulture))).ToImmutableArray();
-        var types = compilation.Assembly.GetAllTypes();
-        var syntaxNodeTypes = types.Where(t => t.IsSupportedNodeType() && !t.IsAbstract && t.IsDerivedFrom(syntaxNodeType) && SymbolEqualityComparer.Default.Equals(t.ContainingNamespace, syntaxNodeType.ContainingNamespace));
-        var kindsToVisit = kindNames.Where(kindName => syntaxNodeTypes.Any(nodeType => nodeType.Name == $"{kindName}Syntax")).ToImmutableArray();
-
         Writer.WriteLine("using System;");
         Writer.WriteLine();
         Writer.WriteLine("namespace Balu.Syntax;");
@@ -37,11 +25,11 @@ sealed class SyntaxTreeVisitorGenerator : BaseGenerator
             {
                 using(new CurlyIndenter(Writer, "switch (node.Kind)"))
                 {
-                    foreach (var kind in kindsToVisit)
+                    foreach (var (kind, node) in mapping.Mappings)
                     {
                         Writer.WriteLine($"case SyntaxKind.{kind.ToIdentifier()}:");
                         Writer.Indent++;
-                        Writer.WriteLine($"{$"Visit{kind}".ToIdentifier()}(({$"{kind}Syntax".ToIdentifier()})node);");
+                        Writer.WriteLine($"{$"Visit{kind.Name}".ToIdentifier()}(({node.ToFullyQualifiedName()})node);");
                         Writer.WriteLine("break;");
                         Writer.Indent--;
                     }
@@ -63,8 +51,11 @@ sealed class SyntaxTreeVisitorGenerator : BaseGenerator
 
             Writer.WriteLine();
 
-            foreach (var kind in kindsToVisit)
-                Writer.WriteLine($"protected virtual void {$"Visit{kind}".ToIdentifier()}({$"{kind}Syntax".ToIdentifier()} node) => VisitChildren(node);");
+            foreach (var (kind, node) in mapping.Mappings)
+            {
+                var accessibility = node.DeclaredAccessibility == Accessibility.Public ? "protected" : "private protected";
+                Writer.WriteLine($"{accessibility} virtual void {$"Visit{kind.Name}".ToIdentifier()}({node.ToFullyQualifiedName()} node) => VisitChildren(node);");
+            }
             Writer.WriteLine("protected virtual void VisitToken(SyntaxToken node) => VisitChildren(node);");
         }
 

--- a/src/Balu.SourceGenerator/TypeExtensions.cs
+++ b/src/Balu.SourceGenerator/TypeExtensions.cs
@@ -15,7 +15,7 @@ static class TypeExtensions
     {
         var result = new List<INamedTypeSymbol>();
         GetAllTypes(result, assembly.GlobalNamespace);
-        return result.OrderBy(type => type.MetadataName).ToImmutableArray();
+        return result.OrderBy(type => type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)).ToImmutableArray();
     }
     static void GetAllTypes(List<INamedTypeSymbol> result, INamespaceOrTypeSymbol symbol)
     {
@@ -40,12 +40,18 @@ static class TypeExtensions
     public static bool IsPartial(this INamedTypeSymbol type) => type.DeclaringSyntaxReferences.Select(declaration => declaration.GetSyntax())
                                                         .OfType<TypeDeclarationSyntax>()
                                                         .Any(syntax => syntax.Modifiers.Any(modifier => modifier.ValueText == "partial"));
-    public static bool IsSupportedNodeType(this INamedTypeSymbol type) => type.ContainingType is null && type.Arity == 0 && !type.IsRecord;
+    public static bool IsSupportedNodeType(this INamedTypeSymbol type) =>
+        type.ContainingType is null && type.Arity == 0 && !type.IsRecord &&
+        !type.DeclaringSyntaxReferences.Select(reference => reference.GetSyntax())
+             .OfType<TypeDeclarationSyntax>()
+             .Any(syntax => syntax.Modifiers.Any(modifier => modifier.ValueText == "file"));
     public static string ToIdentifier(this string name) =>
         SyntaxFacts.GetKeywordKind(name) != SyntaxKind.None || SyntaxFacts.GetContextualKeywordKind(name) != SyntaxKind.None
             ? $"@{name}"
             : name;
     public static string ToIdentifier(this ISymbol symbol) => symbol.Name.ToIdentifier();
+    public static string ToFullyQualifiedName(this ITypeSymbol type) =>
+        type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
     public static bool IsGenericListOf(this INamedTypeSymbol type, INamedTypeSymbol listType, INamedTypeSymbol elementBaseType) =>
         type.TypeArguments.Length == 1 && type.TypeArguments[0].IsDerivedFrom(elementBaseType) &&
         SymbolEqualityComparer.Default.Equals(type.OriginalDefinition, listType);


### PR DESCRIPTION
## Summary
- build a shared, validated mapping between syntax/bound node types and their enum kinds
- diagnose unmatched nodes and kinds, duplicate mappings and enum values, detectable `Kind` mismatches, and unsupported file-local nodes
- generate namespace-aware children and fully qualified visitor/rewriter dispatch for nodes outside the base namespaces
- prevent invalid mappings from producing unsafe runtime casts

## Tests
- `dotnet test src/Balu.SourceGenerator.Tests/Balu.SourceGenerator.Tests.csproj --no-restore` (23 passed)
- `dotnet test src/Balu.Tests/Balu.Tests.csproj --no-restore` (21,805 passed)

Closes #163