### PR TITLE
Format locationless diagnostics safely

### DIFF
--- a/src/Balu.Tests/UnitTests/Diagnostics/DiagnosticTests.cs
+++ b/src/Balu.Tests/UnitTests/Diagnostics/DiagnosticTests.cs
@@ -1,0 +1,45 @@
+using System.IO;
+using Balu.Diagnostics;
+using Balu.Syntax;
+using Balu.Text;
+using Xunit;
+
+namespace Balu.Tests.UnitTests.Diagnostics;
+
+public class DiagnosticTests
+{
+    [Fact]
+    public void Diagnostic_ToString_FormatsNoEntryPointWithoutLocation()
+    {
+        var diagnostic = Assert.Single(Compilation.Create().Diagnostics);
+
+        Assert.Equal(DiagnosticId.NoEntryPointDefined, diagnostic.Id);
+        Assert.False(diagnostic.HasLocation);
+        Assert.Equal($"[{diagnostic.IdString}] {diagnostic.Message}", diagnostic.ToString());
+    }
+
+    [Fact]
+    public void Diagnostic_ToString_FormatsInvalidReferenceWithoutLocation()
+    {
+        var compilation = Compilation.Create(SyntaxTree.Parse("function main() {}"));
+        using var output = new MemoryStream();
+
+        var diagnostic = Assert.Single(compilation.Emit("InvalidReference", [string.Empty], output, null));
+
+        Assert.Equal(DiagnosticId.InvalidAssemblyReference, diagnostic.Id);
+        Assert.False(diagnostic.HasLocation);
+        Assert.Equal($"[{diagnostic.IdString}] {diagnostic.Message}", diagnostic.ToString());
+    }
+
+    [Fact]
+    public void Diagnostic_ToString_PreservesLocatedFormat()
+    {
+        var source = SourceText.From("\"", "test.b");
+        SyntaxTree.ParseTokens(source, out var diagnostics);
+        var diagnostic = Assert.Single(diagnostics);
+
+        Assert.Equal(DiagnosticId.UnterminatedString, diagnostic.Id);
+        Assert.True(diagnostic.HasLocation);
+        Assert.Equal($"test.b(1,1): [{diagnostic.IdString}] {diagnostic.Message}", diagnostic.ToString());
+    }
+}

--- a/src/Balu/Diagnostics/Diagnostic.cs
+++ b/src/Balu/Diagnostics/Diagnostic.cs
@@ -8,6 +8,7 @@ public sealed class Diagnostic
     public string IdString { get; }
     public DiagnosticSeverity Severity { get; }
     public TextLocation Location { get; }
+    public bool HasLocation => !Location.IsNone;
     public string Message { get; }
 
     internal Diagnostic(DiagnosticId id, TextLocation location, string message, DiagnosticSeverity severity = DiagnosticSeverity.Error)
@@ -19,5 +20,8 @@ public sealed class Diagnostic
         Severity = severity;
     }
 
-    public override string ToString() => $"{Location}: [{IdString}] {Message}";
+    public override string ToString() =>
+        HasLocation
+            ? $"{Location}: [{IdString}] {Message}"
+            : $"[{IdString}] {Message}";
 }

--- a/src/Balu/Diagnostics/DiagnosticBag.cs
+++ b/src/Balu/Diagnostics/DiagnosticBag.cs
@@ -89,7 +89,7 @@ sealed class DiagnosticBag : List<Diagnostic>
         returnType == TypeSymbol.Void
             ? $"'{functionName}' does not have a return type and cannot return a value of type '{actualType}'."
             : $"'{functionName}' needs to return a value of type '{returnType}', not '{actualType}'."));
-    public void ReportNotAllPathsReturn(FunctionSymbol function) => Add(new(DiagnosticId.NotAllPathsReturn, function.Declaration?.Body.ClosedBraceToken.Location ?? default, $"Not all code paths of function '{function.Name}' return a value of type '{function.ReturnType}'."));
+    public void ReportNotAllPathsReturn(FunctionSymbol function) => Add(new(DiagnosticId.NotAllPathsReturn, function.Declaration?.Body.ClosedBraceToken.Location ?? TextLocation.None, $"Not all code paths of function '{function.Name}' return a value of type '{function.ReturnType}'."));
     public void ReportInvalidExpressionStatement(TextLocation location) => Add(new(DiagnosticId.InvalidExpressionStatement, location, "Only assignment, call increment or decrement expressions can be used as a statement."));
     public void ReportCannotMixMainAndGlobalStatements(TextLocation location) =>
         Add(new(DiagnosticId.CannotMixMainANdGlobalStatements, location, $"Global statements cannot be mixed with a '{GlobalSymbolNames.Main}' function."));
@@ -98,7 +98,7 @@ sealed class DiagnosticBag : List<Diagnostic>
     public void ReportOnlyOneFileCanHaveGlobalStatements(TextLocation location) =>
         Add(new(DiagnosticId.OnlyOneFileCanHaveGlobalStatements, location, "At most one file can contain global statements."));
     public void ReportNoEntryPointDefined() =>
-        Add(new(DiagnosticId.NoEntryPointDefined, default, $"No entry point found (neither a '{GlobalSymbolNames.Main}' function nor global statements)."));
+        Add(new(DiagnosticId.NoEntryPointDefined, TextLocation.None, $"No entry point found (neither a '{GlobalSymbolNames.Main}' function nor global statements)."));
     public void ReportUnreachableCode(TextLocation location) => Add(new(DiagnosticId.UnreachableCode, location, "Unreachable code detected.", DiagnosticSeverity.Warning));
     public void ReportConstantDivisionByZero(TextLocation location) =>
         Add(new(DiagnosticId.ConstantDivisionByZero, location, "Constant division by zero."));
@@ -106,24 +106,24 @@ sealed class DiagnosticBag : List<Diagnostic>
         Add(new(DiagnosticId.ConstantIntegerOverflow, location, "Constant expression causes an integer overflow."));
 
     public void ReportInvalidAssemblyReference(string reference, string exceptionMessage) =>
-        Add(new(DiagnosticId.InvalidAssemblyReference, default, $"Could not load referenced assembly '{reference}': {exceptionMessage}"));
+        Add(new(DiagnosticId.InvalidAssemblyReference, TextLocation.None, $"Could not load referenced assembly '{reference}': {exceptionMessage}"));
     public void ReportRequiredTypeNotFound(string metaDataname, TypeSymbol? type = null) =>
         Add(new(
                 DiagnosticId.RequiredTypeNotFound,
-                default,
+                TextLocation.None,
                 type is null
                     ? $"The required type '{metaDataname}' could not be resolved among the referenced assemblies."
                     : $"The required type '{type.Name}' ('{metaDataname}') could not be resolved among the referenced assemblies."));
     public void ReportRequiredTypeAmbiguous(string name, TypeDefinition[] typeDefinitions) =>
-        Add(new(DiagnosticId.RequiredTypeAmbiguous, default, $"The required type '{name}' is ambiguous among these referenced assemblies: {string.Join(", ", typeDefinitions.Select(t => t.Module.Assembly.Name.Name).OrderBy(n => n))}."));
+        Add(new(DiagnosticId.RequiredTypeAmbiguous, TextLocation.None, $"The required type '{name}' is ambiguous among these referenced assemblies: {string.Join(", ", typeDefinitions.Select(t => t.Module.Assembly.Name.Name).OrderBy(n => n))}."));
     public void ReportRequiredMethodNotFound(string type, string name, string[] parameterTypeNames) =>
-        Add(new(DiagnosticId.RequiredMethodNotFound, default, $"The required method '{type}.{name}({string.Join(", ", parameterTypeNames)})' could not be found in the referenced assemblies."));
+        Add(new(DiagnosticId.RequiredMethodNotFound, TextLocation.None, $"The required method '{type}.{name}({string.Join(", ", parameterTypeNames)})' could not be found in the referenced assemblies."));
     public void ReportRequiredMethodAmbiguous(string type, string name, string[] parameterTypeNames) =>
-        Add(new(DiagnosticId.RequiredMethodAmbiguous, default, $"The required method '{type}.{name}({string.Join(", ", parameterTypeNames)})' is ambiguous in the referenced assemblies."));
+        Add(new(DiagnosticId.RequiredMethodAmbiguous, TextLocation.None, $"The required method '{type}.{name}({string.Join(", ", parameterTypeNames)})' is ambiguous in the referenced assemblies."));
     public void ReportSourceDocumentNameMissing(TextLocation location) =>
         Add(new(DiagnosticId.SourceDocumentNameMissing, location, "Cannot emit debug symbols for a source document without a name."));
     public void ReportSourceDocumentNameCollision(TextLocation location, string documentName) =>
         Add(new(DiagnosticId.SourceDocumentNameCollision, location, $"Cannot emit debug symbols because document name '{documentName}' identifies different source texts."));
     public void ReportEmitPathCollision(string pathKind, string path, string conflictingPathKind, string conflictingPath) =>
-        Add(new(DiagnosticId.EmitPathCollision, default, $"The {pathKind} path '{path}' conflicts with the {conflictingPathKind} path '{conflictingPath}'."));
+        Add(new(DiagnosticId.EmitPathCollision, TextLocation.None, $"The {pathKind} path '{path}' conflicts with the {conflictingPathKind} path '{conflictingPath}'."));
 }

--- a/src/Balu/Text/TextLocation.cs
+++ b/src/Balu/Text/TextLocation.cs
@@ -2,6 +2,9 @@
 
 public readonly record struct TextLocation(SourceText Text, TextSpan Span)
 {
+    public static TextLocation None => default;
+    public bool IsNone => Text is null;
+
     public string FileName => Text.FileName;
     public int StartLine => Text.GetLineIndex(Span.Start);
     public int EndLine => Text.GetLineIndex(Span.End);
@@ -10,6 +13,8 @@ public readonly record struct TextLocation(SourceText Text, TextSpan Span)
 
     public override string ToString()
     {
+        if (IsNone) return string.Empty;
+
         var line = Text.GetLineIndex(Span.Start);
         return $"{Text.FileName}({line + 1},{Span.Start - Text.Lines[line].Start + 1})";
     }

--- a/src/Balu/Visualization/TextWriterExtensions.cs
+++ b/src/Balu/Visualization/TextWriterExtensions.cs
@@ -38,7 +38,7 @@ public static class TextWriterExtensions
         _ = textWriter ?? throw new ArgumentNullException(nameof(textWriter));
         var diags = (diagnostics ?? throw new ArgumentNullException(nameof(diagnostics))).ToArray();
 
-        foreach (var diagnostic in diags.Where(diagnostic => diagnostic.Location.Text != null).OrderBy(diagnostic => diagnostic.Location.FileName).ThenBy(diagnostic => diagnostic.Location.Span.Start).ThenByDescending(diagnostic => diagnostic.Location.Span.Length))
+        foreach (var diagnostic in diags.Where(diagnostic => diagnostic.HasLocation).OrderBy(diagnostic => diagnostic.Location.FileName).ThenBy(diagnostic => diagnostic.Location.Span.Start).ThenByDescending(diagnostic => diagnostic.Location.Span.Length))
         {
             var sourceText = diagnostic.Location.Text;
             var startLine = sourceText.Lines[diagnostic.Location.StartLine];
@@ -70,7 +70,7 @@ public static class TextWriterExtensions
                 textWriter.WriteLine();
             }
         }
-        foreach (var diagnostic in diags.Where(diagnostic => diagnostic.Location.Text is null))
+        foreach (var diagnostic in diags.Where(diagnostic => !diagnostic.HasLocation))
         {
             WriteColoredText(textWriter, $"[{diagnostic.IdString}]: {diagnostic.Message}",
                              diagnostic.Severity == DiagnosticSeverity.Error ? ConsoleColor.Red : ConsoleColor.Yellow);


### PR DESCRIPTION
## Summary
- represent absent source locations explicitly with `TextLocation.None`
- expose `Diagnostic.HasLocation` and safely format locationless diagnostics
- use the explicit location state when writing diagnostics
- cover no-entry-point, invalid-reference, and located diagnostic formatting

## Testing
- `dotnet test src/Balu.Tests/Balu.Tests.csproj` (21,808 passed)

Closes #167