### PR TITLE
Generate unique metadata names for shadowed script functions

### DIFF
--- a/src/Balu.Tests/EmitterTests/MetadataNameTests.cs
+++ b/src/Balu.Tests/EmitterTests/MetadataNameTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using Balu.Diagnostics;
+using Balu.Symbols;
+using Balu.Syntax;
+using Mono.Cecil;
+using TestHelpers;
+using Xunit;
+
+namespace Balu.Tests.EmitterTests;
+
+public partial class EmitterTests
+{
+    [Fact]
+    public void Emitter_ShadowedScriptFunctions_HaveUniqueDeterministicMetadataNames()
+    {
+        var first = Compilation.CreateScript(null, SyntaxTree.Parse("function value(): int { return 1 }"));
+        var second = Compilation.CreateScript(first, SyntaxTree.Parse("function value(): int { return 2 }"));
+        var compilation = Compilation.CreateScript(second, SyntaxTree.Parse("function value(): int { return 3 }"));
+
+        var functions = compilation.AllSymbols
+            .OfType<FunctionSymbol>()
+            .Where(function => function.Name == "value")
+            .ToArray();
+        Assert.Equal(3, functions.Length);
+
+        using var output = new MemoryStream();
+        var result = compilation.Emit(
+            "ShadowedFunctions",
+            ReferenceProvider.References,
+            output,
+            null,
+            ImmutableDictionary<GlobalVariableSymbol, object>.Empty);
+
+        Assert.False(result.Diagnostics.HasErrors());
+        var metadataNames = functions.Select(function => result.GlobalSymbolNames[function]).ToArray();
+        Assert.Equal(new[] { "<value0>", "<value1>", "value" }, metadataNames);
+
+        var image = output.ToArray();
+        using (var assembly = AssemblyDefinition.ReadAssembly(new MemoryStream(image)))
+        {
+            var methods = assembly.MainModule.GetType("Program").Methods
+                .Where(method => metadataNames.Contains(method.Name))
+                .ToArray();
+
+            Assert.Equal(metadataNames.OrderBy(name => name), methods.Select(method => method.Name).OrderBy(name => name));
+            Assert.All(methods, method =>
+            {
+                Assert.Empty(method.Parameters);
+                Assert.Equal("System.Int32", method.ReturnType.FullName);
+            });
+        }
+
+        var loadContext = new AssemblyLoadContext("ShadowedFunctions", isCollectible: true);
+        try
+        {
+            using var reflectionStream = new MemoryStream(image);
+            var programType = loadContext.LoadFromStream(reflectionStream).GetType("Program")!;
+            foreach (var metadataName in metadataNames)
+            {
+                var method = programType.GetMethod(metadataName, BindingFlags.Static | BindingFlags.NonPublic);
+                Assert.NotNull(method);
+                Assert.Empty(method.GetParameters());
+                Assert.Equal(typeof(int), method.ReturnType);
+            }
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}

--- a/src/Balu/Emit/Emitter.cs
+++ b/src/Balu/Emit/Emitter.cs
@@ -86,8 +86,8 @@ sealed class Emitter : IDisposable
 
     MethodDefinition CreateMethod(FunctionSymbol function)
     {
-        bool isVisilbe = function == program.EntryPoint || program.VisibleSymbols.Contains(function);
-        var name = isVisilbe ? function.Name : $"<{function.Name}{globals.Count}>";
+        bool isVisible = function == program.EntryPoint || program.VisibleSymbols.Contains(function);
+        var name = isVisible ? function.Name : $"<{function.Name}{GetFunctionGeneration(function)}>";
         var attributes = MethodAttributes.Static | MethodAttributes.Private;
         if (name.IsBaluSpecialName()) attributes |= MethodAttributes.SpecialName;
         var method = new MethodDefinition(name, attributes, MapType(function.ReturnType));
@@ -97,6 +97,17 @@ sealed class Emitter : IDisposable
         referencedMembers.ProgramType.Methods.Add(method);
         globalSymbolNames[function] = name;
         return method;
+    }
+    int GetFunctionGeneration(FunctionSymbol function)
+    {
+        int generation = 0;
+        foreach (var symbol in program.Symbols.OfType<FunctionSymbol>())
+        {
+            if (symbol == function) return generation;
+            if (symbol.Name == function.Name) generation++;
+        }
+
+        throw new EmitterException($"Function symbol '{function.Name}' is not part of the program symbols.");
     }
     void EmitMethod(MethodDefinition method, FunctionSymbol function)
     {


### PR DESCRIPTION
## Summary
- derive hidden script function metadata names from their deterministic same-name generation
- keep `EmitterResult.GlobalSymbolNames` unique for retained function symbols
- cover three chained redeclarations through `EmitterResult`, Mono.Cecil, and reflection

## Tests
- `dotnet test src/Balu.Tests/Balu.Tests.csproj` (21,811 passed)

Closes #162