### PR TITLE
Use response files for SDK compiler invocations

### DIFF
--- a/docs/tools/compiler.md
+++ b/docs/tools/compiler.md
@@ -42,6 +42,27 @@ dotnet run --project src/bc -- --help
 At least one source path is required unless help is requested. Source paths are
 positional arguments. `bc` does not require the conventional `.b` extension.
 
+### Response files
+
+Prefix a UTF-8 response-file path with `@` to read additional arguments from
+that file:
+
+```console
+bc @arguments.rsp
+```
+
+Response files accept the same options and positional source paths as the
+direct command line. Quote paths that contain spaces:
+
+```text
+/o "build output/program.dll"
+/r "reference assemblies/System.Runtime.dll"
+"source files/program.b"
+```
+
+`Balu.Sdk` uses a temporary response file automatically so projects with many
+sources or long paths do not exceed operating-system command-line limits.
+
 ## Options
 
 | Option | Value | Description |

--- a/src/Balu.Sdk.Tests/SdkBuildTests.cs
+++ b/src/Balu.Sdk.Tests/SdkBuildTests.cs
@@ -185,6 +185,28 @@ public sealed class SdkBuildTests
     }
 
     [Fact]
+    public void Sdk_CompilerArgumentsExceedingWindowsLimit_Builds()
+    {
+        const int windowsCommandLineLimit = 32_767;
+        using var project = new TestProject();
+        var expandedArgumentsLength = 0;
+
+        for (var index = 0; expandedArgumentsLength <= windowsCommandLineLimit; index++)
+        {
+            var relativePath = $"sources with spaces-\u00E4/source-{index:D4}-{new string('x', 64)}.b";
+            var sourcePath = project.PathFromProject(relativePath);
+            project.SetSource(relativePath, string.Empty);
+            expandedArgumentsLength += sourcePath.Length + 3;
+        }
+
+        Assert.True(expandedArgumentsLength > windowsCommandLineLimit);
+
+        project.Build("Debug");
+
+        Assert.True(File.Exists(project.IntermediateAssembly("Debug")));
+    }
+
+    [Fact]
     public void Sdk_DeletingSourceFile_InvalidatesCompilerOutput()
     {
         using var project = new TestProject();

--- a/src/Balu.Sdk/Balu.Sdk.csproj
+++ b/src/Balu.Sdk/Balu.Sdk.csproj
@@ -7,6 +7,7 @@
 	</PropertyGroup>
 	<PropertyGroup>
 		<IsPackable>true</IsPackable>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageId>Balu.Sdk</PackageId>
 		<Title>Balu.Sdk</Title>
 		<Authors>René Vogt</Authors>
@@ -38,6 +39,7 @@
 					  GlobalPropertiesToRemove="TargetFramework" />
 	</ItemGroup>
 	<ItemGroup>
+		<None Include="README.md" Pack="true" PackagePath="\" />
 		<!-- these lines pack the build props/targets files to the `build` folder in the generated package.
  		by convention, the .NET SDK will look for build\<Package Id>.props and build\<Package Id>.targets
  		for automatic inclusion in the build. -->

--- a/src/Balu.Sdk/BaluCompiler.cs
+++ b/src/Balu.Sdk/BaluCompiler.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -27,6 +28,8 @@ public sealed class BaluCompiler : ToolTask
 
     public bool Debug { get; set; }
 
+    protected override Encoding ResponseFileEncoding { get; } = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
     protected override string GenerateFullPathToTool() => Path.GetFullPath(DotNetPath);
 
     protected override string GenerateCommandLineCommands()
@@ -34,6 +37,13 @@ public sealed class BaluCompiler : ToolTask
         var builder = new CommandLineBuilder();
         builder.AppendTextUnquoted("exec");
         builder.AppendFileNameIfNotNull(Path.GetFullPath(CompilerPath));
+
+        return builder.ToString();
+    }
+
+    protected override string GenerateResponseFileCommands()
+    {
+        var builder = new CommandLineBuilder(quoteHyphensOnCommandLine: false, useNewLineSeparator: true);
         builder.AppendSwitchIfNotNull("/o ", OutputPath);
 
         if (!string.IsNullOrWhiteSpace(SymbolPath))

--- a/src/Balu.Sdk/README.md
+++ b/src/Balu.Sdk/README.md
@@ -1,0 +1,45 @@
+# Balu.Sdk
+
+`Balu.Sdk` is the MSBuild SDK for the Balu programming language. It compiles
+`.b` source files into managed .NET applications using the Balu compiler.
+
+Balu is an experimental, educational language and currently requires the
+.NET 10 SDK.
+
+## Create a project
+
+Create a project file such as `hello.csproj`:
+
+```xml
+<Project Sdk="Balu.Sdk/0.6.0">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+</Project>
+```
+
+Add a `hello.b` file next to it:
+
+```balu
+println("Hello, world!")
+```
+
+All `.b` files below the project directory are included automatically. Build
+or run the project with the standard .NET CLI:
+
+```console
+dotnet build
+dotnet run
+```
+
+## Learn more
+
+- [Balu repository](https://github.com/ReneVogt/Balu)
+- [Getting started](https://github.com/ReneVogt/Balu/blob/main/docs/getting-started.md)
+- [Language reference](https://github.com/ReneVogt/Balu/blob/main/docs/language/reference.md)
+- [`bc` compiler reference](https://github.com/ReneVogt/Balu/blob/main/docs/tools/compiler.md)
+
+## License
+
+Balu is available under the [MIT License](https://github.com/ReneVogt/Balu/blob/main/LICENSE).

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<BaluVersion Condition="'$(BaluVersion)' == ''">0.5.3</BaluVersion>
+		<BaluVersion Condition="'$(BaluVersion)' == ''">0.6.0</BaluVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(MSBuildProjectName)' == 'Balu' Or

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<BaluVersion Condition="'$(BaluVersion)' == ''">0.6.0</BaluVersion>
+		<BaluVersion Condition="'$(BaluVersion)' == ''">0.6.1</BaluVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(MSBuildProjectName)' == 'Balu' Or

--- a/src/HelloWorld/helloworld.csproj
+++ b/src/HelloWorld/helloworld.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.6.0">
+﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.6.1">
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
 		<OutputType>Exe</OutputType>

--- a/src/HelloWorld/helloworld.csproj
+++ b/src/HelloWorld/helloworld.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.5.3">
+﻿<Project ToolsVersion="15.0" Sdk="Balu.Sdk/0.6.0">
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
 		<OutputType>Exe</OutputType>

--- a/src/bc.Tests/CommandLineTests.cs
+++ b/src/bc.Tests/CommandLineTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text;
 using Xunit;
 
 namespace Balu.Compiler.Tests;
@@ -53,6 +54,43 @@ public sealed class CommandLineTests
         Assert.Equal(3, ExitCode);
         Assert.Contains("Compiling '-program.b'", Output);
         Assert.DoesNotContain("Unknown option", Error);
+    }
+
+    [Fact]
+    public void Compiler_ResponseFile_ReadsQuotedUtf8SourcePath()
+    {
+        var directory = Directory.CreateTempSubdirectory("BaluCompilerTests-");
+        try
+        {
+            var sourceDirectory = Directory.CreateDirectory(Path.Combine(directory.FullName, "source files-\u00E4"));
+            var sourcePath = Path.Combine(sourceDirectory.FullName, "program.b");
+            var responsePath = Path.Combine(directory.FullName, "arguments.rsp");
+            File.WriteAllText(sourcePath, "missing()");
+            File.WriteAllText(responsePath, $"\"{sourcePath}\"", new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+            var (ExitCode, Output, Error)= Run([$"@{responsePath}"]);
+
+            Assert.Equal(1, ExitCode);
+            Assert.Contains($"Compiling '{sourcePath}'", Output);
+            Assert.DoesNotContain("bc: error:", Error);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Compiler_MissingResponseFile_ReturnsInvocationError()
+    {
+        var missingPath = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.rsp");
+
+        var (ExitCode, Output, Error)= Run([$"@{missingPath}"]);
+
+        Assert.Equal(2, ExitCode);
+        Assert.Empty(Output);
+        Assert.StartsWith("bc: error: ", Error);
+        Assert.Contains(missingPath, Error);
     }
 
     [Fact]

--- a/src/bc/Program.cs
+++ b/src/bc/Program.cs
@@ -48,7 +48,8 @@ sealed class Program
             { "debug=", "Whether to emit debugger-friendly IL.", (bool v) => debug = v },
             { "m=", "The module {name} of the assembly to create.", v => moduleName = v },
             { "q", _ => quiet = true },
-            { "?|h|help", "Shows help.", _ => helpRequested = true }
+            { "?|h|help", "Shows help.", _ => helpRequested = true },
+            new ResponseFileSource()
         };
 
         quiet = args.TakeWhile(argument => argument != "--").Any(IsQuietOption);
@@ -68,6 +69,11 @@ sealed class Program
                 sourcePaths.AddRange(args[(optionTerminatorIndex + 1)..]);
         }
         catch (OptionException parseError)
+        {
+            LogError(parseError.Message);
+            return InvocationError;
+        }
+        catch (Exception parseError) when (parseError is IOException or UnauthorizedAccessException)
         {
             LogError(parseError.Message);
             return InvocationError;


### PR DESCRIPTION
## Summary

- add UTF-8 response-file argument support to `bc`
- move SDK compiler options, references, and source paths into a `ToolTask` response file
- cover quoted Unicode paths, missing response files, and SDK invocations whose expanded arguments exceed 32,767 characters
- document direct response-file usage
- include a package README for `Balu.Sdk`

## Tests

- `dotnet test src/bc.Tests/bc.Tests.csproj`
- `dotnet test src/Balu.Sdk.Tests/Balu.Sdk.Tests.csproj`
- `dotnet build src/Balu.Sdk/Balu.Sdk.csproj` (0 warnings)

Closes #161