### PR TITLE
Validate debug symbol sequence point counts

### DIFF
--- a/src/Balu.Tests/EmitterTests/IlAsserterTests.cs
+++ b/src/Balu.Tests/EmitterTests/IlAsserterTests.cs
@@ -1,0 +1,25 @@
+using TestHelpers;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Balu.Tests.EmitterTests;
+
+public class IlAsserterTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void SymbolAssertions_Fail_When_SequencePoint_Count_Does_Not_Match(bool tooManyOffsets)
+    {
+        var code = tooManyOffsets ? "[1]" : "[1] + [2]";
+        var offsets = tooManyOffsets ? new[] { 0, 1 } : new[] { 0 };
+        var spanCount = tooManyOffsets ? 1 : 2;
+        var expectedMessage = $"Annotated span count ({spanCount}) does not match supplied sequence-point offset count ({offsets.Length}).";
+
+        var symbolsException = Assert.ThrowsAny<XunitException>(() => code.AssertSymbols("main", offsets));
+        Assert.Contains(expectedMessage, symbolsException.Message);
+
+        var combinedException = Assert.ThrowsAny<XunitException>(() => code.AssertIlAndSymbols("main", "", offsets));
+        Assert.Contains(expectedMessage, combinedException.Message);
+    }
+}

--- a/src/TestHelpers/IlAsserter.cs
+++ b/src/TestHelpers/IlAsserter.cs
@@ -28,11 +28,14 @@ public static class IlAsserter
     {
         var annotated = AnnotatedText.Parse(code);
         var tree = SyntaxTree.Parse(SourceText.From(annotated.Text, "IlAsserter.b"));
+        var spans = annotated.Spans.OrderBy(span => span.Start)
+                             .ThenByDescending(span => span.Length)
+                             .ToArray();
+        var offsets = sequencePointOffsets.ToArray();
+        AssertMatchingSequencePointCounts(spans.Length, offsets.Length);
 
         var expectedSymbols = string.Join(Environment.NewLine,
-                                        annotated.Spans.OrderBy(span => span.Start)
-                                                 .ThenByDescending(span => span.Length)
-                                                 .Zip(sequencePointOffsets, (span, offset) => ToSymbolString(offset, new (tree.Text, span))));
+                                          spans.Zip(offsets, (span, offset) => ToSymbolString(offset, new (tree.Text, span))));
         
         var (_, symbols, actualScopes) = ExecuteEmitter(tree, methodToAssert, script, true, null);
         Assert.Equal(expectedSymbols, symbols);
@@ -44,11 +47,13 @@ public static class IlAsserter
                                    expectedIL.ReplaceLineEndings().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Select(line => line.Trim()));
         var annotated = AnnotatedText.Parse(code);
         var tree = SyntaxTree.Parse(SourceText.From(annotated.Text, "IlAsserter.b"));
+        var spans = annotated.Spans.OrderBy(span => span.Start)
+                             .ThenByDescending(span => span.Length)
+                             .ToArray();
+        var offsets = sequencePointOffsets.ToArray();
+        AssertMatchingSequencePointCounts(spans.Length, offsets.Length);
         var expectedSymbols = string.Join(Environment.NewLine,
-                                          annotated.Spans.OrderBy(span => span.Start)
-                                                   .ThenByDescending(span => span.Length)
-                                                   .Zip(sequencePointOffsets,
-                                                    (span, offset) => ToSymbolString(offset, new (tree.Text, span))));
+                                          spans.Zip(offsets, (span, offset) => ToSymbolString(offset, new (tree.Text, span))));
 
         var (il, symbols, actualScopes) = ExecuteEmitter(tree, methodToAssert, script, true, output, debugFriendly);
         Assert.Equal(expected, il);
@@ -127,4 +132,7 @@ public static class IlAsserter
         ToSymbolString(offset, location.StartLine + 1, location.StartCharacter + 1, location.EndLine + 1, location.EndCharacter + 1);
     static string ToSymbolString(int offset, int startLine, int startColumn, int endLine, int endColumn) =>
         $"{offset:X04}: ({startLine}, {startColumn}) - ({endLine}, {endColumn})";
+    static void AssertMatchingSequencePointCounts(int spanCount, int offsetCount) =>
+        Assert.True(spanCount == offsetCount,
+                    $"Annotated span count ({spanCount}) does not match supplied sequence-point offset count ({offsetCount}).");
 }


### PR DESCRIPTION
## Summary
- materialize annotated spans and supplied sequence-point offsets before pairing them
- fail with both counts when the sequence lengths differ
- cover too few and too many offsets for both symbol assertion helpers

## Tests
- `dotnet test src/Balu.Tests/Balu.Tests.csproj` (21,810 passed)

Closes #169